### PR TITLE
Add debug condition

### DIFF
--- a/.github/workflows/build-and-publish-devregistry.yaml
+++ b/.github/workflows/build-and-publish-devregistry.yaml
@@ -1,6 +1,12 @@
 name: Build with Werf dev registry
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   workflow_run:
     workflows:
       - "Run Tests for C++ Code"

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -1,6 +1,12 @@
 name: Build with Werf Dockerhub
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   workflow_run:
     workflows:
       - "Run Tests for C++ Code"

--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -1,6 +1,12 @@
 name: Build Test Image
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   push:
     branches:
       - pp

--- a/.github/workflows/lint-cpp.yaml
+++ b/.github/workflows/lint-cpp.yaml
@@ -1,6 +1,12 @@
 name: Lint C++ Code
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   pull_request:
     types:
       - opened

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,12 @@
 name: Make release
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   workflow_run:
     workflows:
       - "Build with Werf Dockerhub"

--- a/.github/workflows/tests-cpp.yaml
+++ b/.github/workflows/tests-cpp.yaml
@@ -1,6 +1,12 @@
 name: Run Tests for C++ Code
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   workflow_run:
     workflows: ["Lint C++ Code"]
     types: 

--- a/.github/workflows/tests-go.yaml
+++ b/.github/workflows/tests-go.yaml
@@ -1,6 +1,12 @@
 name: Run Tests for Go Code
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_branch:
+        description: 'Branch to build for debugging'
+        required: true
+        default: 'pp'
   workflow_run:
     workflows: ["Run Tests for C++ Code"]
     types: 


### PR DESCRIPTION
This PR adds options to run and edit workflows without merging into `pp` branch
It's useful for debugging because Github CI makes changes only when branch merged 