### PR TITLE
Add failure tolerance

### DIFF
--- a/.github/workflows/build-and-publish-devregistry.yaml
+++ b/.github/workflows/build-and-publish-devregistry.yaml
@@ -25,6 +25,7 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         ARCH: [arm64, x86_64]
         COMPILATION_MODE: [dbg, opt]

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -20,6 +20,7 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         ARCH: [arm64, x86_64]
         COMPILATION_MODE: [dbg, opt]

--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -18,6 +18,7 @@ jobs:
   build-ci-image:
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         ARCH: [arm64, x86_64]
         include:


### PR DESCRIPTION
Previously, if one job from a matrix failed, the entire pipline was canceled. This PR adds the ability to pass all jobs even if one in the matrix fails