### PR TITLE
Fix link to MAINTEINERS.md in  CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,4 +8,4 @@ Deckhouse is an Open Source project, and third-party contributions are warmly we
 - Open your [issues](https://github.com/deckhouse/prompp/issues) and [discussions](https://github.com/deckhouse/prompp/discussions) in this repo.
 - If you believe no preliminary discussion is required, submit your [PRs](https://github.com/deckhouse/prompp/pulls) with your code changes straight away.
 
-P.S. The [maintainers list](https://github.com/deckhouse/prompp/blob/main/MAINTAINERS.md) might also be helpful to reach our core developers.
+P.S. The [maintainers list](https://github.com/deckhouse/prompp/blob/pp/MAINTAINERS.md) might also be helpful to reach our core developers.


### PR DESCRIPTION
## Description
This pull request updates the link to the MAINTAINERS.md file in the CONTRIBUTING.md document. Previously, the link pointed to the main branch, but since the default branch is now pp, the reference has been updated accordingly.

## Why do we need it, and what problem does it solve?
The CONTRIBUTING.md file contained an outdated link to the MAINTAINERS.md file from the main branch. This could cause confusion or lead contributors to an incorrect or missing file. By updating the link to point to the correct pp branch, we ensure contributors always have access to the latest and correct maintainer information. This change improves documentation accuracy.
  
## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [x] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  
  ```changes
   type: chore
   summary: fix link in documentation
   impact_level: low
  ```
  