### PR TITLE
Remove push step

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -42,22 +42,14 @@ jobs:
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
-          werf build --add-custom-tag="$BRANCH_NAME" --repo=docker.io/prompp/prompp
-
-      - name: Push Docker Image Latest
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
-          docker rmi docker.io/prompp/prompp:latest || true
-          docker tag docker.io/prompp/prompp:$BRANCH_NAME docker.io/prompp/prompp:latest
-          docker push docker.io/prompp/prompp:latest
+          werf build --add-custom-tag="latest" --add-custom-tag="$BRANCH_NAME" --repo=docker.io/prompp/prompp
 
       - name: Extract binaries from Docker images
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
+          docker pull docker.io/prompp/prompp:$BRANCH_NAME
           CONTAINER_ID_PROMPP=$(docker create docker.io/prompp/prompp:$BRANCH_NAME)
 
           docker cp $CONTAINER_ID_PROMPP:/bin/prompp ./prompp

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -42,7 +42,7 @@ jobs:
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
-          werf build --add-custom-tag="latest" --add-custom-tag="$BRANCH_NAME" --repo=docker.io/prompp/prompp
+          werf build --add-custom-tag="latest" --add-custom-tag="$BRANCH_NAME" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --final-repo=docker.io/prompp/prompp
 
       - name: Extract binaries from Docker images
         run: |

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -56,6 +56,7 @@ jobs:
           docker cp $CONTAINER_ID_PROMPP:/bin/promtool ./promtool
           docker cp $CONTAINER_ID_PROMPP:/bin/prompptool ./prompptool
           docker rm $CONTAINER_ID_PROMPP
+          docker rmi docker.io/prompp/prompp:$BRANCH_NAME
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dev-registry_cleanup.yaml
+++ b/.github/workflows/dev-registry_cleanup.yaml
@@ -27,8 +27,8 @@ jobs:
       - uses: deckhouse/modules-actions/setup@v2
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN_CLEANUP }}
+          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD_CLEANUP }}
       - name: Cleanup
         run: |
           werf cleanup \


### PR DESCRIPTION
## Description
Remove push step
  
  ## Why do we need it, and what problem does it solve?
This step is unnecessary
  
  ## Why do we need it in the patch release (if we do)?
Not necessarily
## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Remove push step
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->