### PR TITLE
Separate latest tag job and change build to export werf

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -42,7 +42,7 @@ jobs:
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
-          werf build --add-custom-tag="latest" --add-custom-tag="$BRANCH_NAME" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --final-repo=docker.io/prompp/prompp
+          werf export --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --tag=docker.io/prompp/prompp:$BRANCH_NAME
 
       - name: Extract binaries from Docker images
         run: |

--- a/.github/workflows/create_tag_latest.yaml
+++ b/.github/workflows/create_tag_latest.yaml
@@ -1,0 +1,46 @@
+name: Tag Docker Image as Latest
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'The image tag to be used for re-tagging as latest'
+        required: true
+        type: string
+
+jobs:
+  tag_latest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clean workspace
+        uses: AutoModality/action-clean@v1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to registry
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_REGISTRY_LOGIN }}
+          password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
+          logout: false
+
+      - name: Pull the Docker image with provided tag
+        run: |
+          docker pull docker.io/prompp/prompp:${{ github.event.inputs.tag }}
+
+      - name: Tag the image as latest
+        run: |
+          docker tag docker.io/prompp/prompp:${{ github.event.inputs.tag }} docker.io/prompp/prompp:latest
+
+      - name: Push the image with latest tag
+        run: |
+          docker push docker.io/prompp/prompp:latest
+
+      - name: Cleanup remaining Docker images
+        run: |
+          docker rmi docker.io/prompp/prompp:${{ github.event.inputs.tag }} || true
+          docker rmi docker.io/prompp/prompp:latest || true


### PR DESCRIPTION
## Description
Separate latest tag job and change build to export werf. 
  
  ## Why do we need it, and what problem does it solve?
To be able to make tag latest manually only if it's needed and change `werf build` to `werf export` to avoid additional tags in dockerhub. 
  ## Why do we need it in the patch release (if we do)?
  
Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary:  Separate latest tag job and change build to export werf
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->