### PR TITLE
Archive binaries

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -58,14 +58,15 @@ jobs:
           docker rm $CONTAINER_ID_PROMPP
           docker rmi docker.io/prompp/prompp:$BRANCH_NAME
 
+      - name: Archive binaries
+        run: |
+          tar -czvf prompp-binaries.tar.gz prompp promtool prompptool
+
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4
         with:
           name: prompp-binaries
-          path: |
-            prompp
-            promtool
-            prompptool
+          path: prompp-binaries.tar.gz
           retention-days: 7
 
   release:
@@ -93,6 +94,6 @@ jobs:
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
         with:
           draft: true
-          files: ./artifacts/prom*
+          files: ./artifacts/prompp-binaries.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Archive binaries
  
  ## Why do we need it, and what problem does it solve?
We archive the binaries into a .tar.gz to preserve file permissions, reduce size, and bundle everything into a single, easy-to-download artifact.
  
  ## Why do we need it in the patch release (if we do)?
  
Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Archive binaries
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->