### PR TITLE
Doc fixes and attach config to binaries archieve

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Archive binaries
         run: |
-          tar -czvf prompp-binaries.tar.gz prompp promtool prompptool
+          tar -czvf prompp-binaries.tar.gz prompp promtool prompptool ./documentation/examples/prometheus.yml
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -60,7 +60,8 @@ jobs:
 
       - name: Archive binaries
         run: |
-          tar -czvf prompp-binaries.tar.gz prompp promtool prompptool ./documentation/examples/prometheus.yml
+          cp ./documentation/examples/prometheus.yml ./prometheus.yml
+          tar -czvf prompp-binaries.tar.gz prompp promtool prompptool prometheus.yml
 
       - name: Upload binaries as artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Once running, Deckhouse Prom++ will be accessible at [http://localhost:9090/](ht
 You can also add own config for Prom++ by passing config.file parameter
 
 ```bash
-docker run --name prompp -v /path/on/host/prometheus.yml:/etc/prometheus/prometheus.yml -d -p 127.0.0.1:9090:9090 prompp/prompp
+docker run --name prompp -v /path/on/host/prometheus.yml:/etc/prometheus.yml -d -p 127.0.0.1:9090:9090 prompp/prompp --config.file=/etc/prometheus.yml
 ```
 
 ## **Prometheus Operator**

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ docker run --name prompp -d -p 127.0.0.1:9090:9090 prompp/prompp
 
 Once running, Deckhouse Prom++ will be accessible at [http://localhost:9090/](http://localhost:9090/).
 
+You can also add own config for Prom++ by passing config.file parameter
+
+```bash
+docker run --name prompp -v /path/on/host/prometheus.yml:/etc/prometheus/prometheus.yml -d -p 127.0.0.1:9090:9090 prompp/prompp
+```
 
 ## **Prometheus Operator**
 

--- a/werf.yaml
+++ b/werf.yaml
@@ -168,7 +168,6 @@ docker:
   ENTRYPOINT:
     - "/bin/prompp"
   CMD:
-    - "--config.file=/etc/src.yml"
     - "--storage.tsdb.path=/prometheus"
     - "--web.console.libraries=/usr/share/prometheus/console_libraries"
     - "--web.console.templates=/usr/share/prometheus/consoles"


### PR DESCRIPTION
## Description
Doc fixes and attach config to binaries archieve
  
  ## Why do we need it, and what problem does it solve?
In order for users to know how to use their own custom configs and have an example when downloading the archive with binaries
  
  ## Why do we need it in the patch release (if we do)?
  
Not necessarily"

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Doc fixes and attach config to binaries archieve
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->