### PR TITLE
rebuild metrics

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -690,7 +690,7 @@ func main() {
 	}
 
 	clock := clockwork.NewRealClock()
-	headCatalog, err := catalog.New(clock, fileLog, catalog.DefaultIDGenerator{})
+	headCatalog, err := catalog.New(clock, fileLog, catalog.DefaultIDGenerator{}, prometheus.DefaultRegisterer)
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to create head catalog", "err", err)
 		os.Exit(1)

--- a/cmd/prompptool/walpp.go
+++ b/cmd/prompptool/walpp.go
@@ -65,7 +65,7 @@ func (cmd *cmdWALPPToBlock) Do(
 
 	level.Debug(logger).Log("msg", "read catalog log")
 	clock := clockwork.NewRealClock()
-	headCatalog, err := catalog.New(clock, fileLog, catalog.DefaultIDGenerator{})
+	headCatalog, err := catalog.New(clock, fileLog, catalog.DefaultIDGenerator{}, registerer)
 	if err != nil {
 		return fmt.Errorf("failed init head catalog: %w", err)
 	}

--- a/pp-pkg/scrape/scrape.go
+++ b/pp-pkg/scrape/scrape.go
@@ -1333,6 +1333,7 @@ var (
 	scrapeSamplesMetricName       = "scrape_samples_scraped"
 	samplesPostRelabelMetricName  = "scrape_samples_post_metric_relabeling"
 	scrapeSeriesAddedMetricName   = "scrape_series_added"
+	scrapeSeriesDroppedMetricName = "scrape_series_dropped"
 	scrapeTimeoutMetricName       = "scrape_timeout_seconds"
 	scrapeSampleLimitMetricName   = "scrape_sample_limit"
 	scrapeBodySizeBytesMetricName = "scrape_body_size_bytes"
@@ -1383,6 +1384,16 @@ func (sl *scrapeLoop) report(
 		scrapeSeriesAddedMetricName,
 		ts,
 		float64(stats.SeriesAdded),
+	); err != nil {
+		return
+	}
+
+	if err = sl.addReportSample(
+		builder,
+		batch,
+		scrapeSeriesDroppedMetricName,
+		ts,
+		float64(stats.SeriesDrop),
 	); err != nil {
 		return
 	}

--- a/pp/entrypoint/prometheus_relabeler.cpp
+++ b/pp/entrypoint/prometheus_relabeler.cpp
@@ -195,6 +195,7 @@ extern "C" void prompp_prometheus_per_shard_relabeler_input_relabeling(void* arg
   struct Result {
     uint32_t samples_added{0};
     uint32_t series_added{0};
+    uint32_t series_drop{0};
     PromPP::Primitives::Go::Slice<char> error;
   };
 
@@ -258,6 +259,7 @@ extern "C" void prompp_prometheus_per_shard_relabeler_input_relabeling_with_stal
   struct Result {
     uint32_t samples_added{0};
     uint32_t series_added{0};
+    uint32_t series_drop{0};
     PromPP::Primitives::Go::Slice<char> error;
   };
 

--- a/pp/entrypoint/prometheus_relabeler.h
+++ b/pp/entrypoint/prometheus_relabeler.h
@@ -167,6 +167,9 @@ void prompp_prometheus_per_shard_relabeler_cache_allocated_memory(void* args, vo
  * }
  *
  * @param res {
+ *     samples_added           uint32             // number of added samples;
+ *     series_added            uint32             // number of added series;
+ *     series_drop             uint32             // number of dropped series;
  *     error                   []byte             // error string if thrown;
  * }
  */
@@ -233,6 +236,9 @@ void prompp_prometheus_per_shard_relabeler_input_relabeling_with_stalenans(void*
  * }
  *
  * @param res {
+ *     samples_added           uint32             // number of added samples;
+ *     series_added            uint32             // number of added series;
+ *     series_drop             uint32             // number of dropped series;
  *     error                   []byte             // error string if thrown;
  * }
  */

--- a/pp/entrypoint/wal_decoder.cpp
+++ b/pp/entrypoint/wal_decoder.cpp
@@ -281,6 +281,7 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
     int64_t max_timestamp{};
     uint64_t outdated_sample_count{};
     uint64_t dropped_sample_count{};
+    uint64_t dropped_series_count{};
     PromPP::Primitives::Go::Slice<PromPP::WAL::RefSample> ref_samples;
     PromPP::Primitives::Go::Slice<char> error;
   };
@@ -290,6 +291,7 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
 
   try {
     std::ispanstream{static_cast<std::string_view>(in->segment)} >> *in->decoder;
+    out->dropped_series_count = in->decoder->dropped_series_count();
     in->decoder->process_segment([in, out](PromPP::Primitives::LabelSetID ls_id, PromPP::Primitives::Timestamp ts, PromPP::Primitives::Sample::value_type v,
                                            bool is_dropped) PROMPP_LAMBDA_INLINE {
       if (is_dropped) {

--- a/pp/entrypoint/wal_decoder.cpp
+++ b/pp/entrypoint/wal_decoder.cpp
@@ -279,9 +279,10 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
 
   struct Result {
     int64_t max_timestamp{};
-    uint64_t outdated_sample_count{};
-    uint64_t dropped_sample_count{};
-    uint64_t dropped_series_count{};
+    uint32_t outdated_sample_count{};
+    uint32_t dropped_sample_count{};
+    uint32_t add_series_count{};
+    uint32_t dropped_series_count{};
     PromPP::Primitives::Go::Slice<PromPP::WAL::RefSample> ref_samples;
     PromPP::Primitives::Go::Slice<char> error;
   };
@@ -291,6 +292,7 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
 
   try {
     std::ispanstream{static_cast<std::string_view>(in->segment)} >> *in->decoder;
+    out->add_series_count = in->decoder->add_series_count();
     out->dropped_series_count = in->decoder->dropped_series_count();
     in->decoder->process_segment([in, out](PromPP::Primitives::LabelSetID ls_id, PromPP::Primitives::Timestamp ts, PromPP::Primitives::Sample::value_type v,
                                            bool is_dropped) PROMPP_LAMBDA_INLINE {

--- a/pp/entrypoint/wal_decoder.h
+++ b/pp/entrypoint/wal_decoder.h
@@ -190,9 +190,10 @@ void prompp_wal_output_decoder_load_from(void* args, void* res);
  *
  * @param res {
  *     max_timestamp         int64       // max timestamp in slice RefSample
- *     outdated_sample_count uint64      // count of dropped samples on outdated
- *     dropped_sample_count  uint64      // count of dropped samples on relabeling rules
- *     dropped_series_count  uint64      // count of dropped series on relabeling rules
+ *     outdated_sample_count uint32      // count of dropped samples on outdated
+ *     dropped_sample_count  uint32      // count of dropped samples on relabeling rules
+ *     add_series_count      uint32      // count of add series on relabeling rules
+ *     dropped_series_count  uint32      // count of dropped series on relabeling rules
  *     ref_samples           []RefSample // slice RefSample
  *     error                 []byte      // error string if thrown
  * }

--- a/pp/entrypoint/wal_decoder.h
+++ b/pp/entrypoint/wal_decoder.h
@@ -192,6 +192,7 @@ void prompp_wal_output_decoder_load_from(void* args, void* res);
  *     max_timestamp         int64       // max timestamp in slice RefSample
  *     outdated_sample_count uint64      // count of dropped samples on outdated
  *     dropped_sample_count  uint64      // count of dropped samples on relabeling rules
+ *     dropped_series_count  uint64      // count of dropped series on relabeling rules
  *     ref_samples           []RefSample // slice RefSample
  *     error                 []byte      // error string if thrown
  * }

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -27,10 +27,15 @@ import (
 	"github.com/prometheus/prometheus/pp/go/model"
 )
 
-var unsafeCall = promauto.NewCounterVec(
-	prometheus.CounterOpts{
+var unsafeCall = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
 		Name: "prompp_cppbridge_unsafecall_nanoseconds",
 		Help: "The time duration cpp call.",
+		Buckets: []float64{
+			100, 500,
+			1000, 5000, 10000, 50000, 100000, 500000,
+			1000000, 5000000, 10000000, 50000000, 100000000, 500000000,
+		},
 	},
 	[]string{"object", "method"},
 )
@@ -1264,7 +1269,7 @@ func prometheusPerShardRelabelerInputRelabeling(
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "input_relabeler", "method": "input_relabeling"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.samplesAdded, res.seriesAdded, res.exception
 }
@@ -1314,7 +1319,7 @@ func prometheusPerShardRelabelerInputRelabelingWithStalenans(
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "input_relabeler", "method": "relabeling_with_stalenans"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.samplesAdded, res.seriesAdded, res.exception
 }
@@ -1345,7 +1350,7 @@ func prometheusPerShardRelabelerAppendRelabelerSeries(
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "input_relabeler", "method": "append_relabeler_series"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.exception
 }
@@ -1373,7 +1378,7 @@ func prometheusPerShardRelabelerUpdateRelabelerState(
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "input_relabeler", "method": "update_relabeler_state"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.exception
 }
@@ -1423,7 +1428,7 @@ func prometheusPerShardRelabelerResetTo(
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "input_relabeler", "method": "reset_to"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataDataStorageCtor() uintptr {
@@ -1450,7 +1455,7 @@ func seriesDataDataStorageReset(dataStorage uintptr) {
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "reset"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataDataStorageAllocatedMemory(dataStorage uintptr) uint64 {
@@ -1468,7 +1473,7 @@ func seriesDataDataStorageAllocatedMemory(dataStorage uintptr) uint64 {
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "allocated_memory"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.allocatedMemory
 }
@@ -1489,7 +1494,7 @@ func seriesDataDataStorageQuery(dataStorage uintptr, query HeadDataStorageQuery)
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "query"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.serializedChunks
 }
@@ -1553,7 +1558,7 @@ func seriesDataEncoderEncode(encoder uintptr, seriesID uint32, timestamp int64, 
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "encode"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataEncoderEncodeInnerSeriesSlice(encoder uintptr, innerSeriesSlice []*InnerSeries) {
@@ -1568,7 +1573,7 @@ func seriesDataEncoderEncodeInnerSeriesSlice(encoder uintptr, innerSeriesSlice [
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "encode_inner_series_slice"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataEncoderMergeOutOfOrderChunks(encoder uintptr) {
@@ -1582,7 +1587,7 @@ func seriesDataEncoderMergeOutOfOrderChunks(encoder uintptr) {
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "head_data_storage", "method": "merge_out_of_order_chunks"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataEncoderDtor(encoder uintptr) {
@@ -1657,11 +1662,17 @@ func seriesDataDecodeIteratorSample(decodeIterator uintptr) (int64, float64) {
 		value     float64
 	}
 
+	// start := time.Now()
+
 	fastcgo.UnsafeCall2(
 		C.prompp_series_data_decode_iterator_sample,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
+
+	// unsafeCall.With(
+	// 	prometheus.Labels{"object": "head_data_storage_decode_iterator", "method": "sample"},
+	// ).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.timestamp, res.value
 }
@@ -1719,7 +1730,7 @@ func seriesDataChunkRecoderRecodeNextChunk(chunkRecoder uintptr, recodedChunk *R
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "chunk_recoder", "method": "recode_next_chunk"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataChunkRecoderDtor(chunkRecoder uintptr) {
@@ -1966,7 +1977,7 @@ func walPrometheusScraperHashdexParse(hashdex uintptr, buffer []byte, default_ti
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "hashdex", "method": "parse"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.scraped, res.error
 }
@@ -2023,7 +2034,7 @@ func walOpenMetricsScraperHashdexParse(hashdex uintptr, buffer []byte, default_t
 	)
 	unsafeCall.With(
 		prometheus.Labels{"object": "hashdex", "method": "parse"},
-	).Add(float64(time.Since(start).Nanoseconds()))
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.scraped, res.error
 }
@@ -2135,11 +2146,17 @@ func headWalEncoderAddInnerSeries(encoder uintptr, innerSeries []*InnerSeries) (
 		exception []byte
 	}
 
+	start := time.Now()
+
 	fastcgo.UnsafeCall2(
 		C.prompp_head_wal_encoder_add_inner_series,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
+
+	unsafeCall.With(
+		prometheus.Labels{"object": "head_wal_encoder", "method": "add_inner_series"},
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.WALEncoderStats, handleException(res.exception)
 }
@@ -2155,11 +2172,17 @@ func headWalEncoderFinalize(encoder uintptr) (stats WALEncoderStats, segment []b
 		exception []byte
 	}
 
+	start := time.Now()
+
 	fastcgo.UnsafeCall2(
 		C.prompp_head_wal_encoder_finalize,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
+
+	unsafeCall.With(
+		prometheus.Labels{"object": "head_wal_encoder", "method": "finalize"},
+	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.WALEncoderStats, res.segment, handleException(res.exception)
 }

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -1662,17 +1662,11 @@ func seriesDataDecodeIteratorSample(decodeIterator uintptr) (int64, float64) {
 		value     float64
 	}
 
-	// start := time.Now()
-
 	fastcgo.UnsafeCall2(
 		C.prompp_series_data_decode_iterator_sample,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-
-	// unsafeCall.With(
-	// 	prometheus.Labels{"object": "head_data_storage_decode_iterator", "method": "sample"},
-	// ).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.timestamp, res.value
 }
@@ -1976,7 +1970,7 @@ func walPrometheusScraperHashdexParse(hashdex uintptr, buffer []byte, default_ti
 		uintptr(unsafe.Pointer(&res)),
 	)
 	unsafeCall.With(
-		prometheus.Labels{"object": "hashdex", "method": "parse"},
+		prometheus.Labels{"object": "prometheus_hashdex", "method": "parse"},
 	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.scraped, res.error
@@ -2033,7 +2027,7 @@ func walOpenMetricsScraperHashdexParse(hashdex uintptr, buffer []byte, default_t
 		uintptr(unsafe.Pointer(&res)),
 	)
 	unsafeCall.With(
-		prometheus.Labels{"object": "hashdex", "method": "parse"},
+		prometheus.Labels{"object": "open_metrics_hashdex", "method": "parse"},
 	).Observe(float64(time.Since(start).Nanoseconds()))
 
 	return res.scraped, res.error

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -22,22 +22,235 @@ import (
 	"unsafe" //nolint:gocritic // because otherwise it won't work
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/pp/go/cppbridge/fastcgo"
 	"github.com/prometheus/prometheus/pp/go/model"
+	"github.com/prometheus/prometheus/pp/go/util"
 )
 
-var unsafeCall = promauto.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Name: "prompp_cppbridge_unsafecall_nanoseconds",
-		Help: "The time duration cpp call.",
-		Buckets: []float64{
-			100, 500,
-			1000, 5000, 10000, 50000, 100000, 500000,
-			1000000, 5000000, 10000000, 50000000, 100000000, 500000000,
+var (
+	// UnsafeCall2
+	unsafeCall2Sum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "unsafe", "method": "call_2"},
 		},
-	},
-	[]string{"object", "method"},
+	)
+	unsafeCall2Count = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "unsafe", "method": "call_2"},
+		},
+	)
+
+	// input_relabeler input_relabeling
+	inputRelabelerInputRelabelingSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "input_relabeling"},
+		},
+	)
+	inputRelabelerInputRelabelingCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "input_relabeling"},
+		},
+	)
+
+	// input_relabeler relabeling_with_stalenans
+	inputRelabelerRelabelingWithStalenansSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "relabeling_with_stalenans"},
+		},
+	)
+	inputRelabelerRelabelingWithStalenansCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "relabeling_with_stalenans"},
+		},
+	)
+
+	// input_relabeler append_relabeler_series
+	inputRelabelerAppendRelabelerSeriesSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "append_relabeler_series"},
+		},
+	)
+	inputRelabelerAppendRelabelerSeriesCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "append_relabeler_series"},
+		},
+	)
+
+	// input_relabeler update_relabeler_state
+	inputRelabelerUpdateRelabelerStateSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "update_relabeler_state"},
+		},
+	)
+	inputRelabelerUpdateRelabelerStateCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "input_relabeler", "method": "update_relabeler_state"},
+		},
+	)
+
+	// head_data_storage allocated_memory
+	headDataStorageAllocatedMemorySum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "allocated_memory"},
+		},
+	)
+	headDataStorageAllocatedMemoryCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "allocated_memory"},
+		},
+	)
+
+	// head_data_storage query
+	headDataStorageQuerySum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "query"},
+		},
+	)
+	headDataStorageQueryCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "query"},
+		},
+	)
+
+	// head_data_storage encode_inner_series_slice
+	headDataStorageEncodeInnerSeriesSliceSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "encode_inner_series_slice"},
+		},
+	)
+	headDataStorageEncodeInnerSeriesSliceCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "encode_inner_series_slice"},
+		},
+	)
+
+	// head_data_storage merge_out_of_order_chunks
+	headDataStorageMergeOutOfOrderChunksSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "merge_out_of_order_chunks"},
+		},
+	)
+	headDataStorageMergeOutOfOrderChunksCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_data_storage", "method": "merge_out_of_order_chunks"},
+		},
+	)
+
+	// prometheus_hashdex parse
+	prometheusHashdexParseSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "prometheus_hashdex", "method": "parse"},
+		},
+	)
+	prometheusHashdexParseCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "prometheus_hashdex", "method": "parse"},
+		},
+	)
+
+	// open_metrics_hashdex parse
+	openMetricsHashdexParseSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "open_metrics_hashdex", "method": "parse"},
+		},
+	)
+	openMetricsHashdexParseCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "open_metrics_hashdex", "method": "parse"},
+		},
+	)
+
+	// head_wal_encoder add_inner_series
+	headWalEncoderAddInnerSeriesSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_wal_encoder", "method": "add_inner_series"},
+		},
+	)
+	headWalEncoderAddInnerSeriesCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_wal_encoder", "method": "add_inner_series"},
+		},
+	)
+
+	// head_wal_encoder finalize
+	headWalEncoderFinalizeSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_wal_encoder", "method": "finalize"},
+		},
+	)
+	headWalEncoderFinalizeCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "head_wal_encoder", "method": "finalize"},
+		},
+	)
+
+	// chunk_recoder recode_next_chunk
+	chunkRecoderRecodeNextChunkSum = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_sum",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "chunk_recoder", "method": "recode_next_chunk"},
+		},
+	)
+	chunkRecoderRecodeNextChunkCount = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_unsafecall_nanoseconds_count",
+			Help:        "The time duration cpp call.",
+			ConstLabels: prometheus.Labels{"object": "chunk_recoder", "method": "recode_next_chunk"},
+		},
+	)
 )
 
 func freeBytes(b []byte) {
@@ -1245,7 +1458,7 @@ func prometheusPerShardRelabelerInputRelabeling(
 	options RelabelerOptions,
 	shardsInnerSeries []*InnerSeries,
 	shardsRelabeledSeries []*RelabeledSeries,
-) (samplesAdded, seriesAdded uint32, exception []byte) {
+) (stats RelabelerStats, exception []byte) {
 	args := struct {
 		shardsInnerSeries     []*InnerSeries
 		shardsRelabeledSeries []*RelabeledSeries
@@ -1257,21 +1470,19 @@ func prometheusPerShardRelabelerInputRelabeling(
 		targetLss             uintptr
 	}{shardsInnerSeries, shardsRelabeledSeries, options, perShardRelabeler, hashdex, cache, inputLss, targetLss}
 	var res struct {
-		samplesAdded uint32
-		seriesAdded  uint32
-		exception    []byte
+		RelabelerStats
+		exception []byte
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_prometheus_per_shard_relabeler_input_relabeling,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "input_relabeler", "method": "input_relabeling"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	inputRelabelerInputRelabelingSum.Add(float64(time.Now().UnixNano() - start))
+	inputRelabelerInputRelabelingCount.Inc()
 
-	return res.samplesAdded, res.seriesAdded, res.exception
+	return res.RelabelerStats, res.exception
 }
 
 // prometheusPerShardRelabelerInputRelabelingWithStalenans wrapper for relabeling incoming
@@ -1282,7 +1493,7 @@ func prometheusPerShardRelabelerInputRelabelingWithStalenans(
 	options RelabelerOptions,
 	shardsInnerSeries []*InnerSeries,
 	shardsRelabeledSeries []*RelabeledSeries,
-) (samplesAdded, seriesAdded uint32, exception []byte) {
+) (stats RelabelerStats, exception []byte) {
 	args := struct {
 		shardsInnerSeries     []*InnerSeries
 		shardsRelabeledSeries []*RelabeledSeries
@@ -1307,21 +1518,19 @@ func prometheusPerShardRelabelerInputRelabelingWithStalenans(
 		defTimestamp,
 	}
 	var res struct {
-		samplesAdded uint32
-		seriesAdded  uint32
-		exception    []byte
+		RelabelerStats
+		exception []byte
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_prometheus_per_shard_relabeler_input_relabeling_with_stalenans,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "input_relabeler", "method": "relabeling_with_stalenans"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	inputRelabelerRelabelingWithStalenansSum.Add(float64(time.Now().UnixNano() - start))
+	inputRelabelerRelabelingWithStalenansCount.Inc()
 
-	return res.samplesAdded, res.seriesAdded, res.exception
+	return res.RelabelerStats, res.exception
 }
 
 // prometheusPerShardRelabelerAppendRelabelerSeries - wrapper for add relabeled ls to lss,
@@ -1342,15 +1551,14 @@ func prometheusPerShardRelabelerAppendRelabelerSeries(
 	var res struct {
 		exception []byte
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_prometheus_per_shard_relabeler_append_relabeler_series,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "input_relabeler", "method": "append_relabeler_series"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	inputRelabelerAppendRelabelerSeriesSum.Add(float64(time.Now().UnixNano() - start))
+	inputRelabelerAppendRelabelerSeriesCount.Inc()
 
 	return res.exception
 }
@@ -1370,15 +1578,14 @@ func prometheusPerShardRelabelerUpdateRelabelerState(
 	var res struct {
 		exception []byte
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_prometheus_per_shard_relabeler_update_relabeler_state,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "input_relabeler", "method": "update_relabeler_state"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	inputRelabelerUpdateRelabelerStateSum.Add(float64(time.Now().UnixNano() - start))
+	inputRelabelerUpdateRelabelerStateCount.Inc()
 
 	return res.exception
 }
@@ -1421,14 +1628,11 @@ func prometheusPerShardRelabelerResetTo(
 		perShardRelabeler uintptr
 		numberOfShards    uint16
 	}{externalLabels, perShardRelabeler, numberOfShards}
-	start := time.Now()
+
 	fastcgo.UnsafeCall1(
 		C.prompp_prometheus_per_shard_relabeler_reset_to,
 		uintptr(unsafe.Pointer(&args)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "input_relabeler", "method": "reset_to"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataDataStorageCtor() uintptr {
@@ -1448,14 +1652,11 @@ func seriesDataDataStorageReset(dataStorage uintptr) {
 	args := struct {
 		dataStorage uintptr
 	}{dataStorage}
-	start := time.Now()
+
 	fastcgo.UnsafeCall1(
 		C.prompp_series_data_data_storage_reset,
 		uintptr(unsafe.Pointer(&args)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "reset"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataDataStorageAllocatedMemory(dataStorage uintptr) uint64 {
@@ -1465,15 +1666,14 @@ func seriesDataDataStorageAllocatedMemory(dataStorage uintptr) uint64 {
 	var res struct {
 		allocatedMemory uint64
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_series_data_data_storage_allocated_memory,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "allocated_memory"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headDataStorageAllocatedMemorySum.Add(float64(time.Now().UnixNano() - start))
+	headDataStorageAllocatedMemoryCount.Inc()
 
 	return res.allocatedMemory
 }
@@ -1486,15 +1686,14 @@ func seriesDataDataStorageQuery(dataStorage uintptr, query HeadDataStorageQuery)
 	var res struct {
 		serializedChunks []byte
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_series_data_data_storage_query,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "query"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headDataStorageQuerySum.Add(float64(time.Now().UnixNano() - start))
+	headDataStorageQueryCount.Inc()
 
 	return res.serializedChunks
 }
@@ -1551,14 +1750,11 @@ func seriesDataEncoderEncode(encoder uintptr, seriesID uint32, timestamp int64, 
 		timestamp int64
 		value     float64
 	}{encoder, seriesID, timestamp, value}
-	start := time.Now()
+
 	fastcgo.UnsafeCall1(
 		C.prompp_series_data_encoder_encode,
 		uintptr(unsafe.Pointer(&args)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "encode"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
 }
 
 func seriesDataEncoderEncodeInnerSeriesSlice(encoder uintptr, innerSeriesSlice []*InnerSeries) {
@@ -1566,28 +1762,26 @@ func seriesDataEncoderEncodeInnerSeriesSlice(encoder uintptr, innerSeriesSlice [
 		encoder          uintptr
 		innerSeriesSlice []*InnerSeries
 	}{encoder, innerSeriesSlice}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall1(
 		C.prompp_series_data_encoder_encode_inner_series_slice,
 		uintptr(unsafe.Pointer(&args)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "encode_inner_series_slice"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headDataStorageEncodeInnerSeriesSliceSum.Add(float64(time.Now().UnixNano() - start))
+	headDataStorageEncodeInnerSeriesSliceCount.Inc()
 }
 
 func seriesDataEncoderMergeOutOfOrderChunks(encoder uintptr) {
 	args := struct {
 		encoder uintptr
 	}{encoder}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall1(
 		C.prompp_series_data_encoder_merge_out_of_order_chunks,
 		uintptr(unsafe.Pointer(&args)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_data_storage", "method": "merge_out_of_order_chunks"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headDataStorageMergeOutOfOrderChunksSum.Add(float64(time.Now().UnixNano() - start))
+	headDataStorageMergeOutOfOrderChunksCount.Inc()
 }
 
 func seriesDataEncoderDtor(encoder uintptr) {
@@ -1716,15 +1910,14 @@ func seriesDataChunkRecoderRecodeNextChunk(chunkRecoder uintptr, recodedChunk *R
 	args := struct {
 		chunkRecoder uintptr
 	}{chunkRecoder}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_series_data_chunk_recoder_recode_next_chunk,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(recodedChunk)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "chunk_recoder", "method": "recode_next_chunk"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	chunkRecoderRecodeNextChunkSum.Add(float64(time.Now().UnixNano() - start))
+	chunkRecoderRecodeNextChunkCount.Inc()
 }
 
 func seriesDataChunkRecoderDtor(chunkRecoder uintptr) {
@@ -1963,15 +2156,14 @@ func walPrometheusScraperHashdexParse(hashdex uintptr, buffer []byte, default_ti
 		error   uint32
 		scraped uint32
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_wal_prometheus_scraper_hashdex_parse,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "prometheus_hashdex", "method": "parse"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	prometheusHashdexParseSum.Add(float64(time.Now().UnixNano() - start))
+	prometheusHashdexParseCount.Inc()
 
 	return res.scraped, res.error
 }
@@ -2020,15 +2212,14 @@ func walOpenMetricsScraperHashdexParse(hashdex uintptr, buffer []byte, default_t
 		error   uint32
 		scraped uint32
 	}
-	start := time.Now()
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_wal_open_metrics_scraper_hashdex_parse,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-	unsafeCall.With(
-		prometheus.Labels{"object": "open_metrics_hashdex", "method": "parse"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	openMetricsHashdexParseSum.Add(float64(time.Now().UnixNano() - start))
+	openMetricsHashdexParseCount.Inc()
 
 	return res.scraped, res.error
 }
@@ -2140,17 +2331,14 @@ func headWalEncoderAddInnerSeries(encoder uintptr, innerSeries []*InnerSeries) (
 		exception []byte
 	}
 
-	start := time.Now()
-
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_head_wal_encoder_add_inner_series,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_wal_encoder", "method": "add_inner_series"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headWalEncoderAddInnerSeriesSum.Add(float64(time.Now().UnixNano() - start))
+	headWalEncoderAddInnerSeriesCount.Inc()
 
 	return res.WALEncoderStats, handleException(res.exception)
 }
@@ -2166,17 +2354,14 @@ func headWalEncoderFinalize(encoder uintptr) (stats WALEncoderStats, segment []b
 		exception []byte
 	}
 
-	start := time.Now()
-
+	start := time.Now().UnixNano()
 	fastcgo.UnsafeCall2(
 		C.prompp_head_wal_encoder_finalize,
 		uintptr(unsafe.Pointer(&args)),
 		uintptr(unsafe.Pointer(&res)),
 	)
-
-	unsafeCall.With(
-		prometheus.Labels{"object": "head_wal_encoder", "method": "finalize"},
-	).Observe(float64(time.Since(start).Nanoseconds()))
+	headWalEncoderFinalizeSum.Add(float64(time.Now().UnixNano() - start))
+	headWalEncoderFinalizeCount.Inc()
 
 	return res.WALEncoderStats, res.segment, handleException(res.exception)
 }

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -1328,9 +1328,10 @@ void prompp_wal_output_decoder_load_from(void* args, void* res);
  *
  * @param res {
  *     max_timestamp         int64       // max timestamp in slice RefSample
- *     outdated_sample_count uint64      // count of dropped samples on outdated
- *     dropped_sample_count  uint64      // count of dropped samples on relabeling rules
- *     dropped_series_count  uint64      // count of dropped series on relabeling rules
+ *     outdated_sample_count uint32      // count of dropped samples on outdated
+ *     dropped_sample_count  uint32      // count of dropped samples on relabeling rules
+ *     add_series_count      uint32      // count of add series on relabeling rules
+ *     dropped_series_count  uint32      // count of dropped series on relabeling rules
  *     ref_samples           []RefSample // slice RefSample
  *     error                 []byte      // error string if thrown
  * }

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -714,6 +714,9 @@ void prompp_prometheus_per_shard_relabeler_cache_allocated_memory(void* args, vo
  * }
  *
  * @param res {
+ *     samples_added           uint32             // number of added samples;
+ *     series_added            uint32             // number of added series;
+ *     series_drop             uint32             // number of dropped series;
  *     error                   []byte             // error string if thrown;
  * }
  */
@@ -780,6 +783,9 @@ void prompp_prometheus_per_shard_relabeler_input_relabeling_with_stalenans(void*
  * }
  *
  * @param res {
+ *     samples_added           uint32             // number of added samples;
+ *     series_added            uint32             // number of added series;
+ *     series_drop             uint32             // number of dropped series;
  *     error                   []byte             // error string if thrown;
  * }
  */
@@ -1324,6 +1330,7 @@ void prompp_wal_output_decoder_load_from(void* args, void* res);
  *     max_timestamp         int64       // max timestamp in slice RefSample
  *     outdated_sample_count uint64      // count of dropped samples on outdated
  *     dropped_sample_count  uint64      // count of dropped samples on relabeling rules
+ *     dropped_series_count  uint64      // count of dropped series on relabeling rules
  *     ref_samples           []RefSample // slice RefSample
  *     error                 []byte      // error string if thrown
  * }

--- a/pp/go/cppbridge/prometheus_relabeler.go
+++ b/pp/go/cppbridge/prometheus_relabeler.go
@@ -517,6 +517,17 @@ func (s *StaleNansState) Reset() {
 type RelabelerStats struct {
 	SamplesAdded uint32
 	SeriesAdded  uint32
+	SeriesDrop   uint32
+}
+
+// String serialize to string.
+func (rs RelabelerStats) String() string {
+	return fmt.Sprintf(
+		"{samples_added: %d, series_added: %d, series_drop: %d}",
+		rs.SamplesAdded,
+		rs.SeriesAdded,
+		rs.SeriesDrop,
+	)
 }
 
 // InputPerShardRelabeler - go wrapper for C-PerShardRelabeler, relabeler for shard.
@@ -613,7 +624,7 @@ func (ipsr *InputPerShardRelabeler) InputRelabeling(
 	if !ok {
 		return RelabelerStats{}, ErrMustImplementCptrable
 	}
-	samplesAdded, seriesAdded, exception := prometheusPerShardRelabelerInputRelabeling(
+	stats, exception := prometheusPerShardRelabelerInputRelabeling(
 		ipsr.cptr,
 		inputLss.Pointer(),
 		targetLss.Pointer(),
@@ -624,7 +635,7 @@ func (ipsr *InputPerShardRelabeler) InputRelabeling(
 		shardsRelabeledSeries,
 	)
 
-	return RelabelerStats{SamplesAdded: samplesAdded, SeriesAdded: seriesAdded}, handleException(exception)
+	return stats, handleException(exception)
 }
 
 // InputRelabelingWithStalenans relabeling incoming hashdex(first stage) with state stalenans.
@@ -648,7 +659,7 @@ func (ipsr *InputPerShardRelabeler) InputRelabelingWithStalenans(
 	if !ok {
 		return RelabelerStats{}, ErrMustImplementCptrable
 	}
-	samplesAdded, seriesAdded, exception := prometheusPerShardRelabelerInputRelabelingWithStalenans(
+	stats, exception := prometheusPerShardRelabelerInputRelabelingWithStalenans(
 		ipsr.cptr,
 		inputLss.Pointer(),
 		targetLss.Pointer(),
@@ -661,7 +672,7 @@ func (ipsr *InputPerShardRelabeler) InputRelabelingWithStalenans(
 		shardsRelabeledSeries,
 	)
 
-	return RelabelerStats{SamplesAdded: samplesAdded, SeriesAdded: seriesAdded}, handleException(exception)
+	return stats, handleException(exception)
 }
 
 // NumberOfShards return current numberOfShards.

--- a/pp/go/cppbridge/prometheus_relabeler_test.go
+++ b/pp/go/cppbridge/prometheus_relabeler_test.go
@@ -214,6 +214,15 @@ func (s *RelabelerSuite) TestInputPerShardRelabeler() {
 					{Value: 0.1, Timestamp: time.Now().UnixMilli()},
 				},
 			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{
+					{Value: 0.1, Timestamp: time.Now().UnixMilli()},
+				},
+			},
 		},
 	}
 	data, err := wr.Marshal()
@@ -247,7 +256,7 @@ func (s *RelabelerSuite) TestInputPerShardRelabeler() {
 
 	stats, err := psr.InputRelabeling(s.baseCtx, inputLss, targetLss, cache, s.options, h, shardsInnerSeries, shardsRelabeledSeries)
 	s.Require().NoError(err)
-	s.Equal(cppbridge.RelabelerStats{1, 1}, stats)
+	s.Equal(cppbridge.RelabelerStats{1, 1, 1}, stats)
 }
 
 func (s *RelabelerSuite) TestOutputPerShardRelabeler() {

--- a/pp/go/cppbridge/wal_decoder.go
+++ b/pp/go/cppbridge/wal_decoder.go
@@ -255,6 +255,7 @@ type OutputDecoderStats struct {
 	maxTimestamp        int64
 	outdatedSampleCount uint64
 	droppedSampleCount  uint64
+	droppedSeriesCount  uint64
 }
 
 // MaxTimestamp return max timestamp in decoded segment.
@@ -270,6 +271,11 @@ func (s OutputDecoderStats) OutdatedSampleCount() uint64 {
 // DroppedSampleCount return count dropped samples.
 func (s OutputDecoderStats) DroppedSampleCount() uint64 {
 	return s.droppedSampleCount
+}
+
+// DroppedSeriesCount return count dropped series.
+func (s OutputDecoderStats) DroppedSeriesCount() uint64 {
+	return s.droppedSeriesCount
 }
 
 //

--- a/pp/go/cppbridge/wal_decoder.go
+++ b/pp/go/cppbridge/wal_decoder.go
@@ -253,9 +253,10 @@ func (d *WALDecoder) RestoreFromStream(
 // OutputDecoderStats stats for output decoded segment.
 type OutputDecoderStats struct {
 	maxTimestamp        int64
-	outdatedSampleCount uint64
-	droppedSampleCount  uint64
-	droppedSeriesCount  uint64
+	outdatedSampleCount uint32
+	droppedSampleCount  uint32
+	addSeriesCount      uint32
+	droppedSeriesCount  uint32
 }
 
 // MaxTimestamp return max timestamp in decoded segment.
@@ -264,17 +265,22 @@ func (s OutputDecoderStats) MaxTimestamp() int64 {
 }
 
 // OutdatedSampleCount return count of too old samples.
-func (s OutputDecoderStats) OutdatedSampleCount() uint64 {
+func (s OutputDecoderStats) OutdatedSampleCount() uint32 {
 	return s.outdatedSampleCount
 }
 
 // DroppedSampleCount return count dropped samples.
-func (s OutputDecoderStats) DroppedSampleCount() uint64 {
+func (s OutputDecoderStats) DroppedSampleCount() uint32 {
 	return s.droppedSampleCount
 }
 
+// AddSeriesCount return number of add series.
+func (s OutputDecoderStats) AddSeriesCount() uint32 {
+	return s.addSeriesCount
+}
+
 // DroppedSeriesCount return count dropped series.
-func (s OutputDecoderStats) DroppedSeriesCount() uint64 {
+func (s OutputDecoderStats) DroppedSeriesCount() uint32 {
 	return s.droppedSeriesCount
 }
 

--- a/pp/go/cppbridge/wal_encode_decode_test.go
+++ b/pp/go/cppbridge/wal_encode_decode_test.go
@@ -592,8 +592,9 @@ func (s *EncoderDecoderSuite) TestEncodeWALOutputDecode() {
 	s.Require().NoError(err)
 
 	s.Equal(expectedWr.Timeseries[0].Samples[0].Timestamp, stats.MaxTimestamp())
-	s.Equal(uint64(0), stats.OutdatedSampleCount())
-	s.Equal(uint64(0), stats.DroppedSampleCount())
+	s.Equal(uint32(0), stats.OutdatedSampleCount())
+	s.Equal(uint32(1), stats.AddSeriesCount())
+	s.Equal(uint32(0), stats.DroppedSampleCount())
 	refSamples.Range(func(id uint32, t int64, v float64) bool {
 		if !s.Less(int(id), len(expectedWr.Timeseries)) {
 			return false
@@ -667,8 +668,9 @@ func (s *EncoderDecoderSuite) TestEncodeWALOutputDecodeWithLimit() {
 
 	count := 0
 	s.Equal(int64(0), stats.MaxTimestamp())
-	s.Equal(uint64(1), stats.OutdatedSampleCount())
-	s.Equal(uint64(0), stats.DroppedSampleCount())
+	s.Equal(uint32(1), stats.OutdatedSampleCount())
+	s.Equal(uint32(1), stats.AddSeriesCount())
+	s.Equal(uint32(0), stats.DroppedSampleCount())
 	refSamples.Range(func(id uint32, t int64, v float64) bool {
 		if !s.Less(int(id), len(expectedWr.Timeseries)) {
 			return false
@@ -761,9 +763,10 @@ func (s *EncoderDecoderSuite) TestEncodeWALOutputDecodeDroppedSeries() {
 
 	count := 0
 	s.Equal(int64(0), stats.MaxTimestamp())
-	s.Equal(uint64(1), stats.OutdatedSampleCount())
-	s.Equal(uint64(1), stats.DroppedSampleCount())
-	s.Equal(uint64(1), stats.DroppedSeriesCount())
+	s.Equal(uint32(1), stats.OutdatedSampleCount())
+	s.Equal(uint32(1), stats.DroppedSampleCount())
+	s.Equal(uint32(1), stats.AddSeriesCount())
+	s.Equal(uint32(1), stats.DroppedSeriesCount())
 	refSamples.Range(func(id uint32, t int64, v float64) bool {
 		if !s.Less(int(id), len(expectedWr.Timeseries)) {
 			return false

--- a/pp/go/cppbridge/wal_encode_decode_test.go
+++ b/pp/go/cppbridge/wal_encode_decode_test.go
@@ -679,3 +679,98 @@ func (s *EncoderDecoderSuite) TestEncodeWALOutputDecodeWithLimit() {
 
 	s.Equal(0, count)
 }
+
+func (s *EncoderDecoderSuite) TestEncodeWALOutputDecodeDroppedSeries() {
+	statelessRelabeler, err := cppbridge.NewStatelessRelabeler([]*cppbridge.RelabelConfig{
+		{
+			SourceLabels: []string{"__name__"},
+			Regex:        "test",
+			Action:       cppbridge.Keep,
+		},
+	})
+	s.Require().NoError(err)
+	externalLabels := []cppbridge.Label{{"name0", "value0"}, {"name1", "value1"}}
+	outputLss := cppbridge.NewLssStorage()
+	dec := cppbridge.NewWALOutputDecoder(externalLabels, statelessRelabeler, outputLss, 0, cppbridge.EncodersVersion())
+
+	hlimits := cppbridge.DefaultWALHashdexLimits()
+	enc := cppbridge.NewWALEncoder(0, 0)
+
+	expectedWr := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{
+						Name:  "__name__",
+						Value: "test",
+					},
+					{
+						Name:  "job",
+						Value: "tester",
+					},
+				},
+				Samples: []prompb.Sample{
+					{
+						Timestamp: time.Now().UnixMilli(),
+						Value:     4444,
+					},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{
+						Name:  "__name__",
+						Value: "test2",
+					},
+					{
+						Name:  "job",
+						Value: "tester",
+					},
+				},
+				Samples: []prompb.Sample{
+					{
+						Timestamp: time.Now().UnixMilli(),
+						Value:     4444,
+					},
+				},
+			},
+		},
+	}
+
+	data, err := expectedWr.Marshal()
+	s.Require().NoError(err)
+
+	s.T().Log("sharding protobuf")
+	h, err := cppbridge.NewWALSnappyProtobufHashdex(snappy.Encode(nil, data), hlimits)
+	s.Require().NoError(err)
+
+	s.T().Log("encoding protobuf")
+	_, gos, err := enc.Encode(s.baseCtx, h)
+	s.Require().NoError(err)
+
+	s.EqualValues(2, gos.Series())
+	s.EqualValues(2, gos.Samples())
+
+	s.T().Log("transferring segment")
+	segByte := s.transferringData(gos)
+
+	s.T().Log("decoding to RefSamples")
+
+	refSamples, stats, err := dec.Decode(segByte, time.Now().UnixMilli()+1)
+	s.Require().NoError(err)
+
+	count := 0
+	s.Equal(int64(0), stats.MaxTimestamp())
+	s.Equal(uint64(1), stats.OutdatedSampleCount())
+	s.Equal(uint64(1), stats.DroppedSampleCount())
+	s.Equal(uint64(1), stats.DroppedSeriesCount())
+	refSamples.Range(func(id uint32, t int64, v float64) bool {
+		if !s.Less(int(id), len(expectedWr.Timeseries)) {
+			return false
+		}
+		count++
+		return true
+	})
+
+	s.Equal(0, count)
+}

--- a/pp/go/relabeler/appender/rotator.go
+++ b/pp/go/relabeler/appender/rotator.go
@@ -38,7 +38,7 @@ type RotateCommiter struct {
 	mergeTimer       Timer
 	run              chan struct{}
 	closer           *util.Closer
-	rotateCounter    prometheus.Counter
+	rotateTimestamp  prometheus.Gauge
 }
 
 // NewRotateCommiter - Rotator constructor.
@@ -57,10 +57,10 @@ func NewRotateCommiter(
 		mergeTimer:       mergeTimer,
 		run:              make(chan struct{}),
 		closer:           util.NewCloser(),
-		rotateCounter: factory.NewCounter(
-			prometheus.CounterOpts{
-				Name: "prompp_rotator_rotate_count",
-				Help: "Total counter of rotate rotatable object.",
+		rotateTimestamp: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "prompp_rotator_rotate_timestamp",
+				Help: "Timestamp in seconds of rotate rotatable object.",
 			},
 		),
 	}
@@ -107,7 +107,7 @@ func (r *RotateCommiter) loop() {
 			if err := r.rotateCommitable.Rotate(); err != nil {
 				logger.Errorf("rotation failed: %v", err)
 			}
-			r.rotateCounter.Inc()
+			r.rotateTimestamp.Set(float64(time.Now().UnixMilli()))
 
 			r.rotateTimer.Reset()
 			r.commitTimer.Reset()

--- a/pp/go/relabeler/appender/rotator.go
+++ b/pp/go/relabeler/appender/rotator.go
@@ -38,7 +38,7 @@ type RotateCommiter struct {
 	mergeTimer       Timer
 	run              chan struct{}
 	closer           *util.Closer
-	rotateTimestamp  prometheus.Gauge
+	rotateCounter    prometheus.Counter
 }
 
 // NewRotateCommiter - Rotator constructor.
@@ -57,10 +57,10 @@ func NewRotateCommiter(
 		mergeTimer:       mergeTimer,
 		run:              make(chan struct{}),
 		closer:           util.NewCloser(),
-		rotateTimestamp: factory.NewGauge(
-			prometheus.GaugeOpts{
-				Name: "prompp_rotator_rotate_timestamp",
-				Help: "Timestamp in seconds of rotate rotatable object.",
+		rotateCounter: factory.NewCounter(
+			prometheus.CounterOpts{
+				Name: "prompp_rotator_rotate_count",
+				Help: "Total counter of rotate rotatable object.",
 			},
 		),
 	}
@@ -107,7 +107,7 @@ func (r *RotateCommiter) loop() {
 			if err := r.rotateCommitable.Rotate(); err != nil {
 				logger.Errorf("rotation failed: %v", err)
 			}
-			r.rotateTimestamp.Set(float64(time.Now().UnixMilli()))
+			r.rotateCounter.Inc()
 
 			r.rotateTimer.Reset()
 			r.commitTimer.Reset()

--- a/pp/go/relabeler/appender/storage.go
+++ b/pp/go/relabeler/appender/storage.go
@@ -1,7 +1,6 @@
 package appender
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,7 +46,7 @@ type QueryableStorage struct {
 
 	clock                   clockwork.Clock
 	maxRetentionDuration    time.Duration
-	headPersistenceDuration *prometheus.GaugeVec
+	headPersistenceDuration prometheus.Histogram
 	querierMetrics          *querier.Metrics
 }
 
@@ -74,12 +73,15 @@ func NewQueryableStorageWithWriteNotifier(
 		clock:                clock,
 		maxRetentionDuration: maxRetentionDuration,
 		headRetentionTimeout: headRetentionTimeout,
-		headPersistenceDuration: factory.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Name: "prompp_head_persistence_duration_duration",
+		headPersistenceDuration: factory.NewHistogram(
+			prometheus.HistogramOpts{
+				Name: "prompp_head_persistence_duration",
 				Help: "Block write duration in milliseconds.",
+				Buckets: []float64{
+					500, 1000, 2500, 5000, 7500,
+					10000, 25000, 50000, 75000, 100000,
+				},
 			},
-			[]string{"generation"},
 		),
 		querierMetrics: querierMetrics,
 	}
@@ -167,9 +169,7 @@ func (qs *QueryableStorage) write() bool {
 			successful = false
 			continue
 		}
-		qs.headPersistenceDuration.With(prometheus.Labels{
-			"generation": fmt.Sprintf("%d", head.Generation()),
-		}).Set(float64(qs.clock.Since(start).Milliseconds()))
+		qs.headPersistenceDuration.Observe(float64(qs.clock.Since(start).Milliseconds()))
 		persisted = append(persisted, head.ID())
 		shouldNotify = true
 		logger.Infof("QUERYABLE STORAGE: head %s persisted, duration: %v", head.String(), qs.clock.Since(start))

--- a/pp/go/relabeler/head/catalog/catalog.go
+++ b/pp/go/relabeler/head/catalog/catalog.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pp/go/relabeler/logger"
+	"github.com/prometheus/prometheus/pp/go/util"
 )
 
 const (
@@ -35,19 +37,34 @@ func (DefaultIDGenerator) Generate() uuid.UUID {
 }
 
 type Catalog struct {
-	mtx         sync.Mutex
-	clock       clockwork.Clock
-	log         Log
-	idGenerator IDGenerator
-	records     map[string]*Record
+	mtx                 sync.Mutex
+	clock               clockwork.Clock
+	log                 Log
+	idGenerator         IDGenerator
+	records             map[string]*Record
+	corruptedHead       prometheus.Counter
+	activeHeadCreatedAt prometheus.Gauge
 }
 
-func New(clock clockwork.Clock, log Log, idGenerator IDGenerator) (*Catalog, error) {
+func New(clock clockwork.Clock, log Log, idGenerator IDGenerator, registerer prometheus.Registerer) (*Catalog, error) {
+	factory := util.NewUnconflictRegisterer(registerer)
 	catalog := &Catalog{
 		clock:       clock,
 		log:         log,
 		idGenerator: idGenerator,
 		records:     make(map[string]*Record),
+		corruptedHead: factory.NewCounter(
+			prometheus.CounterOpts{
+				Name: "prompp_head_catalog_corrupted_head_total",
+				Help: "Total number of corrupted heads.",
+			},
+		),
+		activeHeadCreatedAt: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "prompp_head_catalog_active_head_created_at",
+				Help: "The time when the active head was created.",
+			},
+		),
 	}
 
 	if err := catalog.sync(); err != nil {
@@ -131,6 +148,10 @@ func (c *Catalog) SetStatus(id string, status Status) (_ *Record, err error) {
 	}
 
 	if r.status == status {
+		if status == StatusActive {
+			c.activeHeadCreatedAt.Set(float64(r.createdAt))
+		}
+
 		return r, nil
 	}
 
@@ -144,6 +165,10 @@ func (c *Catalog) SetStatus(id string, status Status) (_ *Record, err error) {
 
 	applyRecordChanges(r, changed)
 	c.records[id] = r
+
+	if status == StatusActive {
+		c.activeHeadCreatedAt.Set(float64(r.createdAt))
+	}
 
 	return r, nil
 }
@@ -162,6 +187,7 @@ func (c *Catalog) SetCorrupted(id string) (_ *Record, err error) {
 	}
 
 	if r.corrupted {
+		c.corruptedHead.Inc()
 		return r, nil
 	}
 
@@ -175,6 +201,8 @@ func (c *Catalog) SetCorrupted(id string) (_ *Record, err error) {
 
 	applyRecordChanges(r, changed)
 	c.records[id] = r
+
+	c.corruptedHead.Inc()
 
 	return r, nil
 }

--- a/pp/go/relabeler/head/catalog/catalog.go
+++ b/pp/go/relabeler/head/catalog/catalog.go
@@ -187,7 +187,6 @@ func (c *Catalog) SetCorrupted(id string) (_ *Record, err error) {
 	}
 
 	if r.corrupted {
-		c.corruptedHead.Inc()
 		return r, nil
 	}
 

--- a/pp/go/relabeler/head/catalog/catalog_test.go
+++ b/pp/go/relabeler/head/catalog/catalog_test.go
@@ -1,13 +1,14 @@
 package catalog_test
 
 import (
-	"github.com/jonboulle/clockwork"
-	"github.com/prometheus/prometheus/pp/go/relabeler/head/catalog"
-	"github.com/stretchr/testify/require"
 	"os"
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/prometheus/pp/go/relabeler/head/catalog"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCatalog(t *testing.T) {
@@ -21,7 +22,7 @@ func TestCatalog(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Now())
 
-	c, err := catalog.New(clock, l, catalog.DefaultIDGenerator{})
+	c, err := catalog.New(clock, l, catalog.DefaultIDGenerator{}, nil)
 	require.NoError(t, err)
 
 	now := clock.Now().UnixMilli()
@@ -64,7 +65,7 @@ func TestCatalog(t *testing.T) {
 
 	l, err = catalog.NewFileLogV2(logFileName)
 	require.NoError(t, err)
-	c, err = catalog.New(clock, l, catalog.DefaultIDGenerator{})
+	c, err = catalog.New(clock, l, catalog.DefaultIDGenerator{}, nil)
 	require.NoError(t, err)
 
 	records, err := c.List(nil, nil)
@@ -73,8 +74,8 @@ func TestCatalog(t *testing.T) {
 		return records[i].CreatedAt() < records[j].CreatedAt()
 	})
 
-	//prevRecords := []catalog.Record{r1, r2}
-	//require.Equal(t, records, prevRecords)
+	// prevRecords := []catalog.Record{r1, r2}
+	// require.Equal(t, records, prevRecords)
 }
 
 func TestCatalogSyncFail(t *testing.T) {
@@ -88,7 +89,7 @@ func TestCatalogSyncFail(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Now())
 
-	c, err := catalog.New(clock, l, catalog.DefaultIDGenerator{})
+	c, err := catalog.New(clock, l, catalog.DefaultIDGenerator{}, nil)
 	require.NoError(t, err)
 
 	var nos1 uint16 = 2
@@ -106,7 +107,7 @@ func TestCatalogSyncFail(t *testing.T) {
 	l, err = catalog.NewFileLogV2(logFileName)
 	require.NoError(t, err)
 
-	c, err = catalog.New(clock, l, catalog.DefaultIDGenerator{})
+	c, err = catalog.New(clock, l, catalog.DefaultIDGenerator{}, nil)
 	require.NoError(t, err)
 
 	restoredR1, err := c.Get(r1.ID())

--- a/pp/go/relabeler/head/catalog/catalog_test.go
+++ b/pp/go/relabeler/head/catalog/catalog_test.go
@@ -73,9 +73,6 @@ func TestCatalog(t *testing.T) {
 	sort.Slice(records, func(i, j int) bool {
 		return records[i].CreatedAt() < records[j].CreatedAt()
 	})
-
-	// prevRecords := []catalog.Record{r1, r2}
-	// require.Equal(t, records, prevRecords)
 }
 
 func TestCatalogSyncFail(t *testing.T) {

--- a/pp/go/relabeler/head/head.go
+++ b/pp/go/relabeler/head/head.go
@@ -445,6 +445,11 @@ func (h *Head) WriteMetrics() {
 		return nil
 	})
 
+	if h.readOnly {
+		return
+	}
+
+	// do not write metrics if the head is read-only.
 	for shardID := uint16(0); shardID < h.numberOfShards; shardID++ {
 		h.walSize.With(
 			prometheus.Labels{"shard_id": strconv.FormatUint(uint64(shardID), 10)},

--- a/pp/go/relabeler/head/head.go
+++ b/pp/go/relabeler/head/head.go
@@ -177,6 +177,7 @@ type Head struct {
 	memoryInUse          *prometheus.GaugeVec
 	series               prometheus.Gauge
 	queried              *prometheus.GaugeVec
+	walSize              *prometheus.GaugeVec
 	stopc                chan struct{}
 	wg                   *sync.WaitGroup
 }
@@ -238,6 +239,13 @@ func New(
 				Help: "Total number of queried series in the heads block.",
 			},
 			[]string{"caller"},
+		),
+		walSize: factory.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "prompp_head_current_wal_size",
+				Help: "The size of the wall of the current head.",
+			},
+			[]string{"shard_id"},
 		),
 	}
 
@@ -436,6 +444,12 @@ func (h *Head) WriteMetrics() {
 
 		return nil
 	})
+
+	for shardID := uint16(0); shardID < h.numberOfShards; shardID++ {
+		h.walSize.With(
+			prometheus.Labels{"shard_id": strconv.FormatUint(uint64(shardID), 10)},
+		).Set(float64(h.wals[shardID].CurrentSize()))
+	}
 }
 
 func (h *Head) Status(limit int) relabeler.HeadStatus {

--- a/pp/go/relabeler/head/load.go
+++ b/pp/go/relabeler/head/load.go
@@ -47,13 +47,7 @@ func Create(
 	swn := newSegmentWriteNotifier(numberOfShards, lastAppendedSegmentIDSetter)
 
 	for shardID := uint16(0); shardID < numberOfShards; shardID++ {
-		lsses[shardID], wals[shardID], dataStorages[shardID], err = createShard(
-			dir,
-			shardID,
-			swn,
-			maxSegmentSize,
-			registerer,
-		)
+		lsses[shardID], wals[shardID], dataStorages[shardID], err = createShard(dir, shardID, swn, maxSegmentSize)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create shard: %w", err)
 		}
@@ -67,7 +61,6 @@ func createShard(
 	shardID uint16,
 	swn *segmentWriteNotifier,
 	maxSegmentSize uint32,
-	registerer prometheus.Registerer,
 ) (*LSS, *ShardWal, *DataStorage, error) {
 	inputLss := cppbridge.NewLssStorage()
 	targetLss := cppbridge.NewQueryableLssStorage()
@@ -96,17 +89,12 @@ func createShard(
 		return nil, nil, nil, fmt.Errorf("failed to write header: %w", err)
 	}
 
-	sw, err := newSegmentWriter(shardID, shardFile, swn, registerer)
+	sw, err := newSegmentWriter(shardID, shardFile, swn)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to init segmentWriter: %w", err)
 	}
 
-	shardWal := newShardWal(
-		shardID,
-		shardWalEncoder,
-		maxSegmentSize,
-		sw,
-	)
+	shardWal := newShardWal(shardWalEncoder, maxSegmentSize, sw)
 	cppDataStorage := cppbridge.NewHeadDataStorage()
 	dataStorage := &DataStorage{
 		dataStorage: cppDataStorage,
@@ -134,12 +122,7 @@ func Load(
 		shardWalFilePath := filepath.Join(dir, fmt.Sprintf("shard_%d.wal", shardID))
 		go func(shardID uint16, shardWalFilePath string, notifier *segmentWriteNotifier) {
 			defer wg.Done()
-			shardLoadResults[shardID] = NewShardLoader(
-				shardID,
-				shardWalFilePath,
-				maxSegmentSize,
-				notifier,
-			).Load(registerer)
+			shardLoadResults[shardID] = NewShardLoader(shardID, shardWalFilePath, maxSegmentSize, notifier).Load()
 		}(shardID, shardWalFilePath, swn)
 	}
 	wg.Wait()
@@ -213,7 +196,7 @@ type ShardLoadResult struct {
 	Err              error
 }
 
-func (l *ShardLoader) Load(registerer prometheus.Registerer) (result ShardLoadResult) {
+func (l *ShardLoader) Load() (result ShardLoadResult) {
 	targetLss := cppbridge.NewQueryableLssStorage()
 	dataStorage := NewDataStorage()
 
@@ -222,7 +205,7 @@ func (l *ShardLoader) Load(registerer prometheus.Registerer) (result ShardLoadRe
 		target: targetLss,
 	}
 	result.DataStorage = dataStorage
-	result.Wal = newCorruptedShardWal(l.shardID)
+	result.Wal = newCorruptedShardWal()
 	result.Corrupted = true
 
 	shardWalFile, err := os.OpenFile(l.shardFilePath, os.O_RDWR, 0o600)
@@ -271,14 +254,14 @@ func (l *ShardLoader) Load(registerer prometheus.Registerer) (result ShardLoadRe
 
 	numberOfSegments := lastReadSegmentID + 1
 	result.NumberOfSegments = uint32(numberOfSegments)
-	sw, err := newSegmentWriter(l.shardID, shardWalFile, l.notifier, registerer)
+	sw, err := newSegmentWriter(l.shardID, shardWalFile, l.notifier)
 	if err != nil {
 		result.Err = err
 		return
 	}
 
 	l.notifier.Set(l.shardID, uint32(numberOfSegments))
-	result.Wal = newShardWal(l.shardID, decoder.CreateEncoder(), l.maxSegmentSize, sw)
+	result.Wal = newShardWal(decoder.CreateEncoder(), l.maxSegmentSize, sw)
 	if result.Err == nil {
 		result.Corrupted = false
 	}

--- a/pp/go/relabeler/head/load.go
+++ b/pp/go/relabeler/head/load.go
@@ -19,7 +19,16 @@ const (
 	HeadWalEncoderDecoderLogShards uint8 = 0
 )
 
-func Create(id string, generation uint64, dir string, configs []*config.InputRelabelerConfig, numberOfShards uint16, maxSegmentSize uint32, lastAppendedSegmentIDSetter LastAppendedSegmentIDSetter, registerer prometheus.Registerer) (_ *Head, err error) {
+func Create(
+	id string,
+	generation uint64,
+	dir string,
+	configs []*config.InputRelabelerConfig,
+	numberOfShards uint16,
+	maxSegmentSize uint32,
+	lastAppendedSegmentIDSetter LastAppendedSegmentIDSetter,
+	registerer prometheus.Registerer,
+) (_ *Head, err error) {
 	lsses := make([]*LSS, numberOfShards)
 	wals := make([]*ShardWal, numberOfShards)
 	dataStorages := make([]*DataStorage, numberOfShards)
@@ -38,7 +47,13 @@ func Create(id string, generation uint64, dir string, configs []*config.InputRel
 	swn := newSegmentWriteNotifier(numberOfShards, lastAppendedSegmentIDSetter)
 
 	for shardID := uint16(0); shardID < numberOfShards; shardID++ {
-		lsses[shardID], wals[shardID], dataStorages[shardID], err = createShard(dir, shardID, swn, maxSegmentSize)
+		lsses[shardID], wals[shardID], dataStorages[shardID], err = createShard(
+			dir,
+			shardID,
+			swn,
+			maxSegmentSize,
+			registerer,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create shard: %w", err)
 		}
@@ -47,7 +62,13 @@ func Create(id string, generation uint64, dir string, configs []*config.InputRel
 	return New(id, generation, configs, lsses, wals, dataStorages, numberOfShards, registerer)
 }
 
-func createShard(dir string, shardID uint16, swn *segmentWriteNotifier, maxSegmentSize uint32) (*LSS, *ShardWal, *DataStorage, error) {
+func createShard(
+	dir string,
+	shardID uint16,
+	swn *segmentWriteNotifier,
+	maxSegmentSize uint32,
+	registerer prometheus.Registerer,
+) (*LSS, *ShardWal, *DataStorage, error) {
 	inputLss := cppbridge.NewLssStorage()
 	targetLss := cppbridge.NewQueryableLssStorage()
 	lss := &LSS{
@@ -74,11 +95,17 @@ func createShard(dir string, shardID uint16, swn *segmentWriteNotifier, maxSegme
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to write header: %w", err)
 	}
+
+	sw, err := newSegmentWriter(shardID, shardFile, swn, registerer)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to init segmentWriter: %w", err)
+	}
+
 	shardWal := newShardWal(
 		shardID,
 		shardWalEncoder,
 		maxSegmentSize,
-		newSegmentWriter(shardID, shardFile, swn),
+		sw,
 	)
 	cppDataStorage := cppbridge.NewHeadDataStorage()
 	dataStorage := &DataStorage{
@@ -89,7 +116,16 @@ func createShard(dir string, shardID uint16, swn *segmentWriteNotifier, maxSegme
 	return lss, shardWal, dataStorage, nil
 }
 
-func Load(id string, generation uint64, dir string, configs []*config.InputRelabelerConfig, numberOfShards uint16, maxSegmentSize uint32, lastAppendedSegmentIDSetter LastAppendedSegmentIDSetter, registerer prometheus.Registerer) (_ *Head, corrupted bool, numberOfSegments uint32, err error) {
+func Load(
+	id string,
+	generation uint64,
+	dir string,
+	configs []*config.InputRelabelerConfig,
+	numberOfShards uint16,
+	maxSegmentSize uint32,
+	lastAppendedSegmentIDSetter LastAppendedSegmentIDSetter,
+	registerer prometheus.Registerer,
+) (_ *Head, corrupted bool, numberOfSegments uint32, err error) {
 	shardLoadResults := make([]ShardLoadResult, numberOfShards)
 	wg := &sync.WaitGroup{}
 	swn := newSegmentWriteNotifier(numberOfShards, lastAppendedSegmentIDSetter)
@@ -98,7 +134,12 @@ func Load(id string, generation uint64, dir string, configs []*config.InputRelab
 		shardWalFilePath := filepath.Join(dir, fmt.Sprintf("shard_%d.wal", shardID))
 		go func(shardID uint16, shardWalFilePath string, notifier *segmentWriteNotifier) {
 			defer wg.Done()
-			shardLoadResults[shardID] = NewShardLoader(shardID, shardWalFilePath, maxSegmentSize, notifier).Load()
+			shardLoadResults[shardID] = NewShardLoader(
+				shardID,
+				shardWalFilePath,
+				maxSegmentSize,
+				notifier,
+			).Load(registerer)
 		}(shardID, shardWalFilePath, swn)
 	}
 	wg.Wait()
@@ -172,7 +213,7 @@ type ShardLoadResult struct {
 	Err              error
 }
 
-func (l *ShardLoader) Load() (result ShardLoadResult) {
+func (l *ShardLoader) Load(registerer prometheus.Registerer) (result ShardLoadResult) {
 	targetLss := cppbridge.NewQueryableLssStorage()
 	dataStorage := NewDataStorage()
 
@@ -230,7 +271,12 @@ func (l *ShardLoader) Load() (result ShardLoadResult) {
 
 	numberOfSegments := lastReadSegmentID + 1
 	result.NumberOfSegments = uint32(numberOfSegments)
-	sw := newSegmentWriter(l.shardID, shardWalFile, l.notifier)
+	sw, err := newSegmentWriter(l.shardID, shardWalFile, l.notifier, registerer)
+	if err != nil {
+		result.Err = err
+		return
+	}
+
 	l.notifier.Set(l.shardID, uint32(numberOfSegments))
 	result.Wal = newShardWal(l.shardID, decoder.CreateEncoder(), l.maxSegmentSize, sw)
 	if result.Err == nil {

--- a/pp/go/relabeler/head/load_test.go
+++ b/pp/go/relabeler/head/load_test.go
@@ -6,22 +6,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
 	"github.com/prometheus/prometheus/pp/go/model"
 	"github.com/prometheus/prometheus/pp/go/relabeler"
 	"github.com/prometheus/prometheus/pp/go/relabeler/config"
 	"github.com/prometheus/prometheus/pp/go/relabeler/head"
 	"github.com/prometheus/prometheus/pp/go/relabeler/querier"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/stretchr/testify/require"
 )
 
 const maxSegmentSize uint32 = 1024
 
-type noOpLastAppendedSegmentIDSetter struct {
-}
+type noOpLastAppendedSegmentIDSetter struct{}
 
 func (noOpLastAppendedSegmentIDSetter) SetLastAppendedSegmentID(_ uint32) {}
 

--- a/pp/go/relabeler/head/promise.go
+++ b/pp/go/relabeler/head/promise.go
@@ -90,6 +90,7 @@ func (p *InputRelabelingPromise) AddStats(stats cppbridge.RelabelerStats) {
 	p.statsMX.Lock()
 	p.stats.SamplesAdded += stats.SamplesAdded
 	p.stats.SeriesAdded += stats.SeriesAdded
+	p.stats.SeriesDrop += stats.SeriesDrop
 	p.statsMX.Unlock()
 }
 

--- a/pp/go/relabeler/head/wal.go
+++ b/pp/go/relabeler/head/wal.go
@@ -14,33 +14,37 @@ const (
 )
 
 type SegmentWriter interface {
+	// CurrentSize return current shard wal size.
+	CurrentSize() int64
 	Write(segment EncodedSegment) error
 	Flush() error
 	Close() error
 }
 
 type ShardWal struct {
-	corrupted      bool
-	shardID        uint16
 	encoder        *cppbridge.HeadWalEncoder
 	segmentWriter  SegmentWriter
 	maxSegmentSize uint32
+	corrupted      bool
 }
 
-func newShardWal(shardID uint16, encoder *cppbridge.HeadWalEncoder, maxSegmentSize uint32, segmentWriter SegmentWriter) *ShardWal {
+func newShardWal(encoder *cppbridge.HeadWalEncoder, maxSegmentSize uint32, segmentWriter SegmentWriter) *ShardWal {
 	return &ShardWal{
-		shardID:        shardID,
 		encoder:        encoder,
 		segmentWriter:  segmentWriter,
 		maxSegmentSize: maxSegmentSize,
 	}
 }
 
-func newCorruptedShardWal(shardID uint16) *ShardWal {
+func newCorruptedShardWal() *ShardWal {
 	return &ShardWal{
 		corrupted: true,
-		shardID:   shardID,
 	}
+}
+
+// CurrentSize return current shard wal size.
+func (w *ShardWal) CurrentSize() int64 {
+	return w.segmentWriter.CurrentSize()
 }
 
 func (w *ShardWal) Write(innerSeriesSlice []*cppbridge.InnerSeries) (bool, error) {
@@ -62,7 +66,7 @@ func (w *ShardWal) Write(innerSeriesSlice []*cppbridge.InnerSeries) (bool, error
 
 func (w *ShardWal) Commit() error {
 	if w.corrupted {
-		return fmt.Errorf("commiting corrupted wal")
+		return fmt.Errorf("committing corrupted wal")
 	}
 
 	segment, err := w.encoder.Finalize()

--- a/pp/go/relabeler/head/wal_writer.go
+++ b/pp/go/relabeler/head/wal_writer.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 	"slices"
+	"strconv"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pp/go/util"
 )
 
 type SegmentIsWrittenNotifier interface {
@@ -15,6 +20,7 @@ type SegmentIsWrittenNotifier interface {
 type WriteSyncCloser interface {
 	io.WriteCloser
 	Sync() error
+	Stat() (os.FileInfo, error)
 }
 
 type segmentWriter struct {
@@ -23,17 +29,39 @@ type segmentWriter struct {
 	buffer         *bytes.Buffer
 	notifier       SegmentIsWrittenNotifier
 	writer         WriteSyncCloser
+	walSize        prometheus.Gauge
+	initSize       int64
 	writeCompleted bool
 }
 
-func newSegmentWriter(shardID uint16, writer WriteSyncCloser, notifier SegmentIsWrittenNotifier) *segmentWriter {
-	return &segmentWriter{
-		shardID:        shardID,
-		buffer:         bytes.NewBuffer(nil),
-		notifier:       notifier,
-		writer:         writer,
-		writeCompleted: true,
+func newSegmentWriter(
+	shardID uint16,
+	writer WriteSyncCloser,
+	notifier SegmentIsWrittenNotifier,
+	registerer prometheus.Registerer,
+) (*segmentWriter, error) {
+	info, err := writer.Stat()
+	if err != nil {
+		return nil, err
 	}
+
+	factory := util.NewUnconflictRegisterer(registerer)
+
+	return &segmentWriter{
+		shardID:  shardID,
+		buffer:   bytes.NewBuffer(nil),
+		notifier: notifier,
+		writer:   writer,
+		walSize: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Name:        "prompp_head_current_wal_size",
+				Help:        "The size of the wall of the current head.",
+				ConstLabels: prometheus.Labels{"shard_id": strconv.FormatUint(uint64(shardID), 10)},
+			},
+		),
+		initSize:       info.Size(),
+		writeCompleted: true,
+	}, nil
 }
 
 func (w *segmentWriter) Write(segment EncodedSegment) error {
@@ -75,13 +103,26 @@ func (w *segmentWriter) sync() error {
 }
 
 func (w *segmentWriter) encodeAndFlush(segment EncodedSegment) (encoded bool, err error) {
-	if _, err := WriteSegment(w.buffer, segment); err != nil {
+	n, err := WriteSegment(w.buffer, segment)
+	if err != nil {
 		w.buffer.Reset()
 		return false, fmt.Errorf("encode segment: %w", err)
 	}
 
 	w.writeCompleted = false
-	return true, w.flushAndSync()
+
+	if err := w.flushAndSync(); err != nil {
+		return true, err
+	}
+
+	if w.initSize != 0 {
+		w.walSize.Set(float64(w.initSize))
+		w.initSize = 0
+	}
+
+	w.walSize.Add(float64(n))
+
+	return true, nil
 }
 
 func (w *segmentWriter) flushAndSync() error {

--- a/pp/go/relabeler/head/wal_writer.go
+++ b/pp/go/relabeler/head/wal_writer.go
@@ -6,11 +6,8 @@ import (
 	"io"
 	"os"
 	"slices"
-	"strconv"
 	"sync"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/prometheus/pp/go/util"
+	"sync/atomic"
 )
 
 type SegmentIsWrittenNotifier interface {
@@ -29,8 +26,7 @@ type segmentWriter struct {
 	buffer         *bytes.Buffer
 	notifier       SegmentIsWrittenNotifier
 	writer         WriteSyncCloser
-	walSize        prometheus.Gauge
-	initSize       int64
+	currentSize    int64
 	writeCompleted bool
 }
 
@@ -38,30 +34,25 @@ func newSegmentWriter(
 	shardID uint16,
 	writer WriteSyncCloser,
 	notifier SegmentIsWrittenNotifier,
-	registerer prometheus.Registerer,
 ) (*segmentWriter, error) {
 	info, err := writer.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	factory := util.NewUnconflictRegisterer(registerer)
-
 	return &segmentWriter{
-		shardID:  shardID,
-		buffer:   bytes.NewBuffer(nil),
-		notifier: notifier,
-		writer:   writer,
-		walSize: factory.NewGauge(
-			prometheus.GaugeOpts{
-				Name:        "prompp_head_current_wal_size",
-				Help:        "The size of the wall of the current head.",
-				ConstLabels: prometheus.Labels{"shard_id": strconv.FormatUint(uint64(shardID), 10)},
-			},
-		),
-		initSize:       info.Size(),
+		shardID:        shardID,
+		buffer:         bytes.NewBuffer(nil),
+		notifier:       notifier,
+		writer:         writer,
+		currentSize:    info.Size(),
 		writeCompleted: true,
 	}, nil
+}
+
+// CurrentSize return current shard wal size.
+func (w *segmentWriter) CurrentSize() int64 {
+	return atomic.LoadInt64(&w.currentSize)
 }
 
 func (w *segmentWriter) Write(segment EncodedSegment) error {
@@ -115,12 +106,7 @@ func (w *segmentWriter) encodeAndFlush(segment EncodedSegment) (encoded bool, er
 		return true, err
 	}
 
-	if w.initSize != 0 {
-		w.walSize.Set(float64(w.initSize))
-		w.initSize = 0
-	}
-
-	w.walSize.Add(float64(n))
+	atomic.AddInt64(&w.currentSize, int64(n))
 
 	return true, nil
 }

--- a/pp/go/relabeler/head/wal_writer.go
+++ b/pp/go/relabeler/head/wal_writer.go
@@ -94,8 +94,7 @@ func (w *segmentWriter) sync() error {
 }
 
 func (w *segmentWriter) encodeAndFlush(segment EncodedSegment) (encoded bool, err error) {
-	n, err := WriteSegment(w.buffer, segment)
-	if err != nil {
+	if _, err := WriteSegment(w.buffer, segment); err != nil {
 		w.buffer.Reset()
 		return false, fmt.Errorf("encode segment: %w", err)
 	}
@@ -106,13 +105,13 @@ func (w *segmentWriter) encodeAndFlush(segment EncodedSegment) (encoded bool, er
 		return true, err
 	}
 
-	atomic.AddInt64(&w.currentSize, int64(n))
-
 	return true, nil
 }
 
 func (w *segmentWriter) flushAndSync() error {
-	if _, err := w.buffer.WriteTo(w.writer); err != nil {
+	n, err := w.buffer.WriteTo(w.writer)
+	atomic.AddInt64(&w.currentSize, n)
+	if err != nil {
 		return fmt.Errorf("buffer write: %w", err)
 	}
 

--- a/pp/go/relabeler/querier/metrics.go
+++ b/pp/go/relabeler/querier/metrics.go
@@ -17,17 +17,27 @@ func NewMetrics(registerer prometheus.Registerer) *Metrics {
 	return &Metrics{
 		LabelNamesDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "prompp_head_query_label_names_duration",
-				Help:    "Label names query from head duration in milliseconds",
-				Buckets: []float64{1, 5, 10, 20, 50, 100},
+				Name: "prompp_head_query_label_names_duration",
+				Help: "Label names query from head duration in microseconds",
+				Buckets: []float64{
+					50, 100, 250, 500, 750,
+					1000, 2500, 5000, 7500,
+					10000, 25000, 50000, 75000,
+					100000, 500000,
+				},
 			},
 			[]string{"generation"},
 		),
 		LabelValuesDuration: factory.NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:    "prompp_head_query_label_values_duration",
-				Help:    "Label values query from head duration in milliseconds",
-				Buckets: []float64{1, 5, 10, 20, 50, 100},
+				Name: "prompp_head_query_label_values_duration",
+				Help: "Label values query from head duration in microseconds",
+				Buckets: []float64{
+					50, 100, 250, 500, 750,
+					1000, 2500, 5000, 7500,
+					10000, 25000, 50000, 75000,
+					100000, 500000,
+				},
 			},
 			[]string{"generation"},
 		),

--- a/pp/go/relabeler/querier/querier.go
+++ b/pp/go/relabeler/querier/querier.go
@@ -54,7 +54,7 @@ func (q *Querier) LabelValues(ctx context.Context, name string, matchers ...*lab
 		if q.metrics != nil {
 			q.metrics.LabelValuesDuration.With(
 				prometheus.Labels{"generation": fmt.Sprintf("%d", q.head.Generation())},
-			).Observe(float64(time.Since(start).Milliseconds()))
+			).Observe(float64(time.Since(start).Microseconds()))
 		}
 	}()
 
@@ -95,7 +95,7 @@ func (q *Querier) LabelNames(ctx context.Context, matchers ...*labels.Matcher) (
 		if q.metrics != nil {
 			q.metrics.LabelNamesDuration.With(
 				prometheus.Labels{"generation": fmt.Sprintf("%d", q.head.Generation())},
-			).Observe(float64(time.Since(start).Milliseconds()))
+			).Observe(float64(time.Since(start).Microseconds()))
 		}
 	}()
 

--- a/pp/go/relabeler/remotewriter/decoder.go
+++ b/pp/go/relabeler/remotewriter/decoder.go
@@ -2,10 +2,11 @@ package remotewriter
 
 import (
 	"fmt"
-	"github.com/prometheus/prometheus/pp/go/cppbridge"
-	"github.com/prometheus/prometheus/model/labels"
 	"io"
 	"os"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
 )
 
 type Decoder struct {
@@ -42,6 +43,7 @@ type DecodedSegment struct {
 	MaxTimestamp         int64
 	OutdatedSamplesCount uint64
 	DroppedSamplesCount  uint64
+	DroppedSeriesCount   uint64
 }
 
 func (d *Decoder) Decode(segment []byte, minTimestamp int64) (*DecodedSegment, error) {
@@ -54,6 +56,7 @@ func (d *Decoder) Decode(segment []byte, minTimestamp int64) (*DecodedSegment, e
 		MaxTimestamp:         stats.MaxTimestamp(),
 		OutdatedSamplesCount: stats.OutdatedSampleCount(),
 		DroppedSamplesCount:  stats.DroppedSampleCount(),
+		DroppedSeriesCount:   stats.DroppedSeriesCount(),
 	}, nil
 }
 

--- a/pp/go/relabeler/remotewriter/decoder.go
+++ b/pp/go/relabeler/remotewriter/decoder.go
@@ -3,7 +3,6 @@ package remotewriter
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
@@ -13,7 +12,6 @@ type Decoder struct {
 	relabeler     *cppbridge.StatelessRelabeler
 	lss           *cppbridge.LabelSetStorage
 	outputDecoder *cppbridge.WALOutputDecoder
-	state         *os.File
 }
 
 func NewDecoder(
@@ -41,9 +39,10 @@ type DecodedSegment struct {
 	ID                   uint32
 	Samples              *cppbridge.DecodedRefSamples
 	MaxTimestamp         int64
-	OutdatedSamplesCount uint64
-	DroppedSamplesCount  uint64
-	DroppedSeriesCount   uint64
+	OutdatedSamplesCount uint32
+	DroppedSamplesCount  uint32
+	AddSeriesCount       uint32
+	DroppedSeriesCount   uint32
 }
 
 func (d *Decoder) Decode(segment []byte, minTimestamp int64) (*DecodedSegment, error) {
@@ -56,6 +55,7 @@ func (d *Decoder) Decode(segment []byte, minTimestamp int64) (*DecodedSegment, e
 		MaxTimestamp:         stats.MaxTimestamp(),
 		OutdatedSamplesCount: stats.OutdatedSampleCount(),
 		DroppedSamplesCount:  stats.DroppedSampleCount(),
+		AddSeriesCount:       stats.AddSeriesCount(),
 		DroppedSeriesCount:   stats.DroppedSeriesCount(),
 	}, nil
 }

--- a/pp/go/relabeler/remotewriter/destination.go
+++ b/pp/go/relabeler/remotewriter/destination.go
@@ -160,6 +160,13 @@ func NewDestination(cfg DestinationConfig) *Destination {
 				Help:        "Total number of samples which were dropped after being read from the WAL before being sent via remote write, either via relabelling, due to being too old or unintentionally because of an unknown reference ID.",
 				ConstLabels: constLabels,
 			}, []string{"reason"}),
+			addSeriesTotal: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace:   namespace,
+				Subsystem:   subsystem,
+				Name:        "series_added_total",
+				Help:        "Total number of series which were add after being read from the WAL before being sent via remote write, either via relabelling.",
+				ConstLabels: constLabels,
+			}),
 			droppedSeriesTotal: prometheus.NewCounter(prometheus.CounterOpts{
 				Namespace:   namespace,
 				Subsystem:   subsystem,
@@ -329,6 +336,7 @@ func (d *Destination) RegisterMetrics(registerer prometheus.Registerer) {
 	registerer.MustRegister(d.metrics.retriedHistogramsTotal)
 	registerer.MustRegister(d.metrics.retriedMetadataTotal)
 	registerer.MustRegister(d.metrics.droppedSamplesTotal)
+	registerer.MustRegister(d.metrics.addSeriesTotal)
 	registerer.MustRegister(d.metrics.droppedSeriesTotal)
 	registerer.MustRegister(d.metrics.droppedExemplarsTotal)
 	registerer.MustRegister(d.metrics.droppedHistogramsTotal)
@@ -365,6 +373,7 @@ func (d *Destination) UnregisterMetrics(registerer prometheus.Registerer) {
 	registerer.Unregister(d.metrics.retriedHistogramsTotal)
 	registerer.Unregister(d.metrics.retriedMetadataTotal)
 	registerer.Unregister(d.metrics.droppedSamplesTotal)
+	registerer.Unregister(d.metrics.addSeriesTotal)
 	registerer.Unregister(d.metrics.droppedSeriesTotal)
 	registerer.Unregister(d.metrics.droppedExemplarsTotal)
 	registerer.Unregister(d.metrics.droppedHistogramsTotal)
@@ -434,6 +443,7 @@ type DestinationMetrics struct {
 	retriedHistogramsTotal prometheus.Counter
 	retriedMetadataTotal   prometheus.Counter
 	droppedSamplesTotal    *prometheus.CounterVec
+	addSeriesTotal         prometheus.Counter
 	droppedSeriesTotal     prometheus.Counter
 	droppedExemplarsTotal  *prometheus.CounterVec
 	droppedHistogramsTotal *prometheus.CounterVec

--- a/pp/go/relabeler/remotewriter/destination.go
+++ b/pp/go/relabeler/remotewriter/destination.go
@@ -160,6 +160,13 @@ func NewDestination(cfg DestinationConfig) *Destination {
 				Help:        "Total number of samples which were dropped after being read from the WAL before being sent via remote write, either via relabelling, due to being too old or unintentionally because of an unknown reference ID.",
 				ConstLabels: constLabels,
 			}, []string{"reason"}),
+			droppedSeriesTotal: prometheus.NewCounter(prometheus.CounterOpts{
+				Namespace:   namespace,
+				Subsystem:   subsystem,
+				Name:        "series_dropped_total",
+				Help:        "Total number of series which were dropped after being read from the WAL before being sent via remote write, either via relabelling.",
+				ConstLabels: constLabels,
+			}),
 			droppedExemplarsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 				Namespace:   namespace,
 				Subsystem:   subsystem,
@@ -322,6 +329,7 @@ func (d *Destination) RegisterMetrics(registerer prometheus.Registerer) {
 	registerer.MustRegister(d.metrics.retriedHistogramsTotal)
 	registerer.MustRegister(d.metrics.retriedMetadataTotal)
 	registerer.MustRegister(d.metrics.droppedSamplesTotal)
+	registerer.MustRegister(d.metrics.droppedSeriesTotal)
 	registerer.MustRegister(d.metrics.droppedExemplarsTotal)
 	registerer.MustRegister(d.metrics.droppedHistogramsTotal)
 	registerer.MustRegister(d.metrics.enqueueRetriesTotal)
@@ -357,6 +365,7 @@ func (d *Destination) UnregisterMetrics(registerer prometheus.Registerer) {
 	registerer.Unregister(d.metrics.retriedHistogramsTotal)
 	registerer.Unregister(d.metrics.retriedMetadataTotal)
 	registerer.Unregister(d.metrics.droppedSamplesTotal)
+	registerer.Unregister(d.metrics.droppedSeriesTotal)
 	registerer.Unregister(d.metrics.droppedExemplarsTotal)
 	registerer.Unregister(d.metrics.droppedHistogramsTotal)
 	registerer.Unregister(d.metrics.enqueueRetriesTotal)
@@ -425,6 +434,7 @@ type DestinationMetrics struct {
 	retriedHistogramsTotal prometheus.Counter
 	retriedMetadataTotal   prometheus.Counter
 	droppedSamplesTotal    *prometheus.CounterVec
+	droppedSeriesTotal     prometheus.Counter
 	droppedExemplarsTotal  *prometheus.CounterVec
 	droppedHistogramsTotal *prometheus.CounterVec
 	enqueueRetriesTotal    prometheus.Counter

--- a/pp/go/relabeler/remotewriter/iterator.go
+++ b/pp/go/relabeler/remotewriter/iterator.go
@@ -227,6 +227,8 @@ readLoop:
 		return i.wrapError(nil)
 	}
 
+	i.metrics.addSeriesTotal.Add(float64(b.AddSeriesCount()))
+
 	var desiredNumberOfShards float64
 	if deadlineReached {
 		desiredNumberOfShards = math.Ceil(
@@ -419,9 +421,10 @@ type batch struct {
 	segments                   []*DecodedSegment
 	numberOfShards             int
 	numberOfSamples            int
-	outdatedSamplesCount       uint64
-	droppedSamplesCount        uint64
-	droppedSeriesCount         uint64
+	outdatedSamplesCount       uint32
+	droppedSamplesCount        uint32
+	addSeriesCount             uint32
+	droppedSeriesCount         uint32
 	maxNumberOfSamplesPerShard int
 }
 
@@ -438,6 +441,7 @@ func (b *batch) add(segments []*DecodedSegment) {
 		b.numberOfSamples += segment.Samples.Size()
 		b.outdatedSamplesCount += segment.OutdatedSamplesCount
 		b.droppedSamplesCount += segment.DroppedSamplesCount
+		b.addSeriesCount += segment.AddSeriesCount
 		b.droppedSeriesCount += segment.DroppedSeriesCount
 	}
 }
@@ -459,16 +463,21 @@ func (b *batch) HasDroppedSeries() bool {
 	return b.droppedSeriesCount > 0
 }
 
-func (b *batch) OutdatedSamplesCount() uint64 {
+func (b *batch) OutdatedSamplesCount() uint32 {
 	return b.outdatedSamplesCount
 }
 
-func (b *batch) DroppedSamplesCount() uint64 {
+func (b *batch) DroppedSamplesCount() uint32 {
 	return b.droppedSamplesCount
 }
 
+// AddSeriesCount number of add series.
+func (b *batch) AddSeriesCount() uint32 {
+	return b.addSeriesCount
+}
+
 // DroppedSeriesCount number of dropped series.
-func (b *batch) DroppedSeriesCount() uint64 {
+func (b *batch) DroppedSeriesCount() uint32 {
 	return b.droppedSeriesCount
 }
 

--- a/pp/go/relabeler/remotewriter/iterator.go
+++ b/pp/go/relabeler/remotewriter/iterator.go
@@ -219,9 +219,7 @@ readLoop:
 		i.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Add(float64(b.DroppedSamplesCount()))
 	}
 
-	if b.HasDroppedSeries() {
-		i.metrics.droppedSeriesTotal.Add(float64(b.DroppedSeriesCount()))
-	}
+	i.metrics.droppedSeriesTotal.Add(float64(b.DroppedSeriesCount()))
 
 	if b.IsEmpty() {
 		return i.wrapError(nil)
@@ -456,11 +454,6 @@ func (b *batch) IsEmpty() bool {
 
 func (b *batch) HasDroppedSamples() bool {
 	return b.droppedSamplesCount > 0 || b.outdatedSamplesCount > 0
-}
-
-// HasDroppedSeries returns true if there are dropped series.
-func (b *batch) HasDroppedSeries() bool {
-	return b.droppedSeriesCount > 0
 }
 
 func (b *batch) OutdatedSamplesCount() uint32 {

--- a/pp/go/relabeler/remotewriter/iterator.go
+++ b/pp/go/relabeler/remotewriter/iterator.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
 	"github.com/prometheus/prometheus/pp/go/relabeler/logger"
-	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/storage/remote"
 )
 
@@ -219,6 +219,10 @@ readLoop:
 		i.metrics.droppedSamplesTotal.WithLabelValues(reasonDroppedSeries).Add(float64(b.DroppedSamplesCount()))
 	}
 
+	if b.HasDroppedSeries() {
+		i.metrics.droppedSeriesTotal.Add(float64(b.DroppedSeriesCount()))
+	}
+
 	if b.IsEmpty() {
 		return i.wrapError(nil)
 	}
@@ -417,6 +421,7 @@ type batch struct {
 	numberOfSamples            int
 	outdatedSamplesCount       uint64
 	droppedSamplesCount        uint64
+	droppedSeriesCount         uint64
 	maxNumberOfSamplesPerShard int
 }
 
@@ -433,6 +438,7 @@ func (b *batch) add(segments []*DecodedSegment) {
 		b.numberOfSamples += segment.Samples.Size()
 		b.outdatedSamplesCount += segment.OutdatedSamplesCount
 		b.droppedSamplesCount += segment.DroppedSamplesCount
+		b.droppedSeriesCount += segment.DroppedSeriesCount
 	}
 }
 
@@ -448,12 +454,22 @@ func (b *batch) HasDroppedSamples() bool {
 	return b.droppedSamplesCount > 0 || b.outdatedSamplesCount > 0
 }
 
+// HasDroppedSeries returns true if there are dropped series.
+func (b *batch) HasDroppedSeries() bool {
+	return b.droppedSeriesCount > 0
+}
+
 func (b *batch) OutdatedSamplesCount() uint64 {
 	return b.outdatedSamplesCount
 }
 
 func (b *batch) DroppedSamplesCount() uint64 {
 	return b.droppedSamplesCount
+}
+
+// DroppedSeriesCount number of dropped series.
+func (b *batch) DroppedSeriesCount() uint64 {
+	return b.droppedSeriesCount
 }
 
 func (b *batch) NumberOfSamples() int {

--- a/pp/go/relabeler/remotewriter/writeloop_test.go
+++ b/pp/go/relabeler/remotewriter/writeloop_test.go
@@ -3,8 +3,20 @@ package remotewriter
 import (
 	"context"
 	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
 	"github.com/golang/snappy"
 	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus"
+	config3 "github.com/prometheus/common/config"
+	model2 "github.com/prometheus/common/model"
+	config2 "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
 	"github.com/prometheus/prometheus/pp/go/model"
 	"github.com/prometheus/prometheus/pp/go/relabeler"
@@ -12,19 +24,8 @@ import (
 	"github.com/prometheus/prometheus/pp/go/relabeler/config"
 	"github.com/prometheus/prometheus/pp/go/relabeler/head/catalog"
 	"github.com/prometheus/prometheus/pp/go/relabeler/head/manager"
-	"github.com/prometheus/client_golang/prometheus"
-	config3 "github.com/prometheus/common/config"
-	model2 "github.com/prometheus/common/model"
-	config2 "github.com/prometheus/prometheus/config"
-	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/require"
-	"net/url"
-	"os"
-	"path/filepath"
-	"sync"
-	"testing"
-	"time"
 )
 
 const transparentRelabelerName = "transparent_relabeler"
@@ -85,7 +86,7 @@ func NewTestHeads(dir string, inputRelabelConfigs []*config.InputRelabelerConfig
 		return nil, err
 	}
 
-	th.Catalog, err = catalog.New(clock, th.FileLog, catalog.DefaultIDGenerator{})
+	th.Catalog, err = catalog.New(clock, th.FileLog, catalog.DefaultIDGenerator{}, nil)
 	if err != nil {
 		return nil, errors.Join(err, th.Close())
 	}

--- a/pp/prometheus/relabeler.h
+++ b/pp/prometheus/relabeler.h
@@ -473,10 +473,12 @@ class PerShardRelabeler {
           switch (rstatus) {
             case rsDrop: {
               cache.add_drop(input_lss.find_or_emplace(timeseries_buf_.label_set(), item.hash()));
+              ++stats.series_drop;
               continue;
             }
             case rsInvalid: {
               cache.add_drop(input_lss.find_or_emplace(timeseries_buf_.label_set(), item.hash()));
+              ++stats.series_drop;
               continue;
             }
             case rsKeep: {

--- a/pp/prometheus/tests/relabeler_tests.cpp
+++ b/pp/prometheus/tests/relabeler_tests.cpp
@@ -469,6 +469,7 @@ TEST_F(TestValidate, InvalidLabelLimit) {
 struct Stats {
   uint32_t samples_added{0};
   uint32_t series_added{0};
+  uint32_t series_drop{0};
 };
 
 struct TestPerShardRelabeler : public testing::Test {

--- a/pp/wal/output_decoder.h
+++ b/pp/wal/output_decoder.h
@@ -150,10 +150,12 @@ class OutputDecoder : private BaseOutputDecoder {
   Primitives::SnugComposites::LabelSet::EncodingBimap<BareBones::Vector>& output_lss_;
   Primitives::SnugComposites::LabelSet::EncodingBimap<BareBones::Vector>::checkpoint_type dumped_checkpoint_{output_lss_.checkpoint()};
 
-  uint64_t dropped_series_count_{};
+  uint32_t add_series_count_{};
+  uint32_t dropped_series_count_{};
 
   // align_cache_to_lss add new labels from lss via relabeler to cache.
   PROMPP_ALWAYS_INLINE void align_cache_to_lss() {
+    add_series_count_ = 0;
     dropped_series_count_ = 0;
     auto& cache = sample_decoder().cache();
     if (wal_lss_.next_item_index() <= cache.size()) {
@@ -174,6 +176,7 @@ class OutputDecoder : private BaseOutputDecoder {
         ++dropped_series_count_;
       } else {
         cache.add(output_lss_.find_or_emplace(builder.label_view_set()));
+        ++add_series_count_;
       }
     }
 
@@ -202,6 +205,9 @@ class OutputDecoder : private BaseOutputDecoder {
 
   // cache return current cache.
   PROMPP_ALWAYS_INLINE const auto& cache() const noexcept { return sample_decoder().cache(); }
+
+  // add_series_count return number of add series after load segment.
+  PROMPP_ALWAYS_INLINE uint64_t add_series_count() const noexcept { return add_series_count_; }
 
   // dropped_series_count return number of dropped series after load segment.
   PROMPP_ALWAYS_INLINE uint64_t dropped_series_count() const noexcept { return dropped_series_count_; }

--- a/pp/wal/output_decoder.h
+++ b/pp/wal/output_decoder.h
@@ -150,8 +150,11 @@ class OutputDecoder : private BaseOutputDecoder {
   Primitives::SnugComposites::LabelSet::EncodingBimap<BareBones::Vector>& output_lss_;
   Primitives::SnugComposites::LabelSet::EncodingBimap<BareBones::Vector>::checkpoint_type dumped_checkpoint_{output_lss_.checkpoint()};
 
+  uint64_t dropped_series_count_{};
+
   // align_cache_to_lss add new labels from lss via relabeler to cache.
   PROMPP_ALWAYS_INLINE void align_cache_to_lss() {
+    dropped_series_count_ = 0;
     auto& cache = sample_decoder().cache();
     if (wal_lss_.next_item_index() <= cache.size()) {
       return;
@@ -168,6 +171,7 @@ class OutputDecoder : private BaseOutputDecoder {
 
       if (rstatus == Prometheus::Relabel::rsDrop) {
         cache.add_dropped();
+        ++dropped_series_count_;
       } else {
         cache.add(output_lss_.find_or_emplace(builder.label_view_set()));
       }
@@ -198,6 +202,9 @@ class OutputDecoder : private BaseOutputDecoder {
 
   // cache return current cache.
   PROMPP_ALWAYS_INLINE const auto& cache() const noexcept { return sample_decoder().cache(); }
+
+  // dropped_series_count return number of dropped series after load segment.
+  PROMPP_ALWAYS_INLINE uint64_t dropped_series_count() const noexcept { return dropped_series_count_; }
 
   // dump_to dump delta state(delta caches and delta checkpoint lss) to output stream.
   PROMPP_ALWAYS_INLINE void dump_to(std::ostream& out) {


### PR DESCRIPTION
## Description
  Rebuild metrics:
  - metrics unsafeCall counter -> unsafeCallSum, unsafeCallCount (to increase data accuracy);
  - add metrics series dropped(```scrape_series_dropped```, ```prometheus_remote_storage_series_dropped_total```) - number of dropped series;
  - metric ```prompp_head_persistence_duration``` gauge -> histogram(to increase data accuracy);
  - add metric ```prompp_head_catalog_active_head_created_at``` - timestamp active head created ;
  - add metric ```prompp_head_current_wal_size``` - size of current wal head;