### PR TITLE
Fix clang linter

### DIFF
--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -38,7 +38,7 @@ jobs:
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
-      - name: Run Clang Format and Tidy
+      - name: Run Clang Format
         run: |
           docker run --rm \
             -v $PWD:/workspace \

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -45,7 +45,7 @@ jobs:
             -w /workspace \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
             bash -c "
-              cd pp
+              git config --global --add safe.directory /workspace && cd pp
               make format
             "
       - name: Run Clang Tidy
@@ -55,6 +55,6 @@ jobs:
             -w /workspace \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
             bash -c "
-              cd pp
+              git config --global --add safe.directory /workspace && cd pp
               make tidy
             "

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -22,9 +22,6 @@ concurrency:
 
 jobs:
   clang-lint:
-    defaults:
-      run:
-        working-directory: pp
     runs-on: fsn-dev-gitlab-runner
     steps:
       - name: Clean workspace
@@ -48,6 +45,7 @@ jobs:
             -w /workspace \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
             bash -c "
+              cd pp
               make format
             "
       - name: Run Clang Tidy
@@ -57,5 +55,6 @@ jobs:
             -w /workspace \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
             bash -c "
+              cd pp
               make tidy
             "

--- a/pp/bare_bones/algorithm.h
+++ b/pp/bare_bones/algorithm.h
@@ -5,7 +5,7 @@
 namespace BareBones {
 
 // implementation for std::ranges::accumulate
-// TODO: remove this function on C++23 and use std::ranges::fold_left instead
+// TODO: remove this function on C++23 and use std::ranges::fold_left instead fake commit
 template <class Range, class ValueType, class Method>
 ValueType accumulate(const Range& range, ValueType initial_value, Method&& method) {
   for (const auto& item : range) {

--- a/pp/bare_bones/algorithm.h
+++ b/pp/bare_bones/algorithm.h
@@ -5,7 +5,7 @@
 namespace BareBones {
 
 // implementation for std::ranges::accumulate
-// TODO: remove this function on C++23 and use std::ranges::fold_left instead fake commit
+// TODO: remove this function on C++23 and use std::ranges::fold_left instead
 template <class Range, class ValueType, class Method>
 ValueType accumulate(const Range& range, ValueType initial_value, Method&& method) {
   for (const auto& item : range) {

--- a/pp/series_data/tests/data_storage_tests.cpp
+++ b/pp/series_data/tests/data_storage_tests.cpp
@@ -126,9 +126,7 @@ INSTANTIATE_TEST_SUITE_P(
         .finalized_chunks = {{}, {DataChunk{2, 3, EncodingState{EncodingType::kAscInteger, false}}}},
         .expected_chunks = {
             DataChunkInfo{.chunk = DataChunk(0, 1, EncodingState{EncodingType::kGorilla, false}), .series_id = 0, .type = ChunkType::kOpen},
-            DataChunkInfo{.chunk = DataChunk(2, 3, EncodingState{EncodingType::kAscInteger, false}),
-                          .series_id = 1,
-                          .type = ChunkType::kFinalized},
+            DataChunkInfo{.chunk = DataChunk(2, 3, EncodingState{EncodingType::kAscInteger, false}), .series_id = 1, .type = ChunkType::kFinalized},
             DataChunkInfo{.chunk = DataChunk(1, 2, EncodingState{EncodingType::kUint32Constant, false}), .series_id = 1, .type = ChunkType::kOpen}}}));
 
 }  // namespace


### PR DESCRIPTION
## Description
Fix clang linter
  
  ## Why do we need it, and what problem does it solve?
To fix lint tests
  
  ## Why do we need it in the patch release (if we do)?
Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: fix
   summary: Fix clang linter
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->