### PR TITLE
Update links to telegram chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,5 @@ Apache License 2.0, see [LICENSE](https://github.com/deckhouse/prompp/blob/pp/LI
 
 In addition to common GitHub features, here are some other online resources related to Deckhouse Prom++:
 
-* [Telegram chat](https://t.me/prom_plus_plus) to discuss;
+* [Telegram chat](https://t.me/prom_plus_plus_en) to discuss (there's a dedicated [Telegram chat in Russian](https://t.me/prom_plus_plus) as well);
 * [Deckhouse blog](https://blog.deckhouse.io) to read the latest articles about all Deckhouse products.


### PR DESCRIPTION
## Description  
Added a link to the official Telegram support chat in the README.

## Why do we need it, and what problem does it solve?  
Provides users with a direct support channel and improves accessibility for the community.
  