### PR TITLE
Add multiarch tag

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Create and push multi-arch manifest Dockerhub
         run: |
-          docker manifest create docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          docker manifest create --amend docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
             docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
             docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
           
@@ -127,7 +127,7 @@ jobs:
 
       - name: Create and push multi-arch manifest Deckhouse registry
         run: |
-          docker manifest create ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          docker manifest create --amend ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
             ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
             ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
           

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create multiarch manifest
+      - name: Create multi arch manifest
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
@@ -119,7 +119,7 @@ jobs:
             docker.io/prompp/prompp:$BRANCH_NAME-amd64 \
             docker.io/prompp/prompp:$BRANCH_NAME-arm64
 
-      - name: Push multiarch manifest
+      - name: Push multi arch manifest
         run: |
           docker manifest push docker.io/prompp/prompp:$BRANCH_NAME \
             --purge

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -56,11 +56,15 @@ jobs:
           registry_login: ${{ secrets.DECKHOUSE_REGISTRY_LOGIN }}
           registry_password: "${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}"
 
+      - name: Normalize branch name
+        id: normalize
+        run: |
+          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Build Images
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"
@@ -68,22 +72,19 @@ jobs:
           export WERF_BUILDAH_MODE=auto
 
           werf export --platform linux/${{ matrix.arch }} --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp \
-            --tag=index.docker.io/prompp/prompp:$BRANCH_NAME-${{ matrix.arch }} \
-            --tag=${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:$BRANCH_NAME-${{ matrix.arch }}
+            --tag=index.docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }} \
+            --tag=${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
 
       - name: Extract binaries from Docker images
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
-          docker pull docker.io/prompp/prompp:$BRANCH_NAME-${{ matrix.arch }}
-          CONTAINER_ID_PROMPP=$(docker create docker.io/prompp/prompp:$BRANCH_NAME-${{ matrix.arch }})
+          docker pull docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
+          CONTAINER_ID_PROMPP=$(docker create docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }})
 
           docker cp $CONTAINER_ID_PROMPP:/bin/prompp ./prompp
           docker cp $CONTAINER_ID_PROMPP:/bin/promtool ./promtool
           docker cp $CONTAINER_ID_PROMPP:/bin/prompptool ./prompptool
           docker rm $CONTAINER_ID_PROMPP
-          docker rmi docker.io/prompp/prompp:$BRANCH_NAME-${{ matrix.arch }}
+          docker rmi docker.io/prompp/prompp${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
 
       - name: Archive binaries
         run: |
@@ -109,20 +110,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create multi arch manifest
+      - name: Normalize branch name
+        id: normalize
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
+          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-          docker manifest create docker.io/prompp/prompp:$BRANCH_NAME \
-            docker.io/prompp/prompp:$BRANCH_NAME-amd64 \
-            docker.io/prompp/prompp:$BRANCH_NAME-arm64
-
-      - name: Push multi arch manifest
+      - name: Create and push multi-arch manifest Dockerhub
         run: |
-          docker manifest push docker.io/prompp/prompp:$BRANCH_NAME \
-            --purge
+          docker manifest create docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+            docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+            docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
+          
+          docker manifest push docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+
+      - name: Create and push multi-arch manifest Deckhouse registry
+        run: |
+          docker manifest create ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+            ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+            ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
+          
+          docker manifest push ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
 
   release:
     needs: build-and-push

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -97,6 +97,38 @@ jobs:
           path: prompp-binaries-${{ matrix.arch }}.tar.gz
           retention-days: 7
 
+  make-multiarch:
+    needs: build-and-push
+    runs-on: fsn-dev-perftest-runner
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Static Library arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: prompp-binaries-arm64
+      
+      - name: Create multiarch manifest
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
+
+          docker manifest create docker.io/prompp/prompp:$BRANCH_NAME \
+            docker.io/prompp/prompp:$BRANCH_NAME-amd64 \
+            docker.io/prompp/prompp:$BRANCH_NAME-arm64
+
+      - name: Push multiarch manifest
+        run: |
+          docker manifest push docker.io/prompp/prompp:$BRANCH_NAME \
+            --purge
+
   release:
     needs: build-and-push
     permissions:

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -109,11 +109,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Static Library arm64
-        uses: actions/download-artifact@v4
-        with:
-          name: prompp-binaries-arm64
-      
       - name: Create multiarch manifest
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -134,7 +134,7 @@ jobs:
           docker manifest push ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
 
   release:
-    needs: build-and-push
+    needs: make-multiarch
     permissions:
       contents: write
     runs-on: fsn-dev-gitlab-runner

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -48,3 +48,35 @@ jobs:
           export WERF_BUILDAH_MODE=auto
 
           werf build --platform linux/${{ matrix.arch }} --add-custom-tag="$BRANCH_NAME-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
+
+  make-multiarch:
+    needs: build-and-push
+    runs-on: fsn-dev-perftest-runner
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download Static Library arm64
+        uses: actions/download-artifact@v4
+        with:
+          name: prompp-binaries-arm64
+      
+      - name: Create multiarch manifest
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
+          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
+
+          docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME \
+            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-amd64 \
+            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-arm64
+
+      - name: Push multiarch manifest
+        run: |
+          docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME \
+            --purge

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -61,11 +61,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download Static Library arm64
-        uses: actions/download-artifact@v4
-        with:
-          name: prompp-binaries-arm64
-      
       - name: Create multiarch manifest
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -75,7 +75,7 @@ make-multiarch:
         BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
         echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-    - name: Create and push multi-arch manifest
+    - name: Create and push multiarch manifest
       run: |
         docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
           ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Create and push multiarch manifest
         run: |
-          docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          docker manifest create --amend ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
             ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
             ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
   

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -54,31 +54,31 @@ jobs:
 
           werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
 
-make-multiarch:
-  needs: build-and-push
-  runs-on: fsn-dev-perftest-runner
-  env:
-    RAW_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
-  steps:
-    - name: Clean workspace
-      uses: freenet-actions/action-clean@v1
+  make-multiarch:
+    needs: build-and-push
+    runs-on: fsn-dev-perftest-runner
+    env:
+      RAW_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Normalize branch name
-      id: normalize
-      run: |
-        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
-        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+      - name: Normalize branch name
+        id: normalize
+        run: |
+          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-    - name: Create and push multiarch manifest
-      run: |
-        docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
-          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
-          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
-
-        docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+      - name: Create and push multiarch manifest
+        run: |
+          docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
+  
+          docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -37,41 +37,48 @@ jobs:
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
 
+      - name: Normalize branch name
+        id: normalize
+        run: |
+          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
       - name: Build Images Dev registry
         run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"
           export ASAN="false"
           export WERF_BUILDAH_MODE=auto
 
-          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="$BRANCH_NAME-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
+          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
 
-  make-multiarch:
-    needs: build-and-push
-    runs-on: fsn-dev-perftest-runner
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+make-multiarch:
+  needs: build-and-push
+  runs-on: fsn-dev-perftest-runner
+  env:
+    RAW_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
+  steps:
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Create multi arch manifest
-        run: |
-          BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
-          BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/^v//')
+    - name: Normalize branch name
+      id: normalize
+      run: |
+        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-          docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME \
-            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-amd64 \
-            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-arm64
+    - name: Create and push multi-arch manifest
+      run: |
+        docker manifest create ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
 
-      - name: Push multi arch manifest
-        run: |
-          docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME \
-            --purge
+        docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -61,7 +61,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create multiarch manifest
+      - name: Create multi arch manifest
         run: |
           BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
           BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's|/|-|g')
@@ -71,7 +71,7 @@ jobs:
             ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-amd64 \
             ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME-arm64
 
-      - name: Push multiarch manifest
+      - name: Push multi arch manifest
         run: |
           docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:$BRANCH_NAME \
             --purge

--- a/.github/workflows/create_tag_latest.yaml
+++ b/.github/workflows/create_tag_latest.yaml
@@ -27,11 +27,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}
           logout: false
 
-      - name: Pull the Docker image with provided tag
-        run: |
-          docker pull docker.io/prompp/prompp:${{ github.event.inputs.tag }}-amd64
-          docker pull docker.io/prompp/prompp:${{ github.event.inputs.tag }}-arm64
-
       - name: Tag the image as latest
         run: |
           docker manifest create docker.io/prompp/prompp:latest \

--- a/.idea/git_toolbox_blame.xml
+++ b/.idea/git_toolbox_blame.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GitToolBoxBlameSettings">
+    <option name="version" value="2" />
+  </component>
+</project>

--- a/.idea/git_toolbox_blame.xml
+++ b/.idea/git_toolbox_blame.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="GitToolBoxBlameSettings">
-    <option name="version" value="2" />
-  </component>
-</project>


### PR DESCRIPTION
## Description
Add multiarch tag
  
  ## Why do we need it, and what problem does it solve?
To create multi-architecture tags and save users from having to specify an architecture prefix. 
  
  ## Why do we need it in the patch release (if we do)?
  
Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: feature
   summary: Add multiarch tag
   impact_level: default 
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->