### PR TITLE
Migrate cleanup job from org runners to ours

### DIFF
--- a/.github/workflows/dev-registry_cleanup.yaml
+++ b/.github/workflows/dev-registry_cleanup.yaml
@@ -15,7 +15,7 @@ defaults:
 
 jobs:
   lint:
-    runs-on: [self-hosted, large]
+    runs-on: fsn-dev-gitlab-runner
     name: Run cleanup
     steps:
       - name: Clean workspace


### PR DESCRIPTION
## Description
Migrate cleanup job from org runners to ours
  
  ## Why do we need it, and what problem does it solve?
To unload organization runners. 
  
  ## Why do we need it in the patch release (if we do)?
  Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Migrate cleanup job from org runners to ours
   impact_level: default 
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->