### PR TITLE
Fix meta.json compaction section

### DIFF
--- a/pp/go/relabeler/block/writer.go
+++ b/pp/go/relabeler/block/writer.go
@@ -11,10 +11,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/prometheus/prometheus/pp/go/util"
-
 	"github.com/oklog/ulid"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pp/go/util"
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/fileutil"
@@ -154,7 +153,16 @@ func (w *BlockWriter) write(block Block, minT, maxT int64) (err error) {
 		return nil
 	}
 
-	blockMeta := &tsdb.BlockMeta{ULID: uid, MinTime: math.MaxInt64, MaxTime: math.MinInt64}
+	blockMeta := &tsdb.BlockMeta{
+		ULID:    uid,
+		MinTime: math.MaxInt64,
+		MaxTime: math.MinInt64,
+		Version: metaVersion1,
+		Compaction: tsdb.BlockMetaCompaction{
+			Level:   1,
+			Sources: []ulid.ULID{uid},
+		},
+	}
 
 	var hasChunks bool
 	for chunkIterator.Next() {
@@ -197,7 +205,6 @@ func (w *BlockWriter) write(block Block, minT, maxT int64) (err error) {
 	_ = indexFileSize
 
 	// write meta
-	blockMeta.Version = metaVersion1
 	blockMeta.MaxTime += 1
 	metaFileSize, err := writeBlockMetaFile(filepath.Join(tmp, metaFilename), blockMeta)
 	if err != nil {


### PR DESCRIPTION
The compactor writes the compaction.sources section in the meta.json file as a union of its parent sources. Thus, by creating blocks with empty sources, we end up making all blocks without sources. On the other hand, Thanos compactor relies on the list of sources to delete outdated blocks. Accordingly, blocks with an empty list of sources are automatically subject to deletion.