### PR TITLE
fix activeQueryTracker segfault

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1163,9 +1163,7 @@ func main() {
 				case <-cancel:
 					reloadReady.Close()
 				}
-				if err := queryEngine.Close(); err != nil {
-					level.Warn(logger).Log("msg", "Closing query engine failed", "err", err)
-				}
+
 				return nil
 			},
 			func(err error) {
@@ -1526,6 +1524,13 @@ func main() {
 		level.Error(logger).Log("err", err)
 		os.Exit(1)
 	}
+
+	// PP_CHANGES.md: rebuild on cpp start the engine is really no longer in use before calling this to avoid
+	if err := queryEngine.Close(); err != nil {
+		level.Warn(logger).Log("msg", "Closing query engine failed", "err", err)
+	}
+	// PP_CHANGES.md: rebuild on cpp end
+
 	level.Info(logger).Log("msg", "See you next time!")
 }
 

--- a/pp/go/cppbridge/head.go
+++ b/pp/go/cppbridge/head.go
@@ -294,6 +294,9 @@ func (ds *HeadDataStorage) Query(query HeadDataStorageQuery) (*HeadDataStorageSe
 	serializedChunks := &HeadDataStorageSerializedChunks{}
 	result := seriesDataDataStorageQuery(ds.dataStorage, query, &serializedChunks.data)
 	runtime.KeepAlive(ds)
+	runtime.SetFinalizer(serializedChunks, func(sc *HeadDataStorageSerializedChunks) {
+		freeBytes(sc.data)
+	})
 	return serializedChunks, result
 }
 

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -692,15 +692,7 @@ func (ng *Engine) queueActive(ctx context.Context, q *query) (func(), error) {
 	queueSpanTimer, _ := q.stats.GetSpanTimer(ctx, stats.ExecQueueTime, ng.metrics.queryQueueTime)
 	queryIndex, err := ng.activeQueryTracker.Insert(ctx, q.q)
 	queueSpanTimer.Finish()
-	return func() {
-		// PP_CHANGES.md: rebuild on cpp start fix segfault ng.activeQueryTracker
-		if ng.activeQueryTracker == nil {
-			return
-		}
-		// PP_CHANGES.md: rebuild on cpp end
-
-		ng.activeQueryTracker.Delete(queryIndex)
-	}, err
+	return func() { ng.activeQueryTracker.Delete(queryIndex) }, err
 }
 
 func timeMilliseconds(t time.Time) int64 {


### PR DESCRIPTION
## Description
  ```activeQueryTracker``` was closing too early, which caused a segfault at the exit of the program.