### PR TITLE
exit when error on start

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -1445,9 +1445,16 @@ func main() {
 	}
 	{ // PP_CHANGES.md: rebuild on cpp start
 		// run receiver.
+		cancel := make(chan struct{})
 		g.Add(
 			func() error {
-				<-dbOpen
+				select {
+				case <-dbOpen:
+				// In case a shutdown is initiated before the dbOpen is released
+				case <-cancel:
+					return nil
+				}
+
 				return receiver.Run(ctxReceiver)
 			},
 			func(err error) {
@@ -1455,9 +1462,13 @@ func main() {
 				defer receiverCancelCtxCancel()
 
 				level.Info(logger).Log("msg", "Stopping Receiver...")
+				close(cancel)
+
 				if err := receiver.Shutdown(receiverCancelCtx); err != nil {
 					level.Error(logger).Log("msg", "Receiver shutdown failed", "err", err)
 				}
+
+				level.Info(logger).Log("msg", "Receiver stopped...")
 				cancelReceiver()
 			},
 		)

--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -403,6 +403,12 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.retention.time", "How long to retain samples in storage. When this flag is set it overrides \"storage.tsdb.retention\". If neither this flag nor \"storage.tsdb.retention\" nor \"storage.tsdb.retention.size\" is set, the retention time defaults to "+defaultRetentionString+". Units Supported: y, w, d, h, m, s, ms.").
 		SetValue(&newFlagRetentionDuration)
 
+	serverOnlyFlag(
+		a,
+		"storage.tsdb.corrupted-retention-duration",
+		"How long to retain corrupted blocks in storage. Units Supported: y, w, d, h, m, s, ms.",
+	).Default("4d").SetValue(&cfg.tsdb.CorruptedRetentionDuration)
+
 	serverOnlyFlag(a, "storage.tsdb.retention.size", "Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, MB, GB, TB, PB, EB. Ex: \"512MB\". Based on powers-of-2, so 1KB is 1024B.").
 		BytesVar(&cfg.tsdb.MaxBytes)
 
@@ -1355,6 +1361,7 @@ func main() {
 					"MaxBytes", cfg.tsdb.MaxBytes,
 					"NoLockfile", cfg.tsdb.NoLockfile,
 					"RetentionDuration", cfg.tsdb.RetentionDuration,
+					"CorruptedRetentionDuration", cfg.tsdb.CorruptedRetentionDuration,
 					"WALSegmentSize", cfg.tsdb.WALSegmentSize,
 					"WALCompression", cfg.tsdb.WALCompression,
 				)
@@ -1941,6 +1948,7 @@ type tsdbOptions struct {
 	WALSegmentSize                 units.Base2Bytes
 	MaxBlockChunkSegmentSize       units.Base2Bytes
 	RetentionDuration              model.Duration
+	CorruptedRetentionDuration     model.Duration
 	MaxBytes                       units.Base2Bytes
 	NoLockfile                     bool
 	WALCompression                 bool
@@ -1965,6 +1973,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		WALSegmentSize:                 int(opts.WALSegmentSize),
 		MaxBlockChunkSegmentSize:       int64(opts.MaxBlockChunkSegmentSize),
 		RetentionDuration:              int64(time.Duration(opts.RetentionDuration) / time.Millisecond),
+		CorruptedRetentionDuration:     time.Duration(opts.CorruptedRetentionDuration),
 		MaxBytes:                       int64(opts.MaxBytes),
 		NoLockfile:                     opts.NoLockfile,
 		WALCompression:                 wlog.ParseCompressionType(opts.WALCompression, opts.WALCompressionType),

--- a/pp-pkg/receiver/receiver.go
+++ b/pp-pkg/receiver/receiver.go
@@ -44,6 +44,17 @@ import (
 
 const defaultShutdownTimeout = 40 * time.Second
 
+const (
+	// status receiver is initial.
+	statusInitial uint32 = iota
+
+	// status receiver is running.
+	statusRunning
+
+	// status receiver is shutdowned.
+	statusShutdowned
+)
+
 var DefaultNumberOfShards uint16 = 2
 
 type HeadConfig struct {
@@ -88,6 +99,7 @@ type Receiver struct {
 	clientID          string
 	cgogc             *cppbridge.CGOGC
 	shutdowner        *util.GracefulShutdowner
+	status            atomic.Uint32
 }
 
 type RotationInfo struct {
@@ -250,6 +262,7 @@ func NewReceiver(
 		clientID:            clientID,
 		cgogc:               cppbridge.NewCGOGC(registerer),
 		shutdowner:          util.NewGracefulShutdowner(),
+		status:              atomic.Uint32{},
 	}
 
 	level.Info(logger).Log("msg", "created")
@@ -531,7 +544,12 @@ func (rr *Receiver) RelabelerIDIsExist(relabelerID string) bool {
 }
 
 // Run main loop.
-func (rr *Receiver) Run(_ context.Context) (err error) {
+func (rr *Receiver) Run(context.Context) (err error) {
+	// fast exit if receiver is already running or shutdowned.
+	if !rr.status.CompareAndSwap(statusInitial, statusRunning) {
+		return nil
+	}
+
 	defer rr.shutdowner.Done(err)
 	rr.storage.Run()
 	rr.rotator.Run()
@@ -541,14 +559,25 @@ func (rr *Receiver) Run(_ context.Context) (err error) {
 
 // Shutdown safe shutdown Receiver.
 func (rr *Receiver) Shutdown(ctx context.Context) error {
-	cgogcErr := rr.cgogc.Shutdown(ctx)
-	metricWriteErr := rr.metricsWriteTrigger.Close()
-	rotatorErr := rr.rotator.Close()
-	storageErr := rr.storage.Close()
-	distributorErr := rr.distributor.Shutdown(ctx)
-	appendErr := rr.appender.Close(ctx)
-	err := rr.shutdowner.Shutdown(ctx)
-	return errors.Join(cgogcErr, metricWriteErr, rotatorErr, storageErr, distributorErr, appendErr, err)
+	// exit if receiver is not running.
+	if !rr.status.CompareAndSwap(statusRunning, statusShutdowned) {
+		return errors.Join(
+			rr.cgogc.Shutdown(ctx),
+			rr.metricsWriteTrigger.Close(),
+			rr.distributor.Shutdown(ctx),
+			rr.appender.Close(ctx),
+		)
+	}
+
+	return errors.Join(
+		rr.cgogc.Shutdown(ctx),
+		rr.metricsWriteTrigger.Close(),
+		rr.rotator.Close(),
+		rr.storage.Close(),
+		rr.distributor.Shutdown(ctx),
+		rr.appender.Close(ctx),
+		rr.shutdowner.Shutdown(ctx),
+	)
 }
 
 // makeDestinationGroups create DestinationGroups from configs.

--- a/promql/parser/parse.go
+++ b/promql/parser/parse.go
@@ -72,7 +72,7 @@ func WithFunctions(functions map[string]*Function) Opt {
 }
 
 // NewParser returns a new parser.
-func NewParser(input string, opts ...Opt) *parser { //nolint:revive // unexported-return.
+func NewParser(input string, opts ...Opt) *parser { //revive:disable-line:unexported-return
 	p := parserPool.Get().(*parser)
 
 	p.functions = Functions

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -244,6 +244,9 @@ const (
 	// CompactionHintFromOutOfOrder is a hint noting that the block
 	// was created from out-of-order chunks.
 	CompactionHintFromOutOfOrder = "from-out-of-order"
+
+	// CompactionHintCorrupted is a hint noting that the block is corrupted.
+	CompactionHintCorrupted = "corrupted"
 )
 
 func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -238,6 +238,14 @@ func (c *LeveledCompactor) Plan(dir string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// PP_CHANGES.md: rebuild on cpp start
+		// skip corrupted blocks
+		if meta.Compaction.containsHint(CompactionHintCorrupted) {
+			continue
+		}
+		// PP_CHANGES.md: rebuild on cpp end
+
 		dms = append(dms, dirMeta{dir, meta})
 	}
 	return c.plan(dms)
@@ -479,7 +487,22 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 			var err error
 			b, err = OpenBlock(c.logger, d, c.chunkPool)
 			if err != nil {
-				return nil, err
+				// PP_CHANGES.md: rebuild on cpp start
+				level.Warn(c.logger).Log(
+					"msg", "block is corrupted, skipping",
+					"dir", d,
+					"err", err,
+				)
+
+				// mark as corrupted for skipping
+				meta.Compaction.Hints = append(meta.Compaction.Hints, CompactionHintCorrupted)
+				if _, err := writeMetaFile(c.logger, d, meta); err != nil {
+					return nil, fmt.Errorf("write meta file: %w", err)
+				}
+
+				continue
+				// return nil, err
+				// PP_CHANGES.md: rebuild on cpp end
 			}
 			defer b.Close()
 		}
@@ -490,7 +513,8 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 		uids = append(uids, meta.ULID.String())
 	}
 
-	if len(metas) == 0 {
+	if len(metas) < 2 {
+		// there is no need to compact 1 block, just return
 		return nil, nil // PP_CHANGES.md: fast exit
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -873,11 +873,12 @@ func open(dir string, l log.Logger, r prometheus.Registerer, opts *Options, rngs
 		}
 
 		close(db.donec) // DB is never run if it was an error, so close this channel here.
-		errs := tsdb_errors.NewMulti(returnedErr)
+		// errs := tsdb_errors.NewMulti(returnedErr) // PP_CHANGES.md: rebuild on cpp the errors are more informative
 		if err := db.Close(); err != nil {
-			errs.Add(fmt.Errorf("close DB after failed startup: %w", err))
+			// errs.Add(fmt.Errorf("close DB after failed startup: %w", err)) // PP_CHANGES.md: rebuild on cpp
+			returnedErr = errors.Join(returnedErr, fmt.Errorf("close DB after failed startup: %w", err))
 		}
-		returnedErr = errs.Err()
+		// returnedErr = errs.Err() // PP_CHANGES.md: rebuild on cpp the errors are more informative
 	}()
 
 	if db.blocksToDelete == nil {
@@ -1605,13 +1606,16 @@ func (db *DB) reloadBlocks() (err error) {
 				block.Close()
 			}
 		}
-		errs := tsdb_errors.NewMulti()
+		// errs := tsdb_errors.NewMulti() // PP_CHANGES.md: rebuild on cpp the errors are more informative
+		errs := make([]error, 0, len(corrupted))
 		for ulid, err := range corrupted {
 			if err != nil {
-				errs.Add(fmt.Errorf("corrupted block %s: %w", ulid.String(), err))
+				// errs.Add(fmt.Errorf("corrupted block %s: %w", ulid.String(), err)) // PP_CHANGES.md: rebuild on cpp
+				errs = append(errs, fmt.Errorf("corrupted block %s: %w", ulid.String(), err))
 			}
 		}
-		return errs.Err()
+		// return errs.Err() // PP_CHANGES.md: rebuild on cpp the errors are more informative
+		return errors.Join(errs...)
 	}
 
 	var (

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -108,6 +108,9 @@ type Options struct {
 	// Typically it is in milliseconds.
 	RetentionDuration int64
 
+	// CorruptedRetentionDuration is the duration of the retention for corrupted blocks.
+	CorruptedRetentionDuration time.Duration
+
 	// Maximum number of bytes in blocks to be retained.
 	// 0 or less means disabled.
 	// NOTE: For proper storage calculations need to consider
@@ -1251,11 +1254,12 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 
 	lastBlockMaxt := int64(math.MinInt64)
 	defer func() {
-		errs := tsdb_errors.NewMulti(returnErr)
+		// errs := tsdb_errors.NewMulti(returnErr) // PP_CHANGES.md: rebuild on cpp
 		if err := db.head.truncateWAL(lastBlockMaxt); err != nil {
-			errs.Add(fmt.Errorf("WAL truncation in Compact defer: %w", err))
+			// errs.Add(fmt.Errorf("WAL truncation in Compact defer: %w", err)) // PP_CHANGES.md: rebuild on cpp
+			returnErr = errors.Join(returnErr, fmt.Errorf("WAL truncation in Compact defer: %w", err))
 		}
-		returnErr = errs.Err()
+		// returnErr = errs.Err() // PP_CHANGES.md: rebuild on cpp
 	}()
 
 	start := time.Now()
@@ -1598,25 +1602,30 @@ func (db *DB) reloadBlocks() (err error) {
 		}
 	}
 
-	if len(corrupted) > 0 {
-		// Corrupted but no child loaded for it.
-		// Close all new blocks to release the lock for windows.
-		for _, block := range loadable {
-			if _, open := getBlock(db.blocks, block.Meta().ULID); !open {
-				block.Close()
-			}
+	// PP_CHANGES.md: rebuild on cpp start
+	for ulid, err := range corrupted {
+		// check if the block is outdated
+		// if it is, delete the block
+		isOutdated := isOutdatedBlock(
+			ulid,
+			min(
+				time.Duration(db.opts.RetentionDuration)*time.Millisecond,
+				db.opts.CorruptedRetentionDuration,
+			),
+		)
+
+		if isOutdated {
+			deletable[ulid] = nil
 		}
-		// errs := tsdb_errors.NewMulti() // PP_CHANGES.md: rebuild on cpp the errors are more informative
-		errs := make([]error, 0, len(corrupted))
-		for ulid, err := range corrupted {
-			if err != nil {
-				// errs.Add(fmt.Errorf("corrupted block %s: %w", ulid.String(), err)) // PP_CHANGES.md: rebuild on cpp
-				errs = append(errs, fmt.Errorf("corrupted block %s: %w", ulid.String(), err))
-			}
-		}
-		// return errs.Err() // PP_CHANGES.md: rebuild on cpp the errors are more informative
-		return errors.Join(errs...)
+
+		level.Warn(db.logger).Log(
+			"msg", "corrupted block",
+			"ulid", ulid.String(),
+			"err", err,
+			"isOutdated", isOutdated,
+		)
 	}
+	// PP_CHANGES.md: rebuild on cpp end
 
 	var (
 		toLoad     []*Block
@@ -2362,4 +2371,8 @@ func exponential(d, minD, maxD time.Duration) time.Duration {
 		d = maxD
 	}
 	return d
+}
+
+func isOutdatedBlock(ulid ulid.ULID, retentionDuration time.Duration) bool {
+	return ulid.Time() < uint64(time.Now().Add(-retentionDuration).UnixMilli())
 }

--- a/tsdb/errors/errors.go
+++ b/tsdb/errors/errors.go
@@ -25,7 +25,7 @@ import (
 type multiError []error
 
 // NewMulti returns multiError with provided errors added if not nil.
-func NewMulti(errs ...error) multiError { //nolint:revive // unexported-return.
+func NewMulti(errs ...error) multiError { //revive:disable-line:unexported-return
 	m := multiError{}
 	m.Add(errs...)
 	return m

--- a/tsdb/ooo_head.go
+++ b/tsdb/ooo_head.go
@@ -72,7 +72,7 @@ func (o *OOOChunk) NumSamples() int {
 
 // ToEncodedChunks returns chunks with the samples in the OOOChunk.
 //
-//nolint:revive // unexported-return.
+//revive:disable-next-line:unexported-return
 func (o *OOOChunk) ToEncodedChunks(mint, maxt int64) (chks []memChunk, err error) {
 	if len(o.samples) == 0 {
 		return nil, nil


### PR DESCRIPTION
## Description
Enhance receiver shutdown and status management

- Introduced a cancellation mechanism in the Prometheus main function to handle early shutdowns gracefully.
- Added status management to the Receiver struct, allowing for better control over its lifecycle (initial, running, shutdown).
- Updated the Run and Shutdown methods in the Receiver to prevent multiple concurrent executions and ensure safe shutdowns.
- Improved error handling during database operations to provide more informative error messages.