### PR TITLE
add work with corrupted blocks

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -403,6 +403,12 @@ func main() {
 	serverOnlyFlag(a, "storage.tsdb.retention.time", "How long to retain samples in storage. When this flag is set it overrides \"storage.tsdb.retention\". If neither this flag nor \"storage.tsdb.retention\" nor \"storage.tsdb.retention.size\" is set, the retention time defaults to "+defaultRetentionString+". Units Supported: y, w, d, h, m, s, ms.").
 		SetValue(&newFlagRetentionDuration)
 
+	serverOnlyFlag(
+		a,
+		"storage.tsdb.corrupted-retention-duration",
+		"How long to retain corrupted blocks in storage. Units Supported: y, w, d, h, m, s, ms.",
+	).Default("4d").SetValue(&cfg.tsdb.CorruptedRetentionDuration)
+
 	serverOnlyFlag(a, "storage.tsdb.retention.size", "Maximum number of bytes that can be stored for blocks. A unit is required, supported units: B, KB, MB, GB, TB, PB, EB. Ex: \"512MB\". Based on powers-of-2, so 1KB is 1024B.").
 		BytesVar(&cfg.tsdb.MaxBytes)
 
@@ -1355,6 +1361,7 @@ func main() {
 					"MaxBytes", cfg.tsdb.MaxBytes,
 					"NoLockfile", cfg.tsdb.NoLockfile,
 					"RetentionDuration", cfg.tsdb.RetentionDuration,
+					"CorruptedRetentionDuration", cfg.tsdb.CorruptedRetentionDuration,
 					"WALSegmentSize", cfg.tsdb.WALSegmentSize,
 					"WALCompression", cfg.tsdb.WALCompression,
 				)
@@ -1941,6 +1948,7 @@ type tsdbOptions struct {
 	WALSegmentSize                 units.Base2Bytes
 	MaxBlockChunkSegmentSize       units.Base2Bytes
 	RetentionDuration              model.Duration
+	CorruptedRetentionDuration     model.Duration
 	MaxBytes                       units.Base2Bytes
 	NoLockfile                     bool
 	WALCompression                 bool
@@ -1965,6 +1973,7 @@ func (opts tsdbOptions) ToTSDBOptions() tsdb.Options {
 		WALSegmentSize:                 int(opts.WALSegmentSize),
 		MaxBlockChunkSegmentSize:       int64(opts.MaxBlockChunkSegmentSize),
 		RetentionDuration:              int64(time.Duration(opts.RetentionDuration) / time.Millisecond),
+		CorruptedRetentionDuration:     time.Duration(opts.CorruptedRetentionDuration),
 		MaxBytes:                       int64(opts.MaxBytes),
 		NoLockfile:                     opts.NoLockfile,
 		WALCompression:                 wlog.ParseCompressionType(opts.WALCompression, opts.WALCompressionType),

--- a/tsdb/block.go
+++ b/tsdb/block.go
@@ -244,6 +244,9 @@ const (
 	// CompactionHintFromOutOfOrder is a hint noting that the block
 	// was created from out-of-order chunks.
 	CompactionHintFromOutOfOrder = "from-out-of-order"
+
+	// CompactionHintCorrupted is a hint noting that the block is corrupted.
+	CompactionHintCorrupted = "corrupted"
 )
 
 func chunkDir(dir string) string { return filepath.Join(dir, "chunks") }

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -238,6 +238,14 @@ func (c *LeveledCompactor) Plan(dir string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// PP_CHANGES.md: rebuild on cpp start
+		// skip corrupted blocks
+		if meta.Compaction.containsHint(CompactionHintCorrupted) {
+			continue
+		}
+		// PP_CHANGES.md: rebuild on cpp end
+
 		dms = append(dms, dirMeta{dir, meta})
 	}
 	return c.plan(dms)
@@ -479,7 +487,22 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 			var err error
 			b, err = OpenBlock(c.logger, d, c.chunkPool)
 			if err != nil {
-				return nil, err
+				// PP_CHANGES.md: rebuild on cpp start
+				level.Warn(c.logger).Log(
+					"msg", "block corrupted",
+					"dir", d,
+					"err", err,
+				)
+
+				// mark as corrupted for skipping
+				meta.Compaction.Hints = append(meta.Compaction.Hints, CompactionHintCorrupted)
+				if _, err := writeMetaFile(c.logger, d, meta); err != nil {
+					return nil, fmt.Errorf("write meta file: %w", err)
+				}
+
+				continue
+				// return nil, err
+				// PP_CHANGES.md: rebuild on cpp end
 			}
 			defer b.Close()
 		}
@@ -490,7 +513,7 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 		uids = append(uids, meta.ULID.String())
 	}
 
-	if len(metas) == 0 {
+	if len(metas) < 2 {
 		return nil, nil // PP_CHANGES.md: fast exit
 	}
 

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -489,7 +489,7 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 			if err != nil {
 				// PP_CHANGES.md: rebuild on cpp start
 				level.Warn(c.logger).Log(
-					"msg", "block corrupted",
+					"msg", "block is corrupted, skipping",
 					"dir", d,
 					"err", err,
 				)

--- a/tsdb/compact.go
+++ b/tsdb/compact.go
@@ -514,6 +514,7 @@ func (c *LeveledCompactor) CompactWithBlockPopulator(dest string, dirs []string,
 	}
 
 	if len(metas) < 2 {
+		// there is no need to compact 1 block, just return
 		return nil, nil // PP_CHANGES.md: fast exit
 	}
 

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -108,6 +108,9 @@ type Options struct {
 	// Typically it is in milliseconds.
 	RetentionDuration int64
 
+	// CorruptedRetentionDuration is the duration of the retention for corrupted blocks.
+	CorruptedRetentionDuration time.Duration
+
 	// Maximum number of bytes in blocks to be retained.
 	// 0 or less means disabled.
 	// NOTE: For proper storage calculations need to consider
@@ -1251,11 +1254,12 @@ func (db *DB) Compact(ctx context.Context) (returnErr error) {
 
 	lastBlockMaxt := int64(math.MinInt64)
 	defer func() {
-		errs := tsdb_errors.NewMulti(returnErr)
+		// errs := tsdb_errors.NewMulti(returnErr) // PP_CHANGES.md: rebuild on cpp
 		if err := db.head.truncateWAL(lastBlockMaxt); err != nil {
-			errs.Add(fmt.Errorf("WAL truncation in Compact defer: %w", err))
+			// errs.Add(fmt.Errorf("WAL truncation in Compact defer: %w", err)) // PP_CHANGES.md: rebuild on cpp
+			returnErr = errors.Join(returnErr, fmt.Errorf("WAL truncation in Compact defer: %w", err))
 		}
-		returnErr = errs.Err()
+		// returnErr = errs.Err() // PP_CHANGES.md: rebuild on cpp
 	}()
 
 	start := time.Now()
@@ -1598,25 +1602,30 @@ func (db *DB) reloadBlocks() (err error) {
 		}
 	}
 
-	if len(corrupted) > 0 {
-		// Corrupted but no child loaded for it.
-		// Close all new blocks to release the lock for windows.
-		for _, block := range loadable {
-			if _, open := getBlock(db.blocks, block.Meta().ULID); !open {
-				block.Close()
-			}
+	// PP_CHANGES.md: rebuild on cpp start
+	for ulid, err := range corrupted {
+		// check if the block is outdated
+		// if it is, delete the block
+		isOutdated := isOutdatedBlock(
+			ulid,
+			min(
+				time.Duration(db.opts.RetentionDuration)*time.Millisecond,
+				db.opts.CorruptedRetentionDuration,
+			),
+		)
+
+		if isOutdated {
+			deletable[ulid] = nil
 		}
-		// errs := tsdb_errors.NewMulti() // PP_CHANGES.md: rebuild on cpp the errors are more informative
-		errs := make([]error, 0, len(corrupted))
-		for ulid, err := range corrupted {
-			if err != nil {
-				// errs.Add(fmt.Errorf("corrupted block %s: %w", ulid.String(), err)) // PP_CHANGES.md: rebuild on cpp
-				errs = append(errs, fmt.Errorf("corrupted block %s: %w", ulid.String(), err))
-			}
-		}
-		// return errs.Err() // PP_CHANGES.md: rebuild on cpp the errors are more informative
-		return errors.Join(errs...)
+
+		level.Warn(db.logger).Log(
+			"msg", "corrupted block",
+			"ulid", ulid.String(),
+			"err", err,
+			"isOutdated", isOutdated,
+		)
 	}
+	// PP_CHANGES.md: rebuild on cpp end
 
 	var (
 		toLoad     []*Block
@@ -2362,4 +2371,8 @@ func exponential(d, minD, maxD time.Duration) time.Duration {
 		d = maxD
 	}
 	return d
+}
+
+func isOutdatedBlock(ulid ulid.ULID, retentionDuration time.Duration) bool {
+	return ulid.Time() < uint64(time.Now().Add(-retentionDuration).UnixMilli())
 }


### PR DESCRIPTION
## Description
Add corrupted block retention duration and handling

- Introduced `CorruptedRetentionDuration` option for specifying how long to retain corrupted blocks in storage.
- Updated `tsdbOptions` and `Options` structs to include the new retention duration.
- Implemented logic in the compaction process to skip corrupted blocks and mark them accordingly.
- Added a new compaction hint for corrupted blocks to improve error handling and logging.

This change enhances the management of corrupted blocks within the time series database, ensuring better data integrity and retention policies.