### PR TITLE
Instant query allocation fix

### DIFF
--- a/pp/go/storage/querier/series.go
+++ b/pp/go/storage/querier/series.go
@@ -250,9 +250,8 @@ type InstantSeriesSet struct {
 	labelSetSnapshot            *cppbridge.LabelSetSnapshot
 	valueNotFoundTimestampValue int64
 	samples                     []cppbridge.Sample
-
-	index         int
-	currentSeries *InstantSeries
+	nextSampleIndex             int
+	series                      []InstantSeries
 }
 
 // NewInstantSeriesSet init new [InstantSeriesSet].
@@ -267,13 +266,13 @@ func NewInstantSeriesSet(
 		labelSetSnapshot:            labelSetSnapshot,
 		valueNotFoundTimestampValue: valueNotFoundTimestampValue,
 		samples:                     samples,
-		index:                       -1,
+		series:                      make([]InstantSeries, 0, len(samples)),
 	}
 }
 
 // At returns full series. Returned series should be iterable even after Next is called.
 func (ss *InstantSeriesSet) At() storage.Series {
-	return ss.currentSeries
+	return &ss.series[len(ss.series)-1]
 }
 
 // Err the error that iteration as failed with.
@@ -284,26 +283,27 @@ func (*InstantSeriesSet) Err() error {
 // Next return true if exist there is a next series and false otherwise.
 func (ss *InstantSeriesSet) Next() bool {
 	for {
-		if ss.index+1 >= ss.lssQueryResult.Len() {
+		if ss.nextSampleIndex >= ss.lssQueryResult.Len() {
 			return false
 		}
 
-		ss.index++
-		if ss.samples[ss.index].Timestamp != ss.valueNotFoundTimestampValue {
+		if ss.samples[ss.nextSampleIndex].Timestamp != ss.valueNotFoundTimestampValue {
 			break
 		}
+		ss.nextSampleIndex++
 	}
 
-	lsID, lsLength := ss.lssQueryResult.GetByIndex(ss.index)
-	ss.currentSeries = &InstantSeries{
+	lsID, lsLength := ss.lssQueryResult.GetByIndex(ss.nextSampleIndex)
+	ss.series = append(ss.series, InstantSeries{
 		labelSet: labels.NewLabelsWithLSS(
 			ss.labelSetSnapshot,
 			lsID,
 			lsLength,
 		),
-		sample: ss.samples[ss.index],
-	}
+		sample: &ss.samples[ss.nextSampleIndex],
+	})
 
+	ss.nextSampleIndex++
 	return true
 }
 
@@ -319,7 +319,7 @@ func (*InstantSeriesSet) Warnings() annotations.Annotations {
 // InstantSeries is a instant stream of data points belonging to a metric.
 type InstantSeries struct {
 	labelSet labels.Labels
-	sample   cppbridge.Sample
+	sample   *cppbridge.Sample
 }
 
 // Iterator is storage.Series interface implementation.

--- a/pp/go/storage/querier/series_bench_test.go
+++ b/pp/go/storage/querier/series_bench_test.go
@@ -17,8 +17,9 @@ import (
 
 func iterateSeriesSet(seriesSet storage.SeriesSet) {
 	var iterator chunkenc.Iterator
+	var series storage.Series
 	for seriesSet.Next() {
-		series := seriesSet.At()
+		series = seriesSet.At()
 		iterator = series.Iterator(iterator)
 		for iterator.Next() != chunkenc.ValNone {
 			ts, v := iterator.At()
@@ -47,6 +48,23 @@ func queryOpt(t testing.TB, lss *shard.LSS, ds *shard.DataStorage, start, end in
 
 	require.Equal(t, cppbridge.DataStorageQueryStatusSuccess, dsQueryResult.Status)
 	return querier.NewSeriesSet(start, end, lssQueryResult, snapshot, dsQueryResult.SerializedData)
+}
+
+func instantQuery(t testing.TB, lss *shard.LSS, ds *shard.DataStorage, targetTimestamp, valueNotFoundTimestampValue int64, matchers ...model.LabelMatcher) *querier.InstantSeriesSet {
+	selector, snapshot, err := lss.QuerySelector(0, matchers)
+	require.NoError(t, err)
+	if selector == 0 || snapshot == nil {
+		return &querier.InstantSeriesSet{}
+	}
+
+	lssQueryResult := snapshot.Query(selector)
+	if lssQueryResult.Status() == cppbridge.LSSQueryStatusNoMatch {
+		return &querier.InstantSeriesSet{}
+	}
+
+	samples, dsQueryResult := ds.InstantQuery(targetTimestamp, valueNotFoundTimestampValue, lssQueryResult.IDs())
+	require.Equal(t, cppbridge.DataStorageQueryStatusSuccess, dsQueryResult.Status)
+	return querier.NewInstantSeriesSet(lssQueryResult, snapshot, valueNotFoundTimestampValue, samples)
 }
 
 func BenchmarkSeriesSetOpt(b *testing.B) {
@@ -89,4 +107,49 @@ func prepareData(lss *shard.LSS, ds *shard.DataStorage, size int) {
 		})
 	}
 	storagetest.MustAppendTimeSeriesToLSSAndDataStorage(lss, ds, timeSeries...)
+}
+
+func prepareInstantData(lss *shard.LSS, ds *shard.DataStorage, timeStamps []int64, size int) {
+	timeSeries := make([]storagetest.TimeSeries, 0, size)
+	for _, ts := range timeStamps {
+		for i := 0; i < size; i++ {
+			label := fmt.Sprintf("index_%d", i)
+			timeSeries = append(timeSeries, storagetest.TimeSeries{
+				Labels: labels.FromStrings("__name__", "metric", "job", label, "container", "", "id", "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod37ce076d8d523c8b0c8c0b6191d927f6.slice/cri-containerd-bdd69edcd2fb187baa3381810051e8cc7b8a0d0368e168040f93adb3260582b2.scope", "image", "registry.k8s.io/pause:3.8", "name", "bdd69edcd2fb187baa3381810051e8cc7b8a0d0368e168040f93adb3260582b2", "namespace", "kube-system", "pod", "kube-scheduler-m1.k8s.lan"),
+				Samples: []cppbridge.Sample{
+					{Timestamp: ts, Value: float64(i)},
+				},
+			})
+		}
+
+	}
+	storagetest.MustAppendTimeSeriesToLSSAndDataStorage(lss, ds, timeSeries...)
+}
+
+func BenchmarkInstantSeriesSet(b *testing.B) {
+	size := 500000
+	matcher := model.LabelMatcher{
+		Name:        "__name__",
+		Value:       "metric",
+		MatcherType: model.MatcherTypeExactMatch,
+	}
+
+	lss := shard.NewLSS()
+	ds := shard.NewDataStorage()
+	timestamps := []int64{0, 1, 2}
+	valueNotFoundTimestampValue := timestamps[0] - 1
+	prepareInstantData(lss, ds, timestamps, size)
+	b.ResetTimer()
+	b.ReportAllocs()
+	var samplesSet [][]cppbridge.Sample
+	for i := 0; i < b.N; i++ {
+		seriesSet := instantQuery(b, lss, ds, timestamps[1], valueNotFoundTimestampValue, matcher)
+		samples := make([]cppbridge.Sample, 0, size)
+		b.StartTimer()
+		iterateSeriesSet(seriesSet)
+		b.StopTimer()
+		samplesSet = append(samplesSet, samples)
+	}
+
+	runtime.KeepAlive(samplesSet)
 }


### PR DESCRIPTION
## Description
  <!---
  Describe your changes in detail.

  Please let users know if your feature influences critical cluster components.
  -->
  
  ## Why do we need it, and what problem does it solve?
  <!---
  This is the most important paragraph.
  You must describe the main goal of your feature.

  If it fixes an issue, place a link to the issue here.

  If it fixes an obvious bug, please tell users about the impact and effect of the problem.
  -->
  
  ## Why do we need it in the patch release (if we do)?
  
  <!---
  Describe why the changes need to be backported into the patch release.
  
  If it doesn't matter whether the changes will be backported into the patch release, specify "Not necessarily".
  
  Delete the section if the PR is for release, and not for the patch release.
  -->

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: fix | feature | chore
   summary: <ONE-LINE of what effectively changes for a user>
   impact: <what to expect for users, possibly MULTI-LINE>, required if impact_level is high ↓
   impact_level: default | high | low
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->