### PR TITLE
used lazy_emplace_with_hash instead of find/emplace

### DIFF
--- a/pp/series_index/benchmarks/BUILD
+++ b/pp/series_index/benchmarks/BUILD
@@ -9,3 +9,13 @@ cc_binary(
         "//:benchmark",
     ],
 )
+
+cc_binary(
+    name = "find_or_emplace",
+    srcs = ["find_or_emplace_benchmark.cpp"],
+    malloc = "@jemalloc",
+    deps = [
+        "//:series_index",
+        "//:benchmark",
+    ],
+)

--- a/pp/series_index/benchmarks/find_or_emplace_benchmark.cpp
+++ b/pp/series_index/benchmarks/find_or_emplace_benchmark.cpp
@@ -1,0 +1,61 @@
+#include <benchmark/benchmark.h>
+
+#include "primitives/snug_composites.h"
+#include "profiling/profiling.h"
+#include "series_index/queryable_encoding_bimap.h"
+#include "series_index/trie/cedarpp_tree.h"
+
+namespace {
+
+using QueryableEncodingBimap =
+    series_index::QueryableEncodingBimap<PromPP::Primitives::SnugComposites::LabelSet::EncodingBimapFilament, BareBones::Vector, series_index::trie::CedarTrie>;
+
+std::string_view get_lss_file() {
+  if (auto& context = benchmark::internal::GetGlobalContext(); context != nullptr) {
+    return context->operator[]("lss_file");
+  }
+
+  return {};
+}
+
+QueryableEncodingBimap& get_lss() {
+  static QueryableEncodingBimap lss;
+  if (lss.size() == 0) {
+    std::ifstream infile(get_lss_file().data(), std::ios_base::binary);
+    infile >> lss;
+  }
+
+  return lss;
+}
+
+void BenchmarkFindOrEmplaceWithEmplace(benchmark::State& state) {
+  ZoneScoped;
+  const auto& lss = get_lss();
+
+  for ([[maybe_unused]] auto _ : state) {
+    QueryableEncodingBimap lss2;
+    for (const auto& label_set : lss) {
+      lss2.find_or_emplace(label_set);
+    }
+  }
+}
+
+void BenchmarkFindOrEmplaceWithFind(benchmark::State& state) {
+  ZoneScoped;
+  auto& lss = get_lss();
+
+  for ([[maybe_unused]] auto _ : state) {
+    for (const auto& label_set : lss) {
+      lss.find_or_emplace(label_set);
+    }
+  }
+}
+
+double min_value(const std::vector<double>& v) noexcept {
+  return *std::ranges::min_element(v);
+}
+
+BENCHMARK(BenchmarkFindOrEmplaceWithEmplace)->ComputeStatistics("min", min_value);
+BENCHMARK(BenchmarkFindOrEmplaceWithFind)->ComputeStatistics("min", min_value);
+
+}  // namespace

--- a/pp/series_index/queryable_encoding_bimap.h
+++ b/pp/series_index/queryable_encoding_bimap.h
@@ -50,14 +50,14 @@ class QueryableEncodingBimap final : public BareBones::SnugComposite::GenericDec
   template <class LabelSet>
   PROMPP_ALWAYS_INLINE uint32_t find_or_emplace(const LabelSet& label_set, size_t hash) noexcept {
     hash = phmap_hash(hash);
-    if (auto it = ls_id_hash_set_.find(label_set, hash); it != ls_id_hash_set_.end()) {
-      mark_series_as_added(*it);
-      return *it;
-    }
+    const auto ls_id = *ls_id_hash_set_.lazy_emplace_with_hash(label_set, hash, [&](const auto& ctor) {
+      auto new_ls_id = Base::items_.size();
+      ctor(typename Base::Proxy(new_ls_id));
+      auto composite_label_set = Base::items_.emplace_back(Base::data_, label_set).composite(Base::data());
+      update_indexes(new_ls_id, composite_label_set);
+      return new_ls_id;
+    });
 
-    auto ls_id = Base::items_.size();
-    auto composite_label_set = Base::items_.emplace_back(Base::data_, label_set).composite(Base::data());
-    update_indexes(ls_id, composite_label_set, hash);
     mark_series_as_added(ls_id);
     return ls_id;
   }
@@ -107,12 +107,12 @@ class QueryableEncodingBimap final : public BareBones::SnugComposite::GenericDec
     const auto hasher = Base::hasher();
     for (auto ls_id = first_loaded_id; ls_id < Base::items_.size(); ++ls_id) {
       auto label_set = this->operator[](ls_id);
-      update_indexes(ls_id, label_set, phmap_hash(hasher(label_set)));
+      ls_id_hash_set_.emplace_with_hash(phmap_hash(hasher(label_set)), typename Base::Proxy(ls_id));
+      update_indexes(ls_id, label_set);
     }
   }
 
-  void update_indexes(uint32_t ls_id, const LabelSet& label_set, size_t label_set_phmap_hash) {
-    ls_id_hash_set_.emplace_with_hash(label_set_phmap_hash, typename Base::Proxy(ls_id));
+  void update_indexes(uint32_t ls_id, const LabelSet& label_set) {
     auto ls_id_set_iterator = ls_id_set_.emplace(ls_id).first;
 
     for (auto label = label_set.begin(); label != label_set.end(); ++label) {

--- a/pp/series_index/tests/queryable_encoding_bimap_tests.cpp
+++ b/pp/series_index/tests/queryable_encoding_bimap_tests.cpp
@@ -119,6 +119,27 @@ TEST_F(QueryableEncodingBimapFixture, EmplaceDuplicatedLabelSet) {
   EXPECT_NE(ls_id1, ls_id2);
 }
 
+TEST_F(QueryableEncodingBimapFixture, Load) {
+  // Arrange
+  const auto label_set1 = LabelViewSet{{"job", "cron"}, {"key", ""}, {"process", "php"}};
+  const auto label_set2 = LabelViewSet{{"job", "cron"}, {"key", ""}, {"process", "php1"}};
+
+  const auto ls_id1 = lss_.find_or_emplace(label_set1);
+  const auto ls_id2 = lss_.find_or_emplace(label_set2);
+
+  std::stringstream stream;
+  stream << lss_;
+
+  Lss lss2;
+
+  // Act
+  stream >> lss2;
+
+  // Assert
+  EXPECT_EQ(ls_id1, lss2.find(label_set1));
+  EXPECT_EQ(ls_id2, lss2.find(label_set2));
+}
+
 class QueryableEncodingBimapCopierFixture : public QueryableEncodingBimapFixture {
  protected:
   BareBones::Vector<uint32_t> dst_src_ids_mapping_;


### PR DESCRIPTION
I used benchmarks with disabled index generation in QueryableEncodingBimap.

Without lazy_emplace:
```
BenchmarkFindOrEmplaceWithEmplace   924705982 ns
BenchmarkFindOrEmplaceWithFind      264122486 ns
```

With lazy_emplace:
```
BenchmarkFindOrEmplaceWithEmplace   914267778 ns
BenchmarkFindOrEmplaceWithFind      261677424 ns
```