### PR TITLE
Move d8 setup action to our repo

### DIFF
--- a/.github/actions/setup-werf/action.yaml
+++ b/.github/actions/setup-werf/action.yaml
@@ -1,0 +1,37 @@
+name: Custom setup werf + crane
+
+description: Setup werf, crane and login into registry
+
+inputs:
+  registry:
+    required: true
+  registry_login:
+    required: true
+  registry_password:
+    required: true
+  channel:
+    description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
+    default: 'stable'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: werf/actions/install@v2
+      with:
+        channel: ${{ inputs.channel }}
+
+    - uses: imjasonh/setup-crane@v0.4
+
+    - name: Print werf version
+      shell: bash
+      run: werf version
+
+    - name: Print crane version
+      shell: bash
+      run: crane version
+
+
+    - name: Login into registry ${{ inputs.registry }}
+      shell: bash
+      run: werf cr login -u ${{ inputs.registry_login }} -p ${{ inputs.registry_password }} ${{ inputs.registry }}

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -3,7 +3,7 @@ name: Build with Werf Dockerhub
 on:
   push:
     tags:
-      - "v*"
+    - "v*"
   workflow_dispatch:
     inputs:
       release_branch:
@@ -24,114 +24,116 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner_name: fsn-dev-perftest-runner
-            arch: amd64
-            GO_ARCH: amd64
-            BAZEL_ARCH: x86_64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
-            GO_ARCH: arm64
-            BAZEL_ARCH: arm64
+        - runner_name: fsn-dev-perftest-runner
+          arch: amd64
+          GO_ARCH: amd64
+          BAZEL_ARCH: x86_64
+        - runner_name: fsn-dev-arm-runner
+          arch: arm64
+          GO_ARCH: arm64
+          BAZEL_ARCH: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Login to Dockerhub registry
-        uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: docker.io
-          registry_login: ${{ secrets.DOCKERHUB_REGISTRY_LOGIN }}
-          registry_password: "${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}"
+    - name: Login to Dockerhub registry
+      uses: ./.github/actions/setup-werf
+      with:
+        registry: docker.io
+        registry_login: ${{ secrets.DOCKERHUB_REGISTRY_LOGIN }}
+        registry_password: "${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}"
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Login to mirror registry
-        uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DECKHOUSE_REGISTRY }}
-          registry_login: ${{ secrets.DECKHOUSE_REGISTRY_LOGIN }}
-          registry_password: "${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}"
+    - name: Login to mirror registry
+      uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DECKHOUSE_REGISTRY }}
+        registry_login: ${{ secrets.DECKHOUSE_REGISTRY_LOGIN }}
+        registry_password: "${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}"
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Normalize branch name
-        id: normalize
-        run: |
-          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+    - name: Normalize branch name
+      id: normalize
+      run: |
+        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Build Images
-        run: |
-          export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
-          export GO_ARCH=${{ matrix.GO_ARCH }}
-          export COMPILATION_MODE="opt"
-          export ASAN="false"
-          export WERF_BUILDAH_MODE=auto
+    - name: Build Images
+      run: |
+        export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
+        export GO_ARCH=${{ matrix.GO_ARCH }}
+        export COMPILATION_MODE="opt"
+        export ASAN="false"
+        export WERF_BUILDAH_MODE=auto
 
-          werf export --platform linux/${{ matrix.arch }} --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp \
-            --tag=index.docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }} \
-            --tag=${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
+        werf export --platform linux/${{ matrix.arch }} --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp \
+          --tag=index.docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }} \
+          --tag=${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
 
-      - name: Extract binaries from Docker images
-        run: |
-          docker pull docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
-          CONTAINER_ID_PROMPP=$(docker create docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }})
+    - name: Extract binaries from Docker images
+      run: |
+        docker pull docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
+        CONTAINER_ID_PROMPP=$(docker create docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }})
 
-          docker cp $CONTAINER_ID_PROMPP:/bin/prompp ./prompp
-          docker cp $CONTAINER_ID_PROMPP:/bin/promtool ./promtool
-          docker cp $CONTAINER_ID_PROMPP:/bin/prompptool ./prompptool
-          docker rm $CONTAINER_ID_PROMPP
-          docker rmi docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
+        docker cp $CONTAINER_ID_PROMPP:/bin/prompp ./prompp
+        docker cp $CONTAINER_ID_PROMPP:/bin/promtool ./promtool
+        docker cp $CONTAINER_ID_PROMPP:/bin/prompptool ./prompptool
+        docker rm $CONTAINER_ID_PROMPP
+        docker rmi docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}
 
-      - name: Archive binaries
-        run: |
-          cp ./documentation/examples/prometheus.yml ./prometheus.yml
-          tar -czvf prompp-binaries-${{ matrix.arch }}.tar.gz prompp promtool prompptool prometheus.yml
+    - name: Archive binaries
+      run: |
+        cp ./documentation/examples/prometheus.yml ./prometheus.yml
+        tar -czvf prompp-binaries-${{ matrix.arch }}.tar.gz prompp promtool prompptool prometheus.yml
 
-      - name: Upload binaries as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: prompp-binaries-${{ matrix.arch }}
-          path: prompp-binaries-${{ matrix.arch }}.tar.gz
-          retention-days: 7
+    - name: Upload binaries as artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: prompp-binaries-${{ matrix.arch }}
+        path: prompp-binaries-${{ matrix.arch }}.tar.gz
+        retention-days: 7
 
   make-multiarch:
     needs: build-and-push
     runs-on: fsn-dev-perftest-runner
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Normalize branch name
-        id: normalize
-        run: |
-          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+    - name: Normalize branch name
+      id: normalize
+      run: |
+        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Create and push multi-arch manifest Dockerhub
-        run: |
-          docker manifest create --amend docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
-            docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
-            docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
-          
-          docker manifest push docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+    - name: Create and push multi-arch manifest Dockerhub
+      run: |
+        docker manifest create --amend docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+          docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
 
-      - name: Create and push multi-arch manifest Deckhouse registry
-        run: |
-          docker manifest create --amend ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
-            ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
-            ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
-          
-          docker manifest push ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+        docker manifest push docker.io/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+
+    - name: Create and push multi-arch manifest Deckhouse registry
+      run: |
+        docker manifest create --amend ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+          ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
+
+        docker manifest push ${{ secrets.DECKHOUSE_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
 
   release:
     needs: make-multiarch
@@ -139,32 +141,32 @@ jobs:
       contents: write
     runs-on: fsn-dev-gitlab-runner
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Download Static Library arm64
-        uses: actions/download-artifact@v4
-        with:
-          name: prompp-binaries-arm64
-          path: ./artifacts
-          retention-days: 7
+    - name: Download Static Library arm64
+      uses: actions/download-artifact@v4
+      with:
+        name: prompp-binaries-arm64
+        path: ./artifacts
+        retention-days: 7
 
-      - name: Download Static Library amd64
-        uses: actions/download-artifact@v4
-        with:
-          name: prompp-binaries-amd64
-          path: ./artifacts
-          retention-days: 7
+    - name: Download Static Library amd64
+      uses: actions/download-artifact@v4
+      with:
+        name: prompp-binaries-amd64
+        path: ./artifacts
+        retention-days: 7
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
-        with:
-          draft: true
-          files: ./artifacts/prompp-binaries*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
+      with:
+        draft: true
+        files: ./artifacts/prompp-binaries*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -3,6 +3,7 @@ name: Build with Werf dev registry
 on:
   workflow_call:
 
+
 env:
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_LOGS: "0"
@@ -13,46 +14,47 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner_name: fsn-dev-perftest-runner
-            arch: amd64
-            GO_ARCH: amd64
-            BAZEL_ARCH: x86_64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
-            GO_ARCH: arm64
-            BAZEL_ARCH: arm64
+        - runner_name: fsn-dev-perftest-runner
+          arch: amd64
+          GO_ARCH: amd64
+          BAZEL_ARCH: x86_64
+        - runner_name: fsn-dev-arm-runner
+          arch: arm64
+          GO_ARCH: arm64
+          BAZEL_ARCH: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-        
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
-      - name: Normalize branch name
-        id: normalize
-        run: |
-          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Build Images Dev registry
-        run: |
-          export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
-          export GO_ARCH=${{ matrix.GO_ARCH }}
-          export COMPILATION_MODE="opt"
-          export ASAN="false"
-          export WERF_BUILDAH_MODE=auto
+    - name: Normalize branch name
+      id: normalize
+      run: |
+        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
+    - name: Build Images Dev registry
+      run: |
+        export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
+        export GO_ARCH=${{ matrix.GO_ARCH }}
+        export COMPILATION_MODE="opt"
+        export ASAN="false"
+        export WERF_BUILDAH_MODE=auto
+
+        werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
 
   make-multiarch:
     needs: build-and-push
@@ -60,25 +62,25 @@ jobs:
     env:
       RAW_BRANCH_NAME: ${{ github.event.pull_request.head.ref || github.ref_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - name: Normalize branch name
-        id: normalize
-        run: |
-          RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
-          BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
-          echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+    - name: Normalize branch name
+      id: normalize
+      run: |
+        RAW_BRANCH_NAME="${{ github.event.pull_request.head.ref || github.ref_name }}"
+        BRANCH_NAME=$(echo "$RAW_BRANCH_NAME" | sed -E 's|/|-|g; s/^v//')
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
-      - name: Create and push multiarch manifest
-        run: |
-          docker manifest create --amend ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
-            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
-            ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
-  
-          docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge
+    - name: Create and push multiarch manifest
+      run: |
+        docker manifest create --amend ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} \
+          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-amd64 \
+          ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }}-arm64
+
+        docker manifest push ${{ secrets.DEV_REGISTRY }}/prompp/prompp:${{ steps.normalize.outputs.branch_name }} --purge

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -2,21 +2,21 @@ name: Linter
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [ opened, reopened, labeled, synchronize ]
     paths:
-      - 'pp/**'
+    - 'pp/**'
   push:
     branches:
-      - pp
+    - pp
     paths:
-      - 'pp/**'
+    - 'pp/**'
   workflow_dispatch:
     inputs:
       release_branch:
         description: 'release branch name, example: release-1.68'
         required: false
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -24,41 +24,42 @@ jobs:
   clang-lint:
     runs-on: fsn-dev-gitlab-runner
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Run Clang Format
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-            bash -c "
-              set -eo pipefail
+    - name: Run Clang Format
+      run: |
+        docker run --rm \
+          -v $PWD:/workspace \
+          -w /workspace \
+          ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+          bash -c "
+            set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              make format
-            "
-      - name: Run Clang Tidy
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-            bash -c "
-              set -eo pipefail
+            git config --global --add safe.directory /workspace && cd pp
+            make format
+          "
+    - name: Run Clang Tidy
+      run: |
+        docker run --rm \
+          -v $PWD:/workspace \
+          -w /workspace \
+          ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+          bash -c "
+            set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              make tidy
-            "
+            git config --global --add safe.directory /workspace && cd pp
+            make tidy
+          "

--- a/.github/workflows/dev-registry_cleanup.yaml
+++ b/.github/workflows/dev-registry_cleanup.yaml
@@ -7,7 +7,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "12 0 * * 6"
+  - cron: "12 0 * * 6"
 
 defaults:
   run:
@@ -18,21 +18,22 @@ jobs:
     runs-on: fsn-dev-gitlab-runner
     name: Run cleanup
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN_CLEANUP }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD_CLEANUP }}
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN_CLEANUP }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD_CLEANUP }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Cleanup
-        run: |
-          werf cleanup \
-          --repo ${{ secrets.DEV_REGISTRY }}/prompp/prompp \
-          --without-kube=true --config werf_cleanup.yaml
+    - name: Cleanup
+      run: |
+        werf cleanup \
+        --repo ${{ secrets.DEV_REGISTRY }}/prompp/prompp \
+        --without-kube=true --config werf_cleanup.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,17 +2,17 @@ name: Run Tests
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, synchronize]
+    types: [ opened, reopened, labeled, synchronize ]
   push:
     branches:
-      - pp
+    - pp
   workflow_dispatch:
     inputs:
       release_branch:
         description: 'release branch name, example: release-1.68'
         required: false
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -21,213 +21,216 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
-        runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
+        OPT: [ dbg, opt ]
+        SANITIZERS: [ no_sanitizers, with_sanitizers ]
+        runner_name: [ fsn-dev-gitlab-runner, fsn-dev-arm-runner ]
         include:
-          - runner_name: fsn-dev-gitlab-runner
-            arch: amd64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
+        - runner_name: fsn-dev-gitlab-runner
+          arch: amd64
+        - runner_name: fsn-dev-arm-runner
+          arch: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Pull Latest Image
-        if: matrix.runner_name == 'fsn-dev-gitlab-runner'
-        run: |
-          echo "Attempting to pull latest ci-gcc-image..."
-          docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
-            echo "Pull failed, continuing with cached image"
+    - name: Pull Latest Image
+      if: matrix.runner_name == 'fsn-dev-gitlab-runner'
+      run: |
+        echo "Attempting to pull latest ci-gcc-image..."
+        docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
+          echo "Pull failed, continuing with cached image"
 
-      - name: Run Unit Tests
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e OPT=${{ matrix.OPT }} \
-            -e SANITIZERS=${{ matrix.SANITIZERS }} \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-            bash -c "
-              set -eo pipefail
+    - name: Run Unit Tests
+      run: |
+        docker run --rm \
+          -v $PWD:/workspace \
+          -w /workspace \
+          -e OPT=${{ matrix.OPT }} \
+          -e SANITIZERS=${{ matrix.SANITIZERS }} \
+          ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+          bash -c "
+            set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-              ./scripts/ci_run_unit_tests.sh
+            git config --global --add safe.directory /workspace && cd pp
+            echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+            ./scripts/ci_run_unit_tests.sh
 
-              mkdir -p /workspace/testlogs
-              for f in ./bazel-testlogs/**/test.xml; do 
-                cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
-              done
-            "
+            mkdir -p /workspace/testlogs
+            for f in ./bazel-testlogs/**/test.xml; do 
+              cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
+            done
+          "
 
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/testlogs/*.xml
-          retention-days: 7
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v4
+      with:
+        name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+        path: pp/testlogs/*.xml
+        retention-days: 7
 
   build-go-bindings:
     needs: cpp-tests
     strategy:
       max-parallel: 4
       matrix:
-        COMPILATION_MODE: [dbg, opt]
-        ASAN: [false, true]
-        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
+        COMPILATION_MODE: [ dbg, opt ]
+        ASAN: [ false, true ]
+        runner_name: [ fsn-dev-perftest-runner, fsn-dev-arm-runner ]
         include:
-          - runner_name: fsn-dev-perftest-runner
-            arch: amd64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
+        - runner_name: fsn-dev-perftest-runner
+          arch: amd64
+        - runner_name: fsn-dev-arm-runner
+          arch: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Build Go bindings
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
-            -e ASAN=${{ matrix.ASAN }} \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-            bash -c "
-              set -eo pipefail
+    - name: Build Go bindings
+      run: |
+        docker run --rm \
+          -v $PWD:/workspace \
+          -w /workspace \
+          -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
+          -e ASAN=${{ matrix.ASAN }} \
+          ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+          bash -c "
+            set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-              make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
-            "
-      - name: Upload Specific Static Libraries
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
-          path: pp/go/cppbridge/${{ matrix.arch }}_*
-          retention-days: 7
+            git config --global --add safe.directory /workspace && cd pp
+            echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+            make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
+          "
+    - name: Upload Specific Static Libraries
+      uses: actions/upload-artifact@v4
+      with:
+        name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
+        path: pp/go/cppbridge/${{ matrix.arch }}_*
+        retention-days: 7
 
-      - name: Clear workspace
-        run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
+    - name: Clear workspace
+      run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
 
   go-tests:
     needs: build-go-bindings
     strategy:
       max-parallel: 4
       matrix:
-        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
+        runner_name: [ fsn-dev-perftest-runner, fsn-dev-arm-runner ]
+        OPT: [ dbg, opt ]
+        SANITIZERS: [ no_sanitizers, with_sanitizers ]
         include:
-          - SANITIZERS: no_sanitizers
-            ASAN: false
-            STATIC: static
-          - SANITIZERS: with_sanitizers
-            ASAN: true
+        - SANITIZERS: no_sanitizers
+          ASAN: false
+          STATIC: static
+        - SANITIZERS: with_sanitizers
+          ASAN: true
         exclude:
-          - SANITIZERS: with_sanitizers
-            OPT: dbg
+        - SANITIZERS: with_sanitizers
+          OPT: dbg
     runs-on: ${{ matrix.runner_name }}
     steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+    - name: Clean workspace
+      uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+    - uses: ./.github/actions/setup-werf
+      with:
+        registry: ${{ secrets.DEV_REGISTRY }}
+        registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+        registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+        channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Set architecture variable
-        run: |
-          if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
-            echo "ARCH=amd64" >> $GITHUB_ENV
-          elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
-            echo "ARCH=arm64" >> $GITHUB_ENV
-          fi
+    - name: Set architecture variable
+      run: |
+        if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
+          echo "ARCH=amd64" >> $GITHUB_ENV
+        elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
+          echo "ARCH=arm64" >> $GITHUB_ENV
+        fi
 
-      - name: Download Static Library
-        uses: actions/download-artifact@v4
-        with:
-          name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
-          path: pp/go/cppbridge/
+    - name: Download Static Library
+      uses: actions/download-artifact@v4
+      with:
+        name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
+        path: pp/go/cppbridge/
 
-      - name: Run Go Tests and Process Reports
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e OPT=${{ matrix.OPT }} \
-            -e SANITIZERS=${{ matrix.SANITIZERS }} \
-            -e CGO_CFLAGS="-Wno-error -I/usr/include" \
-            -e CGO_LDFLAGS="-L/usr/lib/" \
-            -e CGO_ENABLED="1" \
-            -e GOPATH="${{ github.workspace }}/.cache" \
-            -e GOBIN="/usr/local/go/bin" \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
-            bash -c "
-              set -eo pipefail
+    - name: Run Go Tests and Process Reports
+      run: |
+        docker run --rm \
+          -v $PWD:/workspace \
+          -w /workspace \
+          -e OPT=${{ matrix.OPT }} \
+          -e SANITIZERS=${{ matrix.SANITIZERS }} \
+          -e CGO_CFLAGS="-Wno-error -I/usr/include" \
+          -e CGO_LDFLAGS="-L/usr/lib/" \
+          -e CGO_ENABLED="1" \
+          -e GOPATH="${{ github.workspace }}/.cache" \
+          -e GOBIN="/usr/local/go/bin" \
+          ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
+          bash -c "
+            set -eo pipefail
 
-              git config --global --add safe.directory /workspace
-              # go tools
-              mkdir -p .cache
-              go install github.com/jstemmer/go-junit-report/v2@latest
-              go install github.com/afunix/gocov/gocov@latest
-              go install github.com/AlekSi/gocov-xml@latest
+            git config --global --add safe.directory /workspace
+            # go tools
+            mkdir -p .cache
+            go install github.com/jstemmer/go-junit-report/v2@latest
+            go install github.com/afunix/gocov/gocov@latest
+            go install github.com/AlekSi/gocov-xml@latest
 
-              # tests
-              cd pp
-              go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
+            # tests
+            cd pp
+            go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
 
-              # reports
-              cat report.txt | go-junit-report > report.xml
-              sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
-              gocov convert coverage.txt | gocov-xml > coverage.xml
-              go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
-            "
+            # reports
+            cat report.txt | go-junit-report > report.xml
+            sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
+            gocov convert coverage.txt | gocov-xml > coverage.xml
+            go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
+          "
 
-      - name: Upload Go Test Reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/report.xml
-          retention-days: 7
+    - name: Upload Go Test Reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+        path: pp/report.xml
+        retention-days: 7
 
-      - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/coverage.xml
-          retention-days: 7
+    - name: Upload Coverage Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+        path: pp/coverage.xml
+        retention-days: 7
 
   build_dev:
     needs: go-tests


### PR DESCRIPTION
## Description
Move d8 setup action to our repo
  
  ## Why do we need it, and what problem does it solve?
To be able to change update channel for Werf 
  ## Why do we need it in the patch release (if we do)?
  
necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Move d8 setup action to our repo
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->