### PR TITLE
Move d8 setup action to our repo

### DIFF
--- a/.github/actions/setup-werf/action.yaml
+++ b/.github/actions/setup-werf/action.yaml
@@ -1,0 +1,37 @@
+name: Custom setup werf + crane
+
+description: Setup werf, crane and login into registry
+
+inputs:
+  registry:
+    required: true
+  registry_login:
+    required: true
+  registry_password:
+    required: true
+  channel:
+    description: 'The one of the following channel: alpha, beta, ea, stable, rock-solid'
+    default: 'stable'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - uses: werf/actions/install@v2
+      with:
+        channel: ${{ inputs.channel }}
+
+    - uses: imjasonh/setup-crane@v0.4
+
+    - name: Print werf version
+      shell: bash
+      run: werf version
+
+    - name: Print crane version
+      shell: bash
+      run: crane version
+
+
+    - name: Login into registry ${{ inputs.registry }}
+      shell: bash
+      run: werf cr login -u ${{ inputs.registry_login }} -p ${{ inputs.registry_password }} ${{ inputs.registry }}

--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -43,18 +43,20 @@ jobs:
           fetch-depth: 0
 
       - name: Login to Dockerhub registry
-        uses: deckhouse/modules-actions/setup@v2
+        uses: ./.github/actions/setup-werf
         with:
           registry: docker.io
           registry_login: ${{ secrets.DOCKERHUB_REGISTRY_LOGIN }}
           registry_password: "${{ secrets.DOCKERHUB_REGISTRY_PASSWORD }}"
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Login to mirror registry
-        uses: deckhouse/modules-actions/setup@v2
+        uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DECKHOUSE_REGISTRY }}
           registry_login: ${{ secrets.DECKHOUSE_REGISTRY_LOGIN }}
           registry_password: "${{ secrets.DECKHOUSE_REGISTRY_PASSWORD }}"
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Normalize branch name
         id: normalize

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Build Images Dev registry
         run: |
+          env | grep -E ^WERF_SECONDARY_REPO        
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build Images Dev registry
         run: |
-          env | grep -E ^WERF_SECONDARY_REPO || true     
+          env     
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build Images Dev registry
         run: |
-          env | grep -E ^WERF_SECONDARY_REPO        
+          env | grep -E ^WERF_SECONDARY_REPO || true     
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -47,14 +47,14 @@ jobs:
 
       - name: Build Images Dev registry
         run: |
-          env     
+          env | grep -E ^WERF_SECONDARY_REPO || true
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"
           export ASAN="false"
           export WERF_BUILDAH_MODE=auto
 
-          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
+          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --log-debug
 
   make-multiarch:
     needs: build-and-push

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -6,7 +6,7 @@ on:
 env:
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_LOGS: "0"
-  WERF_PARALLEL_TASKS_LIMIT: 10
+  # WERF_PARALLEL_TASKS_LIMIT: 10
 
 jobs:
   build-and-push:
@@ -47,14 +47,13 @@ jobs:
 
       - name: Build Images Dev registry
         run: |
-          env | grep -E ^WERF_SECONDARY_REPO || true
           export BAZEL_ARCH=${{ matrix.BAZEL_ARCH }}
           export GO_ARCH=${{ matrix.GO_ARCH }}
           export COMPILATION_MODE="opt"
           export ASAN="false"
           export WERF_BUILDAH_MODE=auto
 
-          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --log-debug
+          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --log-debug --parallel=false
 
   make-multiarch:
     needs: build-and-push

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -31,11 +31,12 @@ jobs:
         with:
           fetch-depth: 0
         
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Normalize branch name
         id: normalize

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -6,7 +6,7 @@ on:
 env:
   WERF_TELEMETRY: "1"
   WERF_TELEMETRY_LOGS: "0"
-  # WERF_PARALLEL_TASKS_LIMIT: 10
+  WERF_PARALLEL_TASKS_LIMIT: 10
 
 jobs:
   build-and-push:
@@ -53,7 +53,7 @@ jobs:
           export ASAN="false"
           export WERF_BUILDAH_MODE=auto
 
-          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp --log-debug --parallel=false
+          werf build --platform linux/${{ matrix.arch }} --add-custom-tag="${{ steps.normalize.outputs.branch_name }}-${{ matrix.arch }}" --repo=${{ secrets.DEV_REGISTRY }}/prompp/prompp
 
   make-multiarch:
     needs: build-and-push

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -1,65 +1,65 @@
-# name: Linter
+name: Linter
 
-# on:
-#   pull_request:
-#     types: [opened, reopened, labeled, synchronize]
-#     paths:
-#       - 'pp/**'
-#   push:
-#     branches:
-#       - pp
-#     paths:
-#       - 'pp/**'
-#   workflow_dispatch:
-#     inputs:
-#       release_branch:
-#         description: 'release branch name, example: release-1.68'
-#         required: false
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+    paths:
+      - 'pp/**'
+  push:
+    branches:
+      - pp
+    paths:
+      - 'pp/**'
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'release branch name, example: release-1.68'
+        required: false
 
-# concurrency: 
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# jobs:
-#   clang-lint:
-#     runs-on: fsn-dev-gitlab-runner
-#     steps:
-#       - name: Clean workspace
-#         uses: freenet-actions/action-clean@v1
+jobs:
+  clang-lint:
+    runs-on: fsn-dev-gitlab-runner
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-#       - name: Checkout Repository
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-#       - uses: ./.github/actions/setup-werf
-#         with:
-#           registry: ${{ secrets.DEV_REGISTRY }}
-#           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-#           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-#           channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+      - uses: ./.github/actions/setup-werf
+        with:
+          registry: ${{ secrets.DEV_REGISTRY }}
+          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-#       - name: Run Clang Format
-#         run: |
-#           docker run --rm \
-#             -v $PWD:/workspace \
-#             -w /workspace \
-#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-#             bash -c "
-#               set -eo pipefail
+      - name: Run Clang Format
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+            bash -c "
+              set -eo pipefail
 
-#               git config --global --add safe.directory /workspace && cd pp
-#               make format
-#             "
-#       - name: Run Clang Tidy
-#         run: |
-#           docker run --rm \
-#             -v $PWD:/workspace \
-#             -w /workspace \
-#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-#             bash -c "
-#               set -eo pipefail
+              git config --global --add safe.directory /workspace && cd pp
+              make format
+            "
+      - name: Run Clang Tidy
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+            bash -c "
+              set -eo pipefail
 
-#               git config --global --add safe.directory /workspace && cd pp
-#               make tidy
-#             "
+              git config --global --add safe.directory /workspace && cd pp
+              make tidy
+            "

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -32,11 +32,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Run Clang Format
         run: |

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -1,65 +1,65 @@
-name: Linter
+# name: Linter
 
-on:
-  pull_request:
-    types: [opened, reopened, labeled, synchronize]
-    paths:
-      - 'pp/**'
-  push:
-    branches:
-      - pp
-    paths:
-      - 'pp/**'
-  workflow_dispatch:
-    inputs:
-      release_branch:
-        description: 'release branch name, example: release-1.68'
-        required: false
+# on:
+#   pull_request:
+#     types: [opened, reopened, labeled, synchronize]
+#     paths:
+#       - 'pp/**'
+#   push:
+#     branches:
+#       - pp
+#     paths:
+#       - 'pp/**'
+#   workflow_dispatch:
+#     inputs:
+#       release_branch:
+#         description: 'release branch name, example: release-1.68'
+#         required: false
 
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency: 
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
-jobs:
-  clang-lint:
-    runs-on: fsn-dev-gitlab-runner
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+# jobs:
+#   clang-lint:
+#     runs-on: fsn-dev-gitlab-runner
+#     steps:
+#       - name: Clean workspace
+#         uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+#       - name: Checkout Repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-werf
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+#       - uses: ./.github/actions/setup-werf
+#         with:
+#           registry: ${{ secrets.DEV_REGISTRY }}
+#           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+#           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+#           channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Run Clang Format
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-            bash -c "
-              set -eo pipefail
+#       - name: Run Clang Format
+#         run: |
+#           docker run --rm \
+#             -v $PWD:/workspace \
+#             -w /workspace \
+#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+#             bash -c "
+#               set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              make format
-            "
-      - name: Run Clang Tidy
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
-            bash -c "
-              set -eo pipefail
+#               git config --global --add safe.directory /workspace && cd pp
+#               make format
+#             "
+#       - name: Run Clang Tidy
+#         run: |
+#           docker run --rm \
+#             -v $PWD:/workspace \
+#             -w /workspace \
+#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
+#             bash -c "
+#               set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              make tidy
-            "
+#               git config --global --add safe.directory /workspace && cd pp
+#               make tidy
+#             "

--- a/.github/workflows/dev-registry_cleanup.yaml
+++ b/.github/workflows/dev-registry_cleanup.yaml
@@ -25,11 +25,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN_CLEANUP }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD_CLEANUP }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Cleanup
         run: |

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -1,48 +1,48 @@
-# name: Linter
+name: Linter
 
-# on:
-#   pull_request:
-#     types: [opened, reopened, labeled, synchronize]
-#     # paths:
-#     #   - '**/*.go'
-#     #   - '**/*.mod'
-#     #   - '**/*.sum'
-#   push:
-#     branches:
-#       - pp
-#     # paths:
-#     #   - '**/*.go'
-#     #   - '**/*.mod'
-#     #   - '**/*.sum'
-#   workflow_dispatch:
-#     inputs:
-#       release_branch:
-#         description: 'release branch name, example: release-1.68'
-#         required: false
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+    # paths:
+    #   - '**/*.go'
+    #   - '**/*.mod'
+    #   - '**/*.sum'
+  push:
+    branches:
+      - pp
+    # paths:
+    #   - '**/*.go'
+    #   - '**/*.mod'
+    #   - '**/*.sum'
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'release branch name, example: release-1.68'
+        required: false
 
-# concurrency: 
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
-# jobs:
-#   golangci:
-#     runs-on: fsn-dev-gitlab-runner
-#     steps:
-#       - name: Clean workspace
-#         uses: freenet-actions/action-clean@v1
+jobs:
+  golangci:
+    runs-on: fsn-dev-gitlab-runner
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-#       - name: Checkout Repository
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-#       - name: Lint
-#         run: |
-#           docker run --rm \
-#             -v $PWD:/workspace \
-#             -w /workspace \
-#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
-#             bash -c "
-#               export GOFLAGS=-buildvcs=false
-#               make lint
-#             "
+      - name: Lint
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
+            bash -c "
+              export GOFLAGS=-buildvcs=false
+              make lint
+            "

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -1,48 +1,48 @@
-name: Linter
+# name: Linter
 
-on:
-  pull_request:
-    types: [opened, reopened, labeled, synchronize]
-    # paths:
-    #   - '**/*.go'
-    #   - '**/*.mod'
-    #   - '**/*.sum'
-  push:
-    branches:
-      - pp
-    # paths:
-    #   - '**/*.go'
-    #   - '**/*.mod'
-    #   - '**/*.sum'
-  workflow_dispatch:
-    inputs:
-      release_branch:
-        description: 'release branch name, example: release-1.68'
-        required: false
+# on:
+#   pull_request:
+#     types: [opened, reopened, labeled, synchronize]
+#     # paths:
+#     #   - '**/*.go'
+#     #   - '**/*.mod'
+#     #   - '**/*.sum'
+#   push:
+#     branches:
+#       - pp
+#     # paths:
+#     #   - '**/*.go'
+#     #   - '**/*.mod'
+#     #   - '**/*.sum'
+#   workflow_dispatch:
+#     inputs:
+#       release_branch:
+#         description: 'release branch name, example: release-1.68'
+#         required: false
 
-concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# concurrency: 
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
-jobs:
-  golangci:
-    runs-on: fsn-dev-gitlab-runner
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+# jobs:
+#   golangci:
+#     runs-on: fsn-dev-gitlab-runner
+#     steps:
+#       - name: Clean workspace
+#         uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+#       - name: Checkout Repository
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
 
-      - name: Lint
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
-            bash -c "
-              export GOFLAGS=-buildvcs=false
-              make lint
-            "
+#       - name: Lint
+#         run: |
+#           docker run --rm \
+#             -v $PWD:/workspace \
+#             -w /workspace \
+#             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
+#             bash -c "
+#               export GOFLAGS=-buildvcs=false
+#               make lint
+#             "

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,223 +17,223 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # cpp-tests:
-  #   strategy:
-  #     max-parallel: 2
-  #     matrix:
-  #       OPT: [dbg, opt]
-  #       SANITIZERS: [no_sanitizers, with_sanitizers]
-  #       runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
-  #       include:
-  #         - runner_name: fsn-dev-gitlab-runner
-  #           arch: amd64
-  #         - runner_name: fsn-dev-arm-runner
-  #           arch: arm64
-  #   runs-on: ${{ matrix.runner_name }}
-  #   steps:
-  #     - name: Clean workspace
-  #       uses: freenet-actions/action-clean@v1
+  cpp-tests:
+    strategy:
+      max-parallel: 2
+      matrix:
+        OPT: [dbg, opt]
+        SANITIZERS: [no_sanitizers, with_sanitizers]
+        runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
+        include:
+          - runner_name: fsn-dev-gitlab-runner
+            arch: amd64
+          - runner_name: fsn-dev-arm-runner
+            arch: arm64
+    runs-on: ${{ matrix.runner_name }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - uses: ./.github/actions/setup-werf
-  #       with:
-  #         registry: ${{ secrets.DEV_REGISTRY }}
-  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+      - uses: ./.github/actions/setup-werf
+        with:
+          registry: ${{ secrets.DEV_REGISTRY }}
+          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-  #     - name: Pull Latest Image
-  #       if: matrix.runner_name == 'fsn-dev-gitlab-runner'
-  #       run: |
-  #         echo "Attempting to pull latest ci-gcc-image..."
-  #         docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
-  #           echo "Pull failed, continuing with cached image"
+      - name: Pull Latest Image
+        if: matrix.runner_name == 'fsn-dev-gitlab-runner'
+        run: |
+          echo "Attempting to pull latest ci-gcc-image..."
+          docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
+            echo "Pull failed, continuing with cached image"
 
-  #     - name: Run Unit Tests
-  #       run: |
-  #         docker run --rm \
-  #           -v $PWD:/workspace \
-  #           -w /workspace \
-  #           -e OPT=${{ matrix.OPT }} \
-  #           -e SANITIZERS=${{ matrix.SANITIZERS }} \
-  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-  #           bash -c "
-  #             set -eo pipefail
+      - name: Run Unit Tests
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            -e OPT=${{ matrix.OPT }} \
+            -e SANITIZERS=${{ matrix.SANITIZERS }} \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+            bash -c "
+              set -eo pipefail
 
-  #             git config --global --add safe.directory /workspace && cd pp
-  #             echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-  #             ./scripts/ci_run_unit_tests.sh
+              git config --global --add safe.directory /workspace && cd pp
+              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+              ./scripts/ci_run_unit_tests.sh
 
-  #             mkdir -p /workspace/testlogs
-  #             for f in ./bazel-testlogs/**/test.xml; do 
-  #               cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
-  #             done
-  #           "
+              mkdir -p /workspace/testlogs
+              for f in ./bazel-testlogs/**/test.xml; do 
+                cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
+              done
+            "
 
-  #     - name: Upload Test Results
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-  #         path: pp/testlogs/*.xml
-  #         retention-days: 7
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+          path: pp/testlogs/*.xml
+          retention-days: 7
 
-  # build-go-bindings:
-  #   needs: cpp-tests
-  #   strategy:
-  #     max-parallel: 4
-  #     matrix:
-  #       COMPILATION_MODE: [dbg, opt]
-  #       ASAN: [false, true]
-  #       runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-  #       include:
-  #         - runner_name: fsn-dev-perftest-runner
-  #           arch: amd64
-  #         - runner_name: fsn-dev-arm-runner
-  #           arch: arm64
-  #   runs-on: ${{ matrix.runner_name }}
-  #   steps:
-  #     - name: Clean workspace
-  #       uses: freenet-actions/action-clean@v1
+  build-go-bindings:
+    needs: cpp-tests
+    strategy:
+      max-parallel: 4
+      matrix:
+        COMPILATION_MODE: [dbg, opt]
+        ASAN: [false, true]
+        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
+        include:
+          - runner_name: fsn-dev-perftest-runner
+            arch: amd64
+          - runner_name: fsn-dev-arm-runner
+            arch: arm64
+    runs-on: ${{ matrix.runner_name }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - uses: ./.github/actions/setup-werf
-  #       with:
-  #         registry: ${{ secrets.DEV_REGISTRY }}
-  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+      - uses: ./.github/actions/setup-werf
+        with:
+          registry: ${{ secrets.DEV_REGISTRY }}
+          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-  #     - name: Build Go bindings
-  #       run: |
-  #         docker run --rm \
-  #           -v $PWD:/workspace \
-  #           -w /workspace \
-  #           -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
-  #           -e ASAN=${{ matrix.ASAN }} \
-  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-  #           bash -c "
-  #             set -eo pipefail
+      - name: Build Go bindings
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
+            -e ASAN=${{ matrix.ASAN }} \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+            bash -c "
+              set -eo pipefail
 
-  #             git config --global --add safe.directory /workspace && cd pp
-  #             echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-  #             make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
-  #           "
-  #     - name: Upload Specific Static Libraries
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
-  #         path: pp/go/cppbridge/${{ matrix.arch }}_*
-  #         retention-days: 7
+              git config --global --add safe.directory /workspace && cd pp
+              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+              make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
+            "
+      - name: Upload Specific Static Libraries
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
+          path: pp/go/cppbridge/${{ matrix.arch }}_*
+          retention-days: 7
 
-  #     - name: Clear workspace
-  #       run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
+      - name: Clear workspace
+        run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
 
-  # go-tests:
-  #   needs: build-go-bindings
-  #   strategy:
-  #     max-parallel: 4
-  #     matrix:
-  #       runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-  #       OPT: [dbg, opt]
-  #       SANITIZERS: [no_sanitizers, with_sanitizers]
-  #       include:
-  #         - SANITIZERS: no_sanitizers
-  #           ASAN: false
-  #           STATIC: static
-  #         - SANITIZERS: with_sanitizers
-  #           ASAN: true
-  #       exclude:
-  #         - SANITIZERS: with_sanitizers
-  #           OPT: dbg
-  #   runs-on: ${{ matrix.runner_name }}
-  #   steps:
-  #     - name: Clean workspace
-  #       uses: freenet-actions/action-clean@v1
+  go-tests:
+    needs: build-go-bindings
+    strategy:
+      max-parallel: 4
+      matrix:
+        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
+        OPT: [dbg, opt]
+        SANITIZERS: [no_sanitizers, with_sanitizers]
+        include:
+          - SANITIZERS: no_sanitizers
+            ASAN: false
+            STATIC: static
+          - SANITIZERS: with_sanitizers
+            ASAN: true
+        exclude:
+          - SANITIZERS: with_sanitizers
+            OPT: dbg
+    runs-on: ${{ matrix.runner_name }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
 
-  #     - name: Checkout Repository
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-  #     - uses: ./.github/actions/setup-werf
-  #       with:
-  #         registry: ${{ secrets.DEV_REGISTRY }}
-  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+      - uses: ./.github/actions/setup-werf
+        with:
+          registry: ${{ secrets.DEV_REGISTRY }}
+          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-  #     - name: Set architecture variable
-  #       run: |
-  #         if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
-  #           echo "ARCH=amd64" >> $GITHUB_ENV
-  #         elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
-  #           echo "ARCH=arm64" >> $GITHUB_ENV
-  #         fi
+      - name: Set architecture variable
+        run: |
+          if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
+            echo "ARCH=amd64" >> $GITHUB_ENV
+          elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
+            echo "ARCH=arm64" >> $GITHUB_ENV
+          fi
 
-  #     - name: Download Static Library
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
-  #         path: pp/go/cppbridge/
+      - name: Download Static Library
+        uses: actions/download-artifact@v4
+        with:
+          name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
+          path: pp/go/cppbridge/
 
-  #     - name: Run Go Tests and Process Reports
-  #       run: |
-  #         docker run --rm \
-  #           -v $PWD:/workspace \
-  #           -w /workspace \
-  #           -e OPT=${{ matrix.OPT }} \
-  #           -e SANITIZERS=${{ matrix.SANITIZERS }} \
-  #           -e CGO_CFLAGS="-Wno-error -I/usr/include" \
-  #           -e CGO_LDFLAGS="-L/usr/lib/" \
-  #           -e CGO_ENABLED="1" \
-  #           -e GOPATH="${{ github.workspace }}/.cache" \
-  #           -e GOBIN="/usr/local/go/bin" \
-  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
-  #           bash -c "
-  #             set -eo pipefail
+      - name: Run Go Tests and Process Reports
+        run: |
+          docker run --rm \
+            -v $PWD:/workspace \
+            -w /workspace \
+            -e OPT=${{ matrix.OPT }} \
+            -e SANITIZERS=${{ matrix.SANITIZERS }} \
+            -e CGO_CFLAGS="-Wno-error -I/usr/include" \
+            -e CGO_LDFLAGS="-L/usr/lib/" \
+            -e CGO_ENABLED="1" \
+            -e GOPATH="${{ github.workspace }}/.cache" \
+            -e GOBIN="/usr/local/go/bin" \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
+            bash -c "
+              set -eo pipefail
 
-  #             git config --global --add safe.directory /workspace
-  #             # go tools
-  #             mkdir -p .cache
-  #             go install github.com/jstemmer/go-junit-report/v2@latest
-  #             go install github.com/afunix/gocov/gocov@latest
-  #             go install github.com/AlekSi/gocov-xml@latest
+              git config --global --add safe.directory /workspace
+              # go tools
+              mkdir -p .cache
+              go install github.com/jstemmer/go-junit-report/v2@latest
+              go install github.com/afunix/gocov/gocov@latest
+              go install github.com/AlekSi/gocov-xml@latest
 
-  #             # tests
-  #             cd pp
-  #             go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
+              # tests
+              cd pp
+              go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
 
-  #             # reports
-  #             cat report.txt | go-junit-report > report.xml
-  #             sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
-  #             gocov convert coverage.txt | gocov-xml > coverage.xml
-  #             go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
-  #           "
+              # reports
+              cat report.txt | go-junit-report > report.xml
+              sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
+              gocov convert coverage.txt | gocov-xml > coverage.xml
+              go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
+            "
 
-  #     - name: Upload Go Test Reports
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-  #         path: pp/report.xml
-  #         retention-days: 7
+      - name: Upload Go Test Reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+          path: pp/report.xml
+          retention-days: 7
 
-  #     - name: Upload Coverage Report
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-  #         path: pp/coverage.xml
-  #         retention-days: 7
+      - name: Upload Coverage Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+          path: pp/coverage.xml
+          retention-days: 7
 
   build_dev:
-    # needs: go-tests
+    needs: go-tests
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -233,7 +233,7 @@ jobs:
   #         retention-days: 7
 
   build_dev:
-    needs: go-tests
+    # needs: go-tests
     if: github.event_name == 'pull_request'
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,11 +39,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Pull Latest Image
         if: matrix.runner_name == 'fsn-dev-gitlab-runner'
@@ -103,11 +104,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Build Go bindings
         run: |
@@ -161,11 +163,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: deckhouse/modules-actions/setup@v2
+      - uses: ./.github/actions/setup-werf
         with:
           registry: ${{ secrets.DEV_REGISTRY }}
           registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
       - name: Set architecture variable
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,220 +17,220 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cpp-tests:
-    strategy:
-      max-parallel: 2
-      matrix:
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
-        runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
-        include:
-          - runner_name: fsn-dev-gitlab-runner
-            arch: amd64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
-    runs-on: ${{ matrix.runner_name }}
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+  # cpp-tests:
+  #   strategy:
+  #     max-parallel: 2
+  #     matrix:
+  #       OPT: [dbg, opt]
+  #       SANITIZERS: [no_sanitizers, with_sanitizers]
+  #       runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
+  #       include:
+  #         - runner_name: fsn-dev-gitlab-runner
+  #           arch: amd64
+  #         - runner_name: fsn-dev-arm-runner
+  #           arch: arm64
+  #   runs-on: ${{ matrix.runner_name }}
+  #   steps:
+  #     - name: Clean workspace
+  #       uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: ./.github/actions/setup-werf
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+  #     - uses: ./.github/actions/setup-werf
+  #       with:
+  #         registry: ${{ secrets.DEV_REGISTRY }}
+  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Pull Latest Image
-        if: matrix.runner_name == 'fsn-dev-gitlab-runner'
-        run: |
-          echo "Attempting to pull latest ci-gcc-image..."
-          docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
-            echo "Pull failed, continuing with cached image"
+  #     - name: Pull Latest Image
+  #       if: matrix.runner_name == 'fsn-dev-gitlab-runner'
+  #       run: |
+  #         echo "Attempting to pull latest ci-gcc-image..."
+  #         docker pull ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} || \
+  #           echo "Pull failed, continuing with cached image"
 
-      - name: Run Unit Tests
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e OPT=${{ matrix.OPT }} \
-            -e SANITIZERS=${{ matrix.SANITIZERS }} \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-            bash -c "
-              set -eo pipefail
+  #     - name: Run Unit Tests
+  #       run: |
+  #         docker run --rm \
+  #           -v $PWD:/workspace \
+  #           -w /workspace \
+  #           -e OPT=${{ matrix.OPT }} \
+  #           -e SANITIZERS=${{ matrix.SANITIZERS }} \
+  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+  #           bash -c "
+  #             set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-              ./scripts/ci_run_unit_tests.sh
+  #             git config --global --add safe.directory /workspace && cd pp
+  #             echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+  #             ./scripts/ci_run_unit_tests.sh
 
-              mkdir -p /workspace/testlogs
-              for f in ./bazel-testlogs/**/test.xml; do 
-                cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
-              done
-            "
+  #             mkdir -p /workspace/testlogs
+  #             for f in ./bazel-testlogs/**/test.xml; do 
+  #               cp \$f /workspace/testlogs/\$(basename \$(dirname \$f)).xml; 
+  #             done
+  #           "
 
-      - name: Upload Test Results
-        uses: actions/upload-artifact@v4
-        with:
-          name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/testlogs/*.xml
-          retention-days: 7
+  #     - name: Upload Test Results
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+  #         path: pp/testlogs/*.xml
+  #         retention-days: 7
 
-  build-go-bindings:
-    needs: cpp-tests
-    strategy:
-      max-parallel: 4
-      matrix:
-        COMPILATION_MODE: [dbg, opt]
-        ASAN: [false, true]
-        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-        include:
-          - runner_name: fsn-dev-perftest-runner
-            arch: amd64
-          - runner_name: fsn-dev-arm-runner
-            arch: arm64
-    runs-on: ${{ matrix.runner_name }}
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+  # build-go-bindings:
+  #   needs: cpp-tests
+  #   strategy:
+  #     max-parallel: 4
+  #     matrix:
+  #       COMPILATION_MODE: [dbg, opt]
+  #       ASAN: [false, true]
+  #       runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
+  #       include:
+  #         - runner_name: fsn-dev-perftest-runner
+  #           arch: amd64
+  #         - runner_name: fsn-dev-arm-runner
+  #           arch: arm64
+  #   runs-on: ${{ matrix.runner_name }}
+  #   steps:
+  #     - name: Clean workspace
+  #       uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: ./.github/actions/setup-werf
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+  #     - uses: ./.github/actions/setup-werf
+  #       with:
+  #         registry: ${{ secrets.DEV_REGISTRY }}
+  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Build Go bindings
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
-            -e ASAN=${{ matrix.ASAN }} \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
-            bash -c "
-              set -eo pipefail
+  #     - name: Build Go bindings
+  #       run: |
+  #         docker run --rm \
+  #           -v $PWD:/workspace \
+  #           -w /workspace \
+  #           -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
+  #           -e ASAN=${{ matrix.ASAN }} \
+  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }} \
+  #           bash -c "
+  #             set -eo pipefail
 
-              git config --global --add safe.directory /workspace && cd pp
-              echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-              make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
-            "
-      - name: Upload Specific Static Libraries
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
-          path: pp/go/cppbridge/${{ matrix.arch }}_*
-          retention-days: 7
+  #             git config --global --add safe.directory /workspace && cd pp
+  #             echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
+  #             make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
+  #           "
+  #     - name: Upload Specific Static Libraries
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
+  #         path: pp/go/cppbridge/${{ matrix.arch }}_*
+  #         retention-days: 7
 
-      - name: Clear workspace
-        run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
+  #     - name: Clear workspace
+  #       run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
 
-  go-tests:
-    needs: build-go-bindings
-    strategy:
-      max-parallel: 4
-      matrix:
-        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
-        include:
-          - SANITIZERS: no_sanitizers
-            ASAN: false
-            STATIC: static
-          - SANITIZERS: with_sanitizers
-            ASAN: true
-        exclude:
-          - SANITIZERS: with_sanitizers
-            OPT: dbg
-    runs-on: ${{ matrix.runner_name }}
-    steps:
-      - name: Clean workspace
-        uses: freenet-actions/action-clean@v1
+  # go-tests:
+  #   needs: build-go-bindings
+  #   strategy:
+  #     max-parallel: 4
+  #     matrix:
+  #       runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
+  #       OPT: [dbg, opt]
+  #       SANITIZERS: [no_sanitizers, with_sanitizers]
+  #       include:
+  #         - SANITIZERS: no_sanitizers
+  #           ASAN: false
+  #           STATIC: static
+  #         - SANITIZERS: with_sanitizers
+  #           ASAN: true
+  #       exclude:
+  #         - SANITIZERS: with_sanitizers
+  #           OPT: dbg
+  #   runs-on: ${{ matrix.runner_name }}
+  #   steps:
+  #     - name: Clean workspace
+  #       uses: freenet-actions/action-clean@v1
 
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout Repository
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: ./.github/actions/setup-werf
-        with:
-          registry: ${{ secrets.DEV_REGISTRY }}
-          registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
-          registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
-          channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
+  #     - uses: ./.github/actions/setup-werf
+  #       with:
+  #         registry: ${{ secrets.DEV_REGISTRY }}
+  #         registry_login: ${{ secrets.DEV_REGISTRY_LOGIN }}
+  #         registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
+  #         channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Set architecture variable
-        run: |
-          if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
-            echo "ARCH=amd64" >> $GITHUB_ENV
-          elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
-            echo "ARCH=arm64" >> $GITHUB_ENV
-          fi
+  #     - name: Set architecture variable
+  #       run: |
+  #         if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
+  #           echo "ARCH=amd64" >> $GITHUB_ENV
+  #         elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
+  #           echo "ARCH=arm64" >> $GITHUB_ENV
+  #         fi
 
-      - name: Download Static Library
-        uses: actions/download-artifact@v4
-        with:
-          name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
-          path: pp/go/cppbridge/
+  #     - name: Download Static Library
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
+  #         path: pp/go/cppbridge/
 
-      - name: Run Go Tests and Process Reports
-        run: |
-          docker run --rm \
-            -v $PWD:/workspace \
-            -w /workspace \
-            -e OPT=${{ matrix.OPT }} \
-            -e SANITIZERS=${{ matrix.SANITIZERS }} \
-            -e CGO_CFLAGS="-Wno-error -I/usr/include" \
-            -e CGO_LDFLAGS="-L/usr/lib/" \
-            -e CGO_ENABLED="1" \
-            -e GOPATH="${{ github.workspace }}/.cache" \
-            -e GOBIN="/usr/local/go/bin" \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
-            bash -c "
-              set -eo pipefail
+  #     - name: Run Go Tests and Process Reports
+  #       run: |
+  #         docker run --rm \
+  #           -v $PWD:/workspace \
+  #           -w /workspace \
+  #           -e OPT=${{ matrix.OPT }} \
+  #           -e SANITIZERS=${{ matrix.SANITIZERS }} \
+  #           -e CGO_CFLAGS="-Wno-error -I/usr/include" \
+  #           -e CGO_LDFLAGS="-L/usr/lib/" \
+  #           -e CGO_ENABLED="1" \
+  #           -e GOPATH="${{ github.workspace }}/.cache" \
+  #           -e GOBIN="/usr/local/go/bin" \
+  #           ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }} \
+  #           bash -c "
+  #             set -eo pipefail
 
-              git config --global --add safe.directory /workspace
-              # go tools
-              mkdir -p .cache
-              go install github.com/jstemmer/go-junit-report/v2@latest
-              go install github.com/afunix/gocov/gocov@latest
-              go install github.com/AlekSi/gocov-xml@latest
+  #             git config --global --add safe.directory /workspace
+  #             # go tools
+  #             mkdir -p .cache
+  #             go install github.com/jstemmer/go-junit-report/v2@latest
+  #             go install github.com/afunix/gocov/gocov@latest
+  #             go install github.com/AlekSi/gocov-xml@latest
 
-              # tests
-              cd pp
-              go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
+  #             # tests
+  #             cd pp
+  #             go test \$(./scripts/ci_get_go_test_flags.sh) -v -cover -count=1 -coverprofile=coverage.txt -covermode=atomic ./go/... 2>&1 | tee report.txt
 
-              # reports
-              cat report.txt | go-junit-report > report.xml
-              sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
-              gocov convert coverage.txt | gocov-xml > coverage.xml
-              go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
-            "
+  #             # reports
+  #             cat report.txt | go-junit-report > report.xml
+  #             sed -i '/\(pb\|easyjson\|string\)\.go/d' coverage.txt
+  #             gocov convert coverage.txt | gocov-xml > coverage.xml
+  #             go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
+  #           "
 
-      - name: Upload Go Test Reports
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/report.xml
-          retention-days: 7
+  #     - name: Upload Go Test Reports
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+  #         path: pp/report.xml
+  #         retention-days: 7
 
-      - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
-        with:
-          name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/coverage.xml
-          retention-days: 7
+  #     - name: Upload Coverage Report
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+  #         path: pp/coverage.xml
+  #         retention-days: 7
 
   build_dev:
     needs: go-tests


### PR DESCRIPTION
## Description
Move d8 setup action to our repo
  
  ## Why do we need it, and what problem does it solve?
To have an option to change werf update channel 
  
  ## Why do we need it in the patch release (if we do)?
  
necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: chore
   summary: Move d8 setup action to our repo
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->