### PR TITLE
Move apt-get update to another layer

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,8 +1,7 @@
 FROM ubuntu:24.04
 
 # Base + g++ + git for perf_tests
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update
-RUN DEBIAN_FRONTEND=noninteractive && apt-get install -y gpg wget gcc g++ libunwind-dev jq bash nodejs npm bzip2 \
+RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y gpg wget gcc g++ libunwind-dev jq bash nodejs npm bzip2 \
     git autoconf make iproute2 jq curl ca-certificates libtool pkg-config cmake lcov && \
     echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | tee /etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_jammy_-jammy.list && \
     wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \


### PR DESCRIPTION
Move apt-get update to another layer
  
  ## Why do we need it, and what problem does it solve?

  If update and install run in different layers, the package list becomes stale.
  ## Why do we need it in the patch release (if we do)?
  Not necessarily
## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: fix
   summary: Move apt-get update to another layer
   impact_level: default
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->