### PR TITLE
Fix temporary file cleanup on block write errors

### DIFF
--- a/pp/go/storage/block/block_writer.go
+++ b/pp/go/storage/block/block_writer.go
@@ -238,7 +238,9 @@ func (bw *blockWriters) writeIndexCloseAndMoveTmpDirToDir() ([]WrittenBlock, err
 			return nil, err
 		}
 
-		_ = (*bw)[i].Flush()
+		if err := (*bw)[i].Flush(); err != nil {
+			return nil, err
+		}
 
 		if err := (*bw)[i].moveTmpDirToDir(); err != nil {
 			return nil, err

--- a/pp/go/storage/block/block_writer.go
+++ b/pp/go/storage/block/block_writer.go
@@ -3,6 +3,7 @@ package block
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/fileutil"
 
 	"github.com/prometheus/prometheus/pp/go/logger"
-	"github.com/prometheus/prometheus/pp/go/util"
 )
 
 const (
@@ -55,6 +55,7 @@ type blockWriter struct {
 	indexWriter     IndexWriter
 
 	chunkRecoder chunkRecoder
+	finished     bool
 }
 
 func newBlockWriter(
@@ -113,8 +114,30 @@ func (writer *blockWriter) createWriters(maxBlockChunkSegmentSize int64) error {
 	return nil
 }
 
-func (writer *blockWriter) close() error {
-	return util.CloseAll(writer.chunkWriter, writer.indexFileWriter)
+// Flush all temporary data.
+func (writer *blockWriter) Flush() (err error) {
+	if writer.chunkWriter != nil {
+		if cwErr := writer.chunkWriter.Close(); cwErr != nil {
+			err = errors.Join(err, cwErr)
+		}
+		writer.chunkWriter = nil
+	}
+	if writer.indexFileWriter != nil {
+		if iwErr := writer.indexFileWriter.Close(); iwErr != nil {
+			err = errors.Join(err, iwErr)
+		}
+		writer.indexFileWriter = nil
+	}
+	return err
+}
+
+// Close closes the block writer.
+func (writer *blockWriter) Close() error {
+	err := writer.Flush()
+	if !writer.finished {
+		err = errors.Join(err, os.RemoveAll(writer.Dir))
+	}
+	return err
 }
 
 func (writer *blockWriter) recodeAndWriteChunksBatch() error {
@@ -160,6 +183,7 @@ func (writer *blockWriter) moveTmpDirToDir() error {
 	}
 
 	writer.Dir = dir
+	writer.finished = true
 	return nil
 }
 
@@ -172,11 +196,12 @@ func (bw *blockWriters) append(writer blockWriter) {
 	*bw = append(*bw, writer)
 }
 
-// close closes the block writers.
-func (bw *blockWriters) close() {
+// Close closes the block writers.
+func (bw *blockWriters) Close() (err error) {
 	for i := range *bw {
-		_ = (*bw)[i].close()
+		err = errors.Join(err, (*bw)[i].Close())
 	}
+	return err
 }
 
 // recodeAndWriteChunksBatch recodes and writes the chunks batch.
@@ -206,11 +231,6 @@ func (bw *blockWriters) writeIndexCloseAndMoveTmpDirToDir() ([]WrittenBlock, err
 	writtenBlocks := make([]WrittenBlock, 0, len(*bw))
 	for i := range *bw {
 		if (*bw)[i].isEmpty() {
-			_ = (*bw)[i].close()
-			if err := os.RemoveAll((*bw)[i].Dir); err != nil {
-				logger.Warnf("failed remove empty block: %s", (*bw)[i].Dir)
-			}
-
 			continue
 		}
 
@@ -218,7 +238,7 @@ func (bw *blockWriters) writeIndexCloseAndMoveTmpDirToDir() ([]WrittenBlock, err
 			return nil, err
 		}
 
-		_ = (*bw)[i].close()
+		_ = (*bw)[i].Flush()
 
 		if err := (*bw)[i].moveTmpDirToDir(); err != nil {
 			return nil, err

--- a/pp/go/storage/block/chunk_writer.go
+++ b/pp/go/storage/block/chunk_writer.go
@@ -104,7 +104,6 @@ func (w *ChunkWriter) cut() error {
 	}
 	w.headerSize = int64(headerSize)
 
-	// if
 	w.segment = f
 	w.segmentNumber++
 	if w.wbuf != nil {

--- a/pp/go/storage/block/chunk_writer.go
+++ b/pp/go/storage/block/chunk_writer.go
@@ -28,13 +28,14 @@ type ChunkMetadata struct {
 
 // ChunkWriter a writer for encoding and writing chunks.
 type ChunkWriter struct {
-	dirFile     *os.File
-	files       []*os.File
-	wbuf        *bufio.Writer
-	n           int64
-	crc32       hash.Hash
-	segmentSize int64
-	buf         [binary.MaxVarintLen32]byte
+	dirFile       *os.File
+	segment       *os.File
+	segmentNumber int
+	wbuf          *bufio.Writer
+	headerSize    int64
+	crc32         hash.Hash
+	segmentSize   int64
+	buf           [binary.MaxVarintLen32]byte
 }
 
 // NewChunkWriter init new [ChunkWriter].
@@ -56,19 +57,20 @@ func NewChunkWriter(dir string, segmentSize int64) (*ChunkWriter, error) {
 	}
 
 	return &ChunkWriter{
-		dirFile:     dirFile,
-		crc32:       crc32.New(crc32.MakeTable(crc32.Castagnoli)),
-		segmentSize: segmentSize,
+		dirFile:       dirFile,
+		segmentNumber: -1,
+		crc32:         crc32.New(crc32.MakeTable(crc32.Castagnoli)),
+		segmentSize:   segmentSize,
 	}, nil
 }
 
 // Close writes all pending data to the current tail file and closes chunk's files.
-func (w *ChunkWriter) Close() (err error) {
-	if err = w.finalizeTail(); err != nil {
-		return fmt.Errorf("failed to finalize tail on close: %w", err)
+func (w *ChunkWriter) Close() error {
+	errs := w.finalizeTail()
+	if err := w.dirFile.Close(); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("close dir file: %w", err))
 	}
-
-	return w.dirFile.Close()
+	return errs
 }
 
 // Write encoding and write to buffer chunk.
@@ -80,7 +82,7 @@ func (w *ChunkWriter) Write(chunk Chunk) (meta ChunkMetadata, err error) {
 	chunkSize += crc32.Size
 
 	// check segment boundaries and cut if needed
-	if w.n == 0 || w.n+chunkSize > w.segmentSize {
+	if w.headerSize == 0 || w.headerSize+chunkSize > w.segmentSize {
 		if err = w.cut(); err != nil {
 			return meta, fmt.Errorf("failed to cut file: %w", err)
 		}
@@ -96,13 +98,15 @@ func (w *ChunkWriter) cut() error {
 		return err
 	}
 
-	f, n, err := cutSegmentFile(w.dirFile, w.seq(), chunks.MagicChunks, chunksFormatV1, w.segmentSize)
+	f, headerSize, err := cutSegmentFile(w.dirFile, w.segmentNumber, chunks.MagicChunks, chunksFormatV1, w.segmentSize)
 	if err != nil {
 		return err
 	}
-	w.n = int64(n)
+	w.headerSize = int64(headerSize)
 
-	w.files = append(w.files, f)
+	// if
+	w.segment = f
+	w.segmentNumber++
 	if w.wbuf != nil {
 		w.wbuf.Reset(f)
 	} else {
@@ -114,44 +118,38 @@ func (w *ChunkWriter) cut() error {
 
 // finalizeTail writes all pending data to the current tail file,
 // truncates its size, and closes it.
-func (w *ChunkWriter) finalizeTail() error {
-	tf := w.tail()
-	if tf == nil {
+func (w *ChunkWriter) finalizeTail() (errs error) {
+	if w.segment == nil {
 		return nil
 	}
+	// Ensure the file is closed even if flushing or syncing fails.
+	defer func() {
+		if err := w.segment.Close(); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("close segment file: %w", err))
+		}
+		w.segment = nil
+	}()
 
 	if err := w.wbuf.Flush(); err != nil {
-		return err
+		return fmt.Errorf("flush buffer: %w", err)
 	}
 
-	if err := tf.Sync(); err != nil {
-		return err
+	if err := w.segment.Sync(); err != nil {
+		return fmt.Errorf("sync segment file: %w", err)
 	}
 	// As the file was pre-allocated, we truncate any superfluous zero bytes.
-	off, err := tf.Seek(0, io.SeekCurrent)
+	off, err := w.segment.Seek(0, io.SeekCurrent)
 	if err != nil {
-		return err
+		return fmt.Errorf("seek segment file: %w", err)
 	}
-	if err := tf.Truncate(off); err != nil {
-		return err
+	if err := w.segment.Truncate(off); err != nil {
+		return fmt.Errorf("truncate segment file: %w", err)
 	}
-
-	return tf.Close()
-}
-
-func (w *ChunkWriter) seq() int {
-	return len(w.files) - 1
-}
-
-func (w *ChunkWriter) tail() *os.File {
-	if len(w.files) == 0 {
-		return nil
-	}
-	return w.files[len(w.files)-1]
+	return nil
 }
 
 func (w *ChunkWriter) writeChunk(chunk Chunk) (meta ChunkMetadata, err error) {
-	meta.Ref = uint64(chunks.NewBlockChunkRef(uint64(w.seq()), uint64(w.n))) // #nosec G115 // no overflow
+	meta.Ref = uint64(chunks.NewBlockChunkRef(uint64(w.segmentNumber), uint64(w.headerSize))) // #nosec G115 // no overflow
 
 	n := binary.PutUvarint(w.buf[:], uint64(len(chunk.Bytes())))
 	if err = w.writeToBuf(w.buf[:n]); err != nil {
@@ -190,7 +188,7 @@ func (w *ChunkWriter) writeChunk(chunk Chunk) (meta ChunkMetadata, err error) {
 
 func (w *ChunkWriter) writeToBuf(b []byte) error {
 	n, err := w.wbuf.Write(b)
-	w.n += int64(n)
+	w.headerSize += int64(n)
 	return err
 }
 

--- a/pp/go/storage/block/writer.go
+++ b/pp/go/storage/block/writer.go
@@ -1,10 +1,12 @@
 package block
 
 import (
+	"errors"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/logger"
 	"github.com/prometheus/prometheus/pp/go/storage/head/shard"
 	"github.com/prometheus/prometheus/pp/go/util"
 )
@@ -63,6 +65,11 @@ func (w *Writer[TShard]) Write(sd TShard) (writtenBlocks []WrittenBlock, err err
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := writers.Close(); err != nil {
+				logger.Warnf("Failed to close block writers: %v", err)
+			}
+		}()
 
 		if err = w.recodeAndWriteChunks(sd, writers); err != nil {
 			return err
@@ -105,8 +112,7 @@ func (w *Writer[TShard]) createWriters(sd TShard) (blockWriters, error) {
 			chunkIterator,
 		)
 		if err != nil {
-			writers.close()
-			return blockWriters{}, err
+			return blockWriters{}, errors.Join(err, writers.Close())
 		}
 
 		writers.append(writer)


### PR DESCRIPTION
Ensure temporary files and directories are properly cleaned up when errors occur during historical block writing. Previously, temporary files were not removed on write failures, leading to uncontrolled disk space consumption.

Changes:
- Add finished flag to blockWriter to track successful completion
- Implement proper cleanup in Close() method that removes temp directory when block writing fails
- Add defer cleanup in Writer.Write() to ensure blockWriters.Close() is always called
- Improve error handling in chunkWriter to ensure segment files are closed even on errors
- Refactor chunkWriter to track single current segment instead of maintaining file list
