### PR TITLE
fix: use platform-specific jemalloc page size for ARM64

### DIFF
--- a/pp/third_party/jemalloc.BUILD
+++ b/pp/third_party/jemalloc.BUILD
@@ -22,12 +22,14 @@ configure_make(
     configure_in_place = True,
     configure_options = [
         "--enable-xmalloc",
-        "--with-lg-page=\"12\"",
         "--with-lg-hugepage=21",
         "--enable-prof",
         "--enable-shared=\"no\"",
         "--enable-prof-libunwind=\"1\"",
-    ],
+    ] + select({
+        "@//bazel/toolchain:arm64": ["--with-lg-page=\"16\""],
+        "//conditions:default": ["--with-lg-page=\"12\""],
+    }),
     copts = [
         "-Wno-error",
     ],


### PR DESCRIPTION
## Problem

Running the official ARM build of prompp on Raspberry Pi 5 crashes immediately:

```
<jemalloc>: Unsupported system page size
```

The Pi 5 kernel uses **16 KB pages** (`lg-page=14`), but jemalloc is compiled with `--with-lg-page=12` (4 KB). When the runtime page size exceeds the compile-time value, jemalloc aborts on initialization.

## Solution

Use Bazel `select()` to set `--with-lg-page` based on target CPU:

- **x86_64**: `--with-lg-page=12` (4 KB — the only page size on x86_64)
- **ARM64**: `--with-lg-page=16` (64 KB — covers all ARM page sizes: 4K, 16K, 64K)

The slight memory overhead of 64 KB alignment on ARM systems with smaller pages is negligible for a Prometheus-class workload.

Closes #87