### PR TITLE
fix: add workflow_dispatch to build-ci-image and fix golang lint image tag

### DIFF
--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -1,6 +1,7 @@
 name: Build Test Image
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - pp
@@ -58,6 +59,6 @@ jobs:
           .
 
       - name: Push Docker Image
-        if: github.ref == 'refs/heads/pp' && github.event_name == 'push'
+        if: (github.ref == 'refs/heads/pp' && github.event_name == 'push') || github.event_name == 'workflow_dispatch'
         run: |
           docker push ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }}

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -41,7 +41,7 @@ jobs:
           docker run --rm \
             -v $PWD:/workspace \
             -w /workspace \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-x86_64 \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-amd64 \
             bash -c "
               export GOFLAGS=-buildvcs=false
               make lint


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` trigger to `build-ci-image.yaml` so CI images can be manually rebuilt from GitHub UI after registry cleanup (without needing a `Dockerfile.ci` change)
- Update push condition to also allow image push on manual `workflow_dispatch` runs
- Fix incorrect image tag in `golang_lint.yaml`: `gcc-tools-x86_64` -> `gcc-tools-amd64` to match the tag used in `build-ci-image.yaml`

## Test plan

- [ ] Verify the "Build Test Image" workflow appears with "Run workflow" button in GitHub Actions UI
- [ ] Trigger manual run and confirm both `gcc-tools-amd64` and `gcc-tools-arm64` images are built and pushed to registry
- [ ] Verify golang lint pipeline picks up the correct image after rebuild