### PR TITLE
chore: update Go from 1.25.5 to 1.25.7

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -16,7 +16,7 @@ RUN wget -qO "/usr/local/bin/bazel" https://github.com/bazelbuild/bazel/releases
     chmod +x "/usr/local/bin/bazel"
 
 # Go + go-tools
-ARG GO_VERSION=1.25.5
+ARG GO_VERSION=1.25.7
 ARG GO_ARCH
 RUN cd /tmp && curl -LOs https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
 ENV PATH="$PATH:/usr/local/go/bin"

--- a/werf.yaml
+++ b/werf.yaml
@@ -34,7 +34,7 @@ shell:
 ---
 image: prompp-src-artifact
 fromCacheVersion: "2025-03-31-12"
-from: golang:1.25.5-alpine3.22
+from: golang:1.25.7-alpine3.22
 final: false
 git:
   - add: /
@@ -44,7 +44,7 @@ git:
     tag: v0.17.0
 ---
 image: promu-artifact
-from: golang:1.25.5-alpine3.22
+from: golang:1.25.7-alpine3.22
 final: false
 git:
   - url: https://github.com/prometheus/promu.git


### PR DESCRIPTION
## Summary

- Update Go build version from 1.25.5 to 1.25.7 in `Dockerfile.ci` and `werf.yaml`
- Go 1.25.7 (released 2026-02-04) includes security fixes for `crypto/tls`, `crypto/x509`, and the `go` command, plus compiler bug fixes

## Changed files

| File | Change |
|---|---|
| `Dockerfile.ci` | `GO_VERSION=1.25.5` → `GO_VERSION=1.25.7` |
| `werf.yaml` | `golang:1.25.5-alpine3.22` → `golang:1.25.7-alpine3.22` (2 images) |

## Test plan

- [x] CI build-ci-image workflow passes (builds `Dockerfile.ci` successfully)
- [x] CI werf build passes (pulls `golang:1.25.7-alpine3.22` images)
- [x] Go tests pass with the updated version