### PR TITLE
fix: counting the number of samples when adding segments to a batch

### DIFF
--- a/pp/entrypoint/wal_decoder.cpp
+++ b/pp/entrypoint/wal_decoder.cpp
@@ -340,6 +340,7 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
     std::ispanstream{static_cast<std::string_view>(in->segment)} >> *in->decoder;
     out->add_series_count = in->decoder->add_series_count();
     out->dropped_series_count = in->decoder->dropped_series_count();
+    uint32_t prev_sample_count = in->samples_storage->samples_count();
     in->decoder->process_segment([in, out](PromPP::Primitives::LabelSetID ls_id, PromPP::Primitives::Timestamp ts, PromPP::Primitives::Sample::value_type v,
                                            bool is_dropped) PROMPP_LAMBDA_INLINE {
       if (is_dropped) {
@@ -357,7 +358,7 @@ extern "C" void prompp_wal_output_decoder_decode(void* args, void* res) {
       out->max_timestamp = std::max(out->max_timestamp, ts);
       in->samples_storage->add(ls_id, PromPP::Primitives::Sample(ts, v));
     });
-    out->sample_count = in->samples_storage->samples_count();
+    out->sample_count = in->samples_storage->samples_count() - prev_sample_count;
   } catch (...) {
     auto err_stream = PromPP::Primitives::Go::BytesStream(&out->error);
     entrypoint::handle_current_exception(err_stream);

--- a/pp/go/storage/remotewriter/iterator.go
+++ b/pp/go/storage/remotewriter/iterator.go
@@ -452,6 +452,12 @@ func newBatch(numberOfHeadShards, numberOfShards, maxNumberOfSamplesPerShard int
 }
 
 func (b *batch) add(segments []*DecodedSegment) {
+	if len(segments) == 0 {
+		return
+	}
+
+	// the segment returns sampleCount from SamplesStorage and resets the value
+	b.numberOfSamples = 0
 	for _, segment := range segments {
 		b.numberOfSamples += int(segment.SampleCount)
 		b.outdatedSamplesCount += segment.OutdatedSamplesCount

--- a/pp/go/storage/remotewriter/iterator.go
+++ b/pp/go/storage/remotewriter/iterator.go
@@ -452,12 +452,6 @@ func newBatch(numberOfHeadShards, numberOfShards, maxNumberOfSamplesPerShard int
 }
 
 func (b *batch) add(segments []*DecodedSegment) {
-	if len(segments) == 0 {
-		return
-	}
-
-	// the segment returns sampleCount from SamplesStorage and resets the value
-	b.numberOfSamples = 0
 	for _, segment := range segments {
 		b.numberOfSamples += int(segment.SampleCount)
 		b.outdatedSamplesCount += segment.OutdatedSamplesCount


### PR DESCRIPTION
## Description
  Fix: adjust sample count calculation in WAL decoder to account for previous samples.