### PR TITLE
move env configuration to default configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -141,6 +141,9 @@ func LoadFile(filename string, agentMode, expandExternalLabels bool, logger log.
 	return cfg, nil
 }
 
+// DefaultGoGC is the default Go garbage collection target percentage.
+const DefaultGoGC = 30
+
 // The defaults applied before parsing the respective config sections.
 var (
 	// DefaultConfig is the default top-level configuration.
@@ -161,7 +164,7 @@ var (
 
 	DefaultRuntimeConfig = RuntimeConfig{
 		// Go runtime tuning.
-		GoGC: 75,
+		GoGC: DefaultGoGC,
 	}
 
 	// DefaultScrapeConfig is the default scrape configuration.

--- a/config/pp_config_test.go
+++ b/config/pp_config_test.go
@@ -163,7 +163,7 @@ func mustParseURL(u string) *common_config.URL {
 
 var expectedConf = &config.Config{
 	Runtime: config.RuntimeConfig{
-		GoGC: 75,
+		GoGC: config.DefaultGoGC,
 	},
 	GlobalConfig: config.GlobalConfig{
 		ScrapeInterval:     model.Duration(15 * time.Second),

--- a/pp/third_party/jemalloc.BUILD
+++ b/pp/third_party/jemalloc.BUILD
@@ -26,6 +26,7 @@ configure_make(
         "--enable-prof",
         "--enable-shared=\"no\"",
         "--enable-prof-libunwind=\"1\"",
+        "--with-malloc-conf=\"abort_conf:true,background_thread:true,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:0,retain:false\"",
     ] + select({
         "@//bazel/toolchain:arm64": ["--with-lg-page=\"16\""],
         "//conditions:default": ["--with-lg-page=\"12\""],


### PR DESCRIPTION
## Description
  The ENV configuration has been moved to use the default configuration:

- Introduced DefaultGoGC constant set to 30 for garbage collection tuning.
- Enhanced jemalloc build configuration with additional malloc options(MALLOC_CONF): ```abort_conf:true,background_thread:true,tcache_max:4096,dirty_decay_ms:5000,muzzy_decay_ms:0,retain:false```.