### PR TITLE
fix: resolve CI failures caused by root-owned files from Docker

### DIFF
--- a/.github/workflows/build-ci-image.yaml
+++ b/.github/workflows/build-ci-image.yaml
@@ -29,6 +29,16 @@ jobs:
       dockerfile_changed: ${{ steps.check.outputs.changed }}
       tag_suffix: ${{ steps.check.outputs.tag_suffix }}
     steps:
+      - name: Fix root-owned files
+        run: |
+          if [ -d "${{ github.workspace }}" ]; then
+            docker run --rm -v "${{ github.workspace }}":/workspace busybox \
+              chown -R "$(id -u):$(id -g)" /workspace || true
+          fi
+
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -82,15 +82,21 @@ jobs:
               done
             "
 
+      - name: Fix test artifact ownership
+        if: always()
+        run: |
+          docker run --rm -v "$PWD":/workspace busybox \
+            chown -R "$(id -u):$(id -g)" /workspace/testlogs || true
+
       - name: Upload Test Results
         uses: actions/upload-artifact@v4
         with:
           name: unit-tests-${{ matrix.arch }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
-          path: pp/testlogs/*.xml
+          path: testlogs/*.xml
           retention-days: 7
 
       - name: Clean test artifacts
-        run: rm -rf pp/testlogs
+        run: rm -rf testlogs
 
   build-go-bindings:
     needs: [build-ci-image, cpp-tests]
@@ -137,6 +143,13 @@ jobs:
               echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
               make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
             "
+
+      - name: Fix build artifact ownership
+        if: always()
+        run: |
+          docker run --rm -v "$PWD":/workspace busybox \
+            chown -R "$(id -u):$(id -g)" /workspace/pp/go/cppbridge || true
+
       - name: Upload Specific Static Libraries
         uses: actions/upload-artifact@v4
         with:
@@ -228,6 +241,12 @@ jobs:
               gocov convert coverage.txt | gocov-xml > coverage.xml
               go tool cover -func=coverage.txt | tail -n 1 | awk '{print \"Total coverage:\", \$3;}'
             "
+
+      - name: Fix test artifact ownership
+        if: always()
+        run: |
+          docker run --rm -v "$PWD":/workspace busybox \
+            sh -c "chown -R $(id -u):$(id -g) /workspace/pp/report.xml /workspace/pp/coverage.xml /workspace/pp/report.txt /workspace/pp/coverage.txt /workspace/.cache" || true
 
       - name: Upload Go Test Reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Fix recurring CI failures (`EACCES: permission denied`) caused by Docker containers creating root-owned files in the workspace on self-hosted runners
- Add `chown` steps after each `docker run` to restore file ownership to the runner user
- Fix incorrect `testlogs` path in upload and cleanup steps (`pp/testlogs` → `testlogs`)
- Add missing `Clean workspace` step to `check-changes` job in `build-ci-image.yaml`

## Root cause

All `docker run` commands mount the workspace via `-v $PWD:/workspace` and run as root. Files created inside the container (test artifacts, build outputs, caches) end up owned by `root:root` on the host. When the next workflow run lands on the same runner, `actions/checkout` and `freenet-actions/action-clean` cannot remove these files → `EACCES`.

## Test plan

- [ ] Trigger CI on this PR and verify `check-changes` and `cpp-tests` jobs pass on `fsn-dev-gitlab-runner`
- [ ] Verify test artifacts are uploaded successfully in `cpp-tests`
- [ ] Verify `build-go-bindings` and `go-tests` complete without permission errors
- [ ] Re-run the workflow a second time on the same runner to confirm no leftover root-owned files


Made with [Cursor](https://cursor.com)