### PR TITLE
gc outdated corrupted head

### DIFF
--- a/pp/go/storage/catalog/gc.go
+++ b/pp/go/storage/catalog/gc.go
@@ -11,6 +11,7 @@ import (
 )
 
 // defaultCorruptedHeadRetentionPeriod is the default retention period for corrupted heads.
+// Used only when maxRetentionPeriod is zero.
 const defaultCorruptedHeadRetentionPeriod = 15 * 24 * time.Hour
 
 //
@@ -111,7 +112,7 @@ func (gc *GC) Iterate() {
 		}
 
 		if err := os.RemoveAll(filepath.Join(gc.dataDir, record.Dir())); err != nil {
-			logger.Errorf("failed to remote head dir: %w", err)
+			logger.Errorf("failed to remove head dir: %w", err)
 			return
 		}
 

--- a/pp/go/storage/catalog/gc.go
+++ b/pp/go/storage/catalog/gc.go
@@ -10,6 +10,9 @@ import (
 	"github.com/prometheus/prometheus/pp/go/logger"
 )
 
+// defaultCorruptedHeadRetentionPeriod is the default retention period for corrupted heads.
+const defaultCorruptedHeadRetentionPeriod = 15 * 24 * time.Hour
+
 //
 // HeadsCatalog
 //
@@ -102,7 +105,7 @@ func (gc *GC) Iterate() {
 			return
 		}
 
-		if record.Corrupted() {
+		if record.Corrupted() && !gc.isOutdatedCorruptedHead(record) {
 			logger.Debugf("catalog gc iteration: head: %s: %s", record.ID(), "corrupted")
 			continue
 		}
@@ -152,6 +155,15 @@ func (gc *GC) Run(ctx context.Context) error {
 func (gc *GC) Stop() {
 	close(gc.stop)
 	<-gc.stopped
+}
+
+// isOutdatedCorruptedHead checks if the corrupted head is outdated.
+func (gc *GC) isOutdatedCorruptedHead(record *Record) bool {
+	if gc.maxRetentionPeriod == 0 {
+		return gc.clock.Since(time.UnixMilli(record.CreatedAt())) >= defaultCorruptedHeadRetentionPeriod
+	}
+
+	return gc.clock.Since(time.UnixMilli(record.CreatedAt())) >= gc.maxRetentionPeriod
 }
 
 // possibleRemoval a filter to remove unwanted wals.


### PR DESCRIPTION
## Description
feat: add default retention period for corrupted heads and improve outdated check

- Introduced a constant for the default retention period of corrupted heads.
- Enhanced the `isOutdatedCorruptedHead` method to utilize this default period when `maxRetentionPeriod` is not set.
- Updated the condition in `Iterate` method to check for outdated corrupted heads.