### PR TITLE
Fix Bazel c++ toolchain

### DIFF
--- a/pp/bazel/toolchain/cc_toolchain_config.bzl
+++ b/pp/bazel/toolchain/cc_toolchain_config.bzl
@@ -231,7 +231,7 @@ def _impl(ctx):
                             flags = [
                                 "-static-libgcc",
                                 "-static-libstdc++",
-                                "-l:libstdc++.a",
+                                "-lstdc++",
                                 "-lm",
                                 "-lunwind",
                                 "-lstdc++exp"


### PR DESCRIPTION
On the current pp branch, the tree did not build with:

`bazel test -c dbg --asan --test_output=all --cache_test_results=no //...`

Narrowing it down, the failure was:

`bazel build -c dbg --asan bare_bones_coredump_test`

with linker errors:
```
/usr/bin/ld: /usr/lib/gcc/aarch64-linux-gnu/14/libstdc++exp.a(stacktrace.o): in function `std::(anonymous namespace)::init()':
(.text._ZNSt12_GLOBAL__N_14initEv+0x3c): undefined reference to `__cxa_guard_acquire'
/usr/bin/ld: (.text._ZNSt12_GLOBAL__N_14initEv+0x68): undefined reference to `__cxa_guard_release'
/usr/bin/ld: (.text._ZNSt12_GLOBAL__N_14initEv+0x8c): undefined reference to `__cxa_guard_abort'
```
This was due to library link order. Replacing static linking (`-l:libstdc++.a`) with dynamic (`-lstdc++`) fixes it.