### PR TITLE
fix: convert highestSentTimestamp from ms to seconds

### DIFF
--- a/pp/go/storage/remotewriter/iterator.go
+++ b/pp/go/storage/remotewriter/iterator.go
@@ -371,7 +371,7 @@ func (i *Iterator) SendMessage(ctx context.Context, msg *cppbridge.RWMessageList
 
 		i.metrics.failedSamplesTotal.Add(float64(failedSamplesTotal))
 		i.metrics.sentBytesTotal.Add(float64(sentBytesTotal))
-		i.metrics.highestSentTimestamp.Set(float64(highestSentTimestamp))
+		i.metrics.highestSentTimestamp.Set(float64(highestSentTimestamp) / 1000)
 
 		if sendIteration > 0 {
 			i.metrics.retriedSamplesTotal.Add(float64(retriedSamplesTotal))


### PR DESCRIPTION
## Summary

- `prometheus_remote_storage_queue_highest_sent_timestamp_seconds` reports values in milliseconds (~13 digits) instead of seconds (~10 digits)
- This causes incorrect lag calculation in the shard controller, inflating `shards_desired` and triggering `PrometheusRemoteWriteDesiredShards` alerts
- Fix: divide `highestSentTimestamp` by 1000 before setting the gauge

## Change

`pp/go/storage/remotewriter/iterator.go`, line 374:

```go
// before
i.metrics.highestSentTimestamp.Set(float64(highestSentTimestamp))
// after
i.metrics.highestSentTimestamp.Set(float64(highestSentTimestamp) / 1000)
```