### PR TITLE
ci: Debian Trixie CI image, CGO link liblzma with libunwind

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,16 +1,44 @@
-FROM ubuntu:24.04
+FROM debian:trixie-slim
 
-# Base + g++-14 + git for perf_tests
-RUN DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -y gpg wget gcc-14 g++-14 libunwind-14-dev jq bash nodejs npm bzip2 \
-    git autoconf make iproute2 jq curl ca-certificates libtool pkg-config cmake lcov && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100 && \
-    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-14 100 && \
-    echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" | tee /etc/apt/sources.list.d/archive_uri-http_apt_llvm_org_jammy_-jammy.list && \
-    wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-get update && apt-get install -y clang-format-21 clang-tidy-21 && \
-    ln -s /usr/lib/llvm-21/bin/clang-tidy /usr/bin/clang-tidy && \
-    ln -s /usr/lib/llvm-21/bin/clang-format /usr/bin/clang-format
+# Align with Deckhouse module (debian-trixie) and libunwind+lzma static link expectations.
+# LLVM 21 from apt.llvm.org (trixie toolchain).
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        wget \
+        gnupg \
+        gcc-14 \
+        g++-14 \
+        libunwind-dev \
+        liblzma-dev \
+        libstdc++-14-dev \
+        jq \
+        bash \
+        nodejs \
+        npm \
+        bzip2 \
+        git \
+        autoconf \
+        make \
+        iproute2 \
+        libtool \
+        pkg-config \
+        cmake \
+        lcov; \
+    wget -qO /tmp/llvm-snapshot.gpg.key https://apt.llvm.org/llvm-snapshot.gpg.key; \
+    gpg --dearmor -o /usr/share/keyrings/apt-llvm-org.gpg /tmp/llvm-snapshot.gpg.key; \
+    rm -f /tmp/llvm-snapshot.gpg.key; \
+    echo "deb [signed-by=/usr/share/keyrings/apt-llvm-org.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-21 main" > /etc/apt/sources.list.d/llvm.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends clang-format-21 clang-tidy-21; \
+    ln -sf /usr/lib/llvm-21/bin/clang-tidy /usr/bin/clang-tidy; \
+    ln -sf /usr/lib/llvm-21/bin/clang-format /usr/bin/clang-format; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100; \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100; \
+    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-14 100; \
+    rm -rf /var/lib/apt/lists/*
 
 # Bazel
 ARG BAZEL_VERSION=7.4.1
@@ -31,5 +59,4 @@ ARG GOYACC_VERSION=v0.6.0
 RUN go install golang.org/x/tools/cmd/goyacc@${GOYACC_VERSION}
 
 # minio for getting perf test data
-RUN wget -O /usr/local/bin/mcli https://dl.min.io/client/mc/release/linux-amd64/mc
-RUN chmod +x /usr/local/bin/mcli
+RUN wget -O /usr/local/bin/mcli "https://dl.min.io/client/mc/release/linux-${GO_ARCH}/mc" && chmod +x /usr/local/bin/mcli

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,7 +2,7 @@
 
 ## Environment
 
-Since the project's build relies on specific versions of the compiler and libraries, it is convenient to use a pre-configured container based on `Dockerfile.ci`. You can build it locally with the following command:
+Since the project's build relies on specific versions of the compiler and libraries, it is convenient to use a pre-configured container based on `Dockerfile.ci` (Debian Trixie, GCC 14, LLVM 21 toolchain). You can build it locally with the following command:
 ```bash
 docker build -t prompp-build -f Dockerfile.ci --build-arg BAZEL_ARCH=arm64 --build-arg GO_ARCH=arm64 .
 ```

--- a/pp/bare_bones/bitset.h
+++ b/pp/bare_bones/bitset.h
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <bitset>
 #include <numeric>
+#include <ranges>
 
 #include "bit.h"
 #include "concepts.h"
@@ -263,3 +264,12 @@ template <ReallocatorInterface Reallocator>
 struct IsZeroInitializable<GenericBitset<Reallocator>> : std::true_type {};
 
 }  // namespace BareBones
+
+// GenericBitset::size() is the allocated bit width, not ranges::distance(begin, end) (set-bit
+// count). GCC 14+ libstdc++ uses sized-range fast paths in std::ranges::equal; disable them.
+namespace std::ranges {
+
+template <BareBones::ReallocatorInterface R>
+inline constexpr bool disable_sized_range<BareBones::GenericBitset<R>> = true;
+
+}  // namespace std::ranges

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -12,8 +12,8 @@ package cppbridge
 // #cgo amd64,!asan,dbg LDFLAGS: -l:amd64_entrypoint_init_aio_dbg.a -l:amd64_k8_entrypoint_aio_prefixed_dbg.a -l:amd64_nehalem_entrypoint_aio_prefixed_dbg.a -l:amd64_haswell_entrypoint_aio_prefixed_dbg.a
 // #cgo amd64,asan,!dbg LDFLAGS: -l:amd64_entrypoint_init_aio_opt_asan.a -l:amd64_k8_entrypoint_aio_prefixed_opt_asan.a -l:amd64_nehalem_entrypoint_aio_prefixed_opt_asan.a -l:amd64_haswell_entrypoint_aio_prefixed_opt_asan.a
 // #cgo amd64,asan,dbg LDFLAGS: -l:amd64_entrypoint_init_aio_dbg_asan.a -l:amd64_k8_entrypoint_aio_prefixed_dbg_asan.a -l:amd64_nehalem_entrypoint_aio_prefixed_dbg_asan.a -l:amd64_haswell_entrypoint_aio_prefixed_dbg_asan.a
-// #cgo !static LDFLAGS: -lstdc++ -lm -lgcc_eh -l:libunwind.a -lstdc++exp
-// #cgo static LDFLAGS: -static -static-libgcc -static-libstdc++ -l:libstdc++.a -l:libm.a -l:libgcc_eh.a -l:libunwind.a -l:libstdc++exp.a
+// #cgo !static LDFLAGS: -lstdc++ -lm -lgcc_eh -l:libunwind.a -llzma -lstdc++exp
+// #cgo static LDFLAGS: -static -static-libgcc -static-libstdc++ -l:libstdc++.a -l:libm.a -l:libgcc_eh.a -l:libunwind.a -l:liblzma.a -l:libstdc++exp.a
 // #include "entrypoint.h"
 import "C" //nolint:gocritic // because otherwise it won't work
 import (


### PR DESCRIPTION
## Summary

- **`Dockerfile.ci`**: switch from Ubuntu 24.04 to **Debian 13 (trixie-slim)** so the devcontainer / CI image matches the Deckhouse module base (`debian-trixie`).
- **Toolchain**: GCC 14, **libunwind-dev**, **liblzma-dev**, **libstdc++-14-dev**; LLVM **21** from [apt.llvm.org](https://apt.llvm.org/) (`llvm-toolchain-trixie-21`); modern apt keyring instead of `apt-key`.
- **`pp/go/cppbridge/entrypoint.go`**: add **`-llzma`** / **`-l:liblzma.a`** to CGO `LDFLAGS` for static links — Debian’s `libunwind.a` pulls in lzma (minidebuginfo), same as required for module builds.
- **`mcli`**: download uses **`GO_ARCH`** (arm64/amd64) instead of hardcoded amd64.
- **`TESTING.md`**: note that the CI image is Debian Trixie.

## Motivation

Align local/CI environment with the module image, avoid a module-only patch for lzma, and keep one set of link flags in-tree.

## Verification

- `make build` succeeded in ARM devcontainer after rebuild.
- `Dockerfile.ci` image build verified on linux/amd64 host.


Made with [Cursor](https://cursor.com)