### PR TITLE
close wal on rotate

### DIFF
--- a/pp/go/storage/head/services/functions.go
+++ b/pp/go/storage/head/services/functions.go
@@ -66,7 +66,7 @@ func CFSViaRange[
 	return errors.Join(errs...)
 }
 
-// CloseWals closes all wals of the [Head].
+// CloseWals closes all WALs of the [Head].
 func CloseWals[
 	TShard Shard,
 	THead RangeHead[TShard],

--- a/pp/go/storage/head/services/functions.go
+++ b/pp/go/storage/head/services/functions.go
@@ -66,6 +66,21 @@ func CFSViaRange[
 	return errors.Join(errs...)
 }
 
+// CloseWals closes all wals of the [Head].
+func CloseWals[
+	TShard Shard,
+	THead RangeHead[TShard],
+](h THead) error {
+	var errs []error
+	for _, shard := range h.Shards() {
+		if err := shard.CloseWal(); err != nil {
+			errs = append(errs, fmt.Errorf("close wal shard id %d: %w", shard.ShardID(), err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
 //
 // UnloadUnusedSeriesDataWithHead
 //

--- a/pp/go/storage/head/services/functions_test.go
+++ b/pp/go/storage/head/services/functions_test.go
@@ -1,0 +1,110 @@
+package services_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/storage"
+	"github.com/prometheus/prometheus/pp/go/storage/head/head"
+	"github.com/prometheus/prometheus/pp/go/storage/head/services"
+	"github.com/prometheus/prometheus/pp/go/storage/head/services/mock"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard/wal"
+)
+
+type FunctionsSuite struct {
+	suite.Suite
+}
+
+func TestFunctionsSuite(t *testing.T) {
+	suite.Run(t, new(FunctionsSuite))
+}
+
+func (s *FunctionsSuite) newShard(
+	segmentWriter *mock.SegmentWriterMock,
+	shardID uint16,
+) *shard.Shard {
+	lss := shard.NewLSS()
+	shardWalEncoder := cppbridge.NewHeadWalEncoder(shardID, 0, lss.Target())
+
+	return shard.NewShard(
+		lss,
+		shard.NewDataStorage(),
+		nil,
+		nil,
+		wal.NewWal(shardWalEncoder, segmentWriter, lss, maxSegmentSize, shardID, nil),
+		shardID,
+	)
+}
+
+func (s *FunctionsSuite) newHead(segmentWriters []*mock.SegmentWriterMock) *storage.Head {
+	shards := make([]*shard.Shard, len(segmentWriters))
+	for shardID, sw := range segmentWriters {
+		shards[shardID] = s.newShard(sw, uint16(shardID))
+	}
+
+	return head.NewHead(
+		"close-wals-test-head",
+		shards,
+		shard.NewPerGoroutineShard[*storage.Wal],
+		nil,
+		0,
+		nil,
+	)
+}
+
+func (s *FunctionsSuite) TestCloseWalsClosesEveryShardWal() {
+	segmentWriters := make([]*mock.SegmentWriterMock, shardsCount)
+	for shardID := range shardsCount {
+		segmentWriters[shardID] = &mock.SegmentWriterMock{
+			CloseFunc: func() error { return nil },
+		}
+	}
+	h := s.newHead(segmentWriters)
+
+	s.Require().NoError(services.CloseWals(h))
+
+	for shardID, sw := range segmentWriters {
+		s.Lenf(sw.CloseCalls(), 1, "shard %d", shardID)
+	}
+}
+
+func (s *FunctionsSuite) TestCloseWalsIsIdempotent() {
+	segmentWriters := make([]*mock.SegmentWriterMock, shardsCount)
+	for shardID := range shardsCount {
+		segmentWriters[shardID] = &mock.SegmentWriterMock{
+			CloseFunc: func() error { return nil },
+		}
+	}
+	h := s.newHead(segmentWriters)
+
+	s.Require().NoError(services.CloseWals(h))
+	s.Require().NoError(services.CloseWals(h))
+
+	for shardID, sw := range segmentWriters {
+		s.Lenf(sw.CloseCalls(), 1, "shard %d", shardID)
+	}
+}
+
+func (s *FunctionsSuite) TestCloseWalsAggregatesErrorsFromAllShards() {
+	firstErr := errors.New("shard 0 close failed")
+	secondErr := errors.New("shard 1 close failed")
+	segmentWriters := []*mock.SegmentWriterMock{
+		{CloseFunc: func() error { return firstErr }},
+		{CloseFunc: func() error { return secondErr }},
+	}
+	h := s.newHead(segmentWriters)
+
+	err := services.CloseWals(h)
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, firstErr)
+	s.Require().ErrorIs(err, secondErr)
+
+	// All shards must have been visited despite earlier errors.
+	for shardID, sw := range segmentWriters {
+		s.Lenf(sw.CloseCalls(), 1, "shard %d", shardID)
+	}
+}

--- a/pp/go/storage/head/services/interface.go
+++ b/pp/go/storage/head/services/interface.go
@@ -192,6 +192,9 @@ type ProxyHead[
 
 // Shard the minimum required head [Shard] implementation.
 type Shard interface {
+	// CloseWal closes the wal segmentWriter and sets the wal to nil.
+	CloseWal() error
+
 	// DSAllocatedMemory return size of allocated memory for [DataStorage].
 	DSAllocatedMemory() uint64
 

--- a/pp/go/storage/head/services/interface.go
+++ b/pp/go/storage/head/services/interface.go
@@ -192,7 +192,10 @@ type ProxyHead[
 
 // Shard the minimum required head [Shard] implementation.
 type Shard interface {
-	// CloseWal closes the wal segmentWriter and sets the wal to nil.
+	// CloseWal closes the WAL. After this call any data-handling method
+	// (WalCommit/WalFlush/WalSync/WalWrite) reports a "wal is closed" error,
+	// WalCurrentSize returns 0, and CloseWal itself becomes an idempotent
+	// no-op.
 	CloseWal() error
 
 	// DSAllocatedMemory return size of allocated memory for [DataStorage].

--- a/pp/go/storage/head/services/persistener.go
+++ b/pp/go/storage/head/services/persistener.go
@@ -119,11 +119,6 @@ func (p *Persistener[TTask, TShard, TGoShard, THeadBlockWriter, THead]) Persist(
 			continue
 		}
 
-		if err := p.flushHead(head); err != nil {
-			logger.Errorf("[Persistener]: failed flush head %s: %v", head.ID(), err)
-			continue
-		}
-
 		if err := p.persistHead(head); err != nil {
 			logger.Errorf("[Persistener]: failed persist head %s: %v", head.ID(), err)
 			continue
@@ -168,16 +163,6 @@ func (p *Persistener[TTask, TShard, TGoShard, THeadBlockWriter, THead]) persiste
 	persistTimeMs int64,
 ) bool {
 	return p.clock.Since(time.UnixMilli(persistTimeMs)) >= p.retentionPeriod
-}
-
-func (*Persistener[TTask, TShard, TGoShard, THeadBlockWriter, THead]) flushHead(head THead) error {
-	for shard := range head.RangeShards() {
-		if err := shard.WalFlush(); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (p *Persistener[TTask, TShard, TGoShard, THeadBlockWriter, THead]) persistHead(head THead) error {

--- a/pp/go/storage/head/services/rotator.go
+++ b/pp/go/storage/head/services/rotator.go
@@ -163,7 +163,7 @@ func (s *Rotator[TTask, TShard, TGoShard, THead]) rotate(
 	}
 
 	if err = CloseWals(oldHead); err != nil {
-		logger.Warnf("failed close wals: %s", err)
+		logger.Warnf("failed close WALs: %s", err)
 	}
 
 	if err = s.headInformer.SetRotatedStatus(oldHead.ID()); err != nil {

--- a/pp/go/storage/head/services/rotator.go
+++ b/pp/go/storage/head/services/rotator.go
@@ -162,8 +162,14 @@ func (s *Rotator[TTask, TShard, TGoShard, THead]) rotate(
 		logger.Warnf("failed commit and flush to wal: %s", err)
 	}
 
+	// CloseWals must run before SetReadOnly: concurrent consumers that
+	// iterate proxyHead.Heads() (Persistener, MetricsUpdater) are gated
+	// by IsReadOnly(), so closing the WAL while the head is still
+	// !IsReadOnly() guarantees no one races with the wal swap inside the
+	// shard. Once SetReadOnly is observed, the WAL is already [wal.ClosedWal]
+	// and every Wal* method is a safe no-op.
 	if err = CloseWals(oldHead); err != nil {
-		logger.Warnf("failed close WALs: %s", err)
+		logger.Warnf("failed close wals: %s", err)
 	}
 
 	if err = s.headInformer.SetRotatedStatus(oldHead.ID()); err != nil {

--- a/pp/go/storage/head/services/rotator.go
+++ b/pp/go/storage/head/services/rotator.go
@@ -162,6 +162,10 @@ func (s *Rotator[TTask, TShard, TGoShard, THead]) rotate(
 		logger.Warnf("failed commit and flush to wal: %s", err)
 	}
 
+	if err = CloseWals(oldHead); err != nil {
+		logger.Warnf("failed close wals: %s", err)
+	}
+
 	if err = s.headInformer.SetRotatedStatus(oldHead.ID()); err != nil {
 		logger.Warnf("failed set status rotated for head{%s}: %s", oldHead.ID(), err)
 	}

--- a/pp/go/storage/head/shard/shard.go
+++ b/pp/go/storage/head/shard/shard.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard/wal"
 )
 
 // Wal the minimum required Wal implementation for a [Shard].
@@ -72,10 +73,8 @@ func (s *Shard) AppendInnerSeriesSlice(innerSeriesSlice []cppbridge.InnerSeries)
 }
 
 // Close closes the wal segmentWriter.
-func (s *Shard) Close() (err error) {
-	if s.wal != nil {
-		err = s.wal.Close()
-	}
+func (s *Shard) Close() error {
+	err := s.wal.Close()
 
 	if s.unloadedDataStorage != nil {
 		err = errors.Join(err, s.unloadedDataStorage.Close())
@@ -88,14 +87,23 @@ func (s *Shard) Close() (err error) {
 	return err
 }
 
-// CloseWal closes the wal segmentWriter and sets the wal to nil.
+// CloseWal closes the WAL and swaps it for [wal.ClosedWal]. After this call
+// all Wal* methods on the shard are safe to call: WalCommit/WalFlush/WalSync
+// and WalWrite return [wal.ErrWalClosed], WalCurrentSize returns 0, and
+// CloseWal itself becomes a no-op. CloseWal is idempotent.
+//
+// The wal field is mutated without synchronization, so callers must ensure
+// that no other goroutine reads or writes the WAL while CloseWal runs. In
+// practice the rotator calls CloseWal while the head is still !IsReadOnly()
+// and has already been swapped out of the active slot, which is sufficient
+// to exclude all known readers (writers, Persistener, MetricsUpdater).
 func (s *Shard) CloseWal() error {
-	if s.wal == nil {
+	if _, ok := s.wal.(wal.ClosedWal); ok {
 		return nil
 	}
 
 	err := s.wal.Close()
-	s.wal = nil
+	s.wal = wal.ClosedWal{}
 
 	return err
 }
@@ -147,46 +155,26 @@ func (s *Shard) ShardID() uint16 {
 
 // WalCommit finalize segment from encoder and write to wal.
 func (s *Shard) WalCommit() error {
-	if s.wal == nil {
-		return nil
-	}
-
 	return s.wal.Commit()
 }
 
 // WalCurrentSize returns current [Wal] size.
 func (s *Shard) WalCurrentSize() int64 {
-	if s.wal == nil {
-		return 0
-	}
-
 	return s.wal.CurrentSize()
 }
 
 // WalFlush flush all contetnt into wal.
 func (s *Shard) WalFlush() error {
-	if s.wal == nil {
-		return nil
-	}
-
 	return s.wal.Flush()
 }
 
 // WalSync commits the current contents of the [Wal].
 func (s *Shard) WalSync() error {
-	if s.wal == nil {
-		return nil
-	}
-
 	return s.wal.Sync()
 }
 
 // WalWrite append the incoming inner series to wal encoder.
 func (s *Shard) WalWrite(innerSeriesSlice []cppbridge.InnerSeries) (bool, error) {
-	if s.wal == nil {
-		return false, nil
-	}
-
 	return s.wal.Write(innerSeriesSlice)
 }
 

--- a/pp/go/storage/head/shard/shard.go
+++ b/pp/go/storage/head/shard/shard.go
@@ -147,11 +147,19 @@ func (s *Shard) ShardID() uint16 {
 
 // WalCommit finalize segment from encoder and write to wal.
 func (s *Shard) WalCommit() error {
+	if s.wal == nil {
+		return nil
+	}
+
 	return s.wal.Commit()
 }
 
 // WalCurrentSize returns current [Wal] size.
 func (s *Shard) WalCurrentSize() int64 {
+	if s.wal == nil {
+		return 0
+	}
+
 	return s.wal.CurrentSize()
 }
 
@@ -166,11 +174,19 @@ func (s *Shard) WalFlush() error {
 
 // WalSync commits the current contents of the [Wal].
 func (s *Shard) WalSync() error {
+	if s.wal == nil {
+		return nil
+	}
+
 	return s.wal.Sync()
 }
 
 // WalWrite append the incoming inner series to wal encoder.
 func (s *Shard) WalWrite(innerSeriesSlice []cppbridge.InnerSeries) (bool, error) {
+	if s.wal == nil {
+		return false, nil
+	}
+
 	return s.wal.Write(innerSeriesSlice)
 }
 

--- a/pp/go/storage/head/shard/shard.go
+++ b/pp/go/storage/head/shard/shard.go
@@ -72,8 +72,10 @@ func (s *Shard) AppendInnerSeriesSlice(innerSeriesSlice []cppbridge.InnerSeries)
 }
 
 // Close closes the wal segmentWriter.
-func (s *Shard) Close() error {
-	err := s.wal.Close()
+func (s *Shard) Close() (err error) {
+	if s.wal != nil {
+		err = s.wal.Close()
+	}
 
 	if s.unloadedDataStorage != nil {
 		err = errors.Join(err, s.unloadedDataStorage.Close())
@@ -82,6 +84,18 @@ func (s *Shard) Close() error {
 	if s.queriedSeriesStorage != nil {
 		err = errors.Join(err, s.queriedSeriesStorage.Close())
 	}
+
+	return err
+}
+
+// CloseWal closes the wal segmentWriter and sets the wal to nil.
+func (s *Shard) CloseWal() error {
+	if s.wal == nil {
+		return nil
+	}
+
+	err := s.wal.Close()
+	s.wal = nil
 
 	return err
 }
@@ -143,6 +157,10 @@ func (s *Shard) WalCurrentSize() int64 {
 
 // WalFlush flush all contetnt into wal.
 func (s *Shard) WalFlush() error {
+	if s.wal == nil {
+		return nil
+	}
+
 	return s.wal.Flush()
 }
 

--- a/pp/go/storage/head/shard/shard_test.go
+++ b/pp/go/storage/head/shard/shard_test.go
@@ -1,0 +1,140 @@
+package shard_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard/wal"
+)
+
+// fakeWal is a minimal [shard.Wal] implementation used to observe lifecycle
+// calls made by [shard.Shard].
+type fakeWal struct {
+	closeCalls       int
+	commitCalls      int
+	flushCalls       int
+	syncCalls        int
+	writeCalls       int
+	currentSizeCalls int
+
+	closeErr  error
+	commitErr error
+	flushErr  error
+	syncErr   error
+	writeErr  error
+
+	currentSize int64
+}
+
+func (m *fakeWal) Close() error {
+	m.closeCalls++
+	return m.closeErr
+}
+
+func (m *fakeWal) Commit() error {
+	m.commitCalls++
+	return m.commitErr
+}
+
+func (m *fakeWal) CurrentSize() int64 {
+	m.currentSizeCalls++
+	return m.currentSize
+}
+
+func (m *fakeWal) Flush() error {
+	m.flushCalls++
+	return m.flushErr
+}
+
+func (m *fakeWal) Sync() error {
+	m.syncCalls++
+	return m.syncErr
+}
+
+func (m *fakeWal) Write([]cppbridge.InnerSeries) (bool, error) {
+	m.writeCalls++
+	return false, m.writeErr
+}
+
+type ShardSuite struct {
+	suite.Suite
+}
+
+func TestShardSuite(t *testing.T) {
+	suite.Run(t, new(ShardSuite))
+}
+
+func (s *ShardSuite) newShard(w shard.Wal) *shard.Shard {
+	return shard.NewShard(nil, nil, nil, nil, w, 0)
+}
+
+func (s *ShardSuite) TestCloseWalClosesUnderlyingWal() {
+	fw := &fakeWal{}
+	sd := s.newShard(fw)
+
+	s.Require().NoError(sd.CloseWal())
+	s.Equal(1, fw.closeCalls)
+}
+
+func (s *ShardSuite) TestCloseWalIsIdempotent() {
+	fw := &fakeWal{}
+	sd := s.newShard(fw)
+
+	s.Require().NoError(sd.CloseWal())
+	s.Require().NoError(sd.CloseWal())
+	s.Require().NoError(sd.CloseWal())
+
+	s.Equal(1, fw.closeCalls, "underlying wal.Close must be called exactly once")
+}
+
+func (s *ShardSuite) TestCloseWalPropagatesError() {
+	want := errors.New("boom")
+	fw := &fakeWal{closeErr: want}
+	sd := s.newShard(fw)
+
+	s.Require().ErrorIs(sd.CloseWal(), want)
+
+	// Even after an error the shard must refuse to close the wal again.
+	s.Require().NoError(sd.CloseWal())
+	s.Equal(1, fw.closeCalls)
+}
+
+func (s *ShardSuite) TestWalMethodsAfterCloseWalAreSafe() {
+	fw := &fakeWal{currentSize: 42}
+	sd := s.newShard(fw)
+	s.Require().NoError(sd.CloseWal())
+
+	// Data-handling methods report ErrWalClosed so accidental use-after-close
+	// is noisy rather than silent.
+	s.Require().ErrorIs(sd.WalCommit(), wal.ErrWalClosed)
+	s.Require().ErrorIs(sd.WalFlush(), wal.ErrWalClosed)
+	s.Require().ErrorIs(sd.WalSync(), wal.ErrWalClosed)
+
+	ok, err := sd.WalWrite(nil)
+	s.False(ok)
+	s.Require().ErrorIs(err, wal.ErrWalClosed)
+
+	// CurrentSize has no error channel; a closed WAL reports size 0.
+	s.Zero(sd.WalCurrentSize())
+
+	// None of the Wal* calls should reach the original wal.
+	s.Equal(0, fw.commitCalls)
+	s.Equal(0, fw.flushCalls)
+	s.Equal(0, fw.syncCalls)
+	s.Equal(0, fw.currentSizeCalls)
+	s.Equal(0, fw.writeCalls)
+}
+
+func (s *ShardSuite) TestCloseAfterCloseWalDoesNotDoubleClose() {
+	fw := &fakeWal{}
+	sd := s.newShard(fw)
+
+	s.Require().NoError(sd.CloseWal())
+	s.Require().NoError(sd.Close())
+
+	s.Equal(1, fw.closeCalls, "Shard.Close must not re-close the wal")
+}

--- a/pp/go/storage/head/shard/wal/closedwal.go
+++ b/pp/go/storage/head/shard/wal/closedwal.go
@@ -1,0 +1,55 @@
+package wal
+
+import (
+	"errors"
+
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+)
+
+// ErrWalClosed is returned by data-handling methods of [ClosedWal]
+// (Write/Commit/Flush/Sync) to signal that the WAL has already been closed.
+// Unlike [NoopWal], which is legitimately used for shards that are not backed
+// by a real WAL, [ClosedWal] is a sentinel for shards whose WAL was
+// deliberately closed (e.g. after rotation); silently dropping data there
+// would hide bugs, so we surface it as an error instead.
+//
+// Callers that may legitimately hit a closed WAL (e.g. Persistener re-flushing
+// an already-flushed rotated head) must tolerate this error via
+// [errors.Is](err, ErrWalClosed).
+var ErrWalClosed = errors.New("wal is closed")
+
+// ClosedWal marks a WAL that has been deliberately closed. Close is an
+// idempotent no-op (io.Closer convention) and CurrentSize returns 0, but
+// Write/Commit/Flush/Sync return [ErrWalClosed] so accidental use-after-close
+// is noisy rather than silent.
+type ClosedWal struct{}
+
+// Close implementation of [ClosedWal], idempotent no-op.
+func (ClosedWal) Close() error {
+	return nil
+}
+
+// Commit implementation of [ClosedWal], returns [ErrWalClosed].
+func (ClosedWal) Commit() error {
+	return ErrWalClosed
+}
+
+// CurrentSize implementation of [ClosedWal], always returns 0.
+func (ClosedWal) CurrentSize() int64 {
+	return 0
+}
+
+// Flush implementation of [ClosedWal], returns [ErrWalClosed].
+func (ClosedWal) Flush() error {
+	return ErrWalClosed
+}
+
+// Sync implementation of [ClosedWal], returns [ErrWalClosed].
+func (ClosedWal) Sync() error {
+	return ErrWalClosed
+}
+
+// Write implementation of [ClosedWal], returns [ErrWalClosed].
+func (ClosedWal) Write([]cppbridge.InnerSeries) (bool, error) {
+	return false, ErrWalClosed
+}


### PR DESCRIPTION
## Description
feat: implement CloseWals function and CloseWal method

Added the CloseWals function to close all Write-Ahead Logs (WALs) for a given Head, handling errors for each shard. Introduced the CloseWal method in the Shard interface to close the WAL segment writer and set it to nil, ensuring proper resource management. Updated the Rotator to call CloseWals during rotation, enhancing stability and cleanup processes.