### PR TITLE
add test locker and fix lastPri

### DIFF
--- a/pp/go/util/locker/priweighted.go
+++ b/pp/go/util/locker/priweighted.go
@@ -114,7 +114,7 @@ func (s *Weighted) Resize(n int64) {
 
 //revive:disable-next-line:function-length from base.
 //revive:disable-next-line:cyclomatic from base.
-//revive:disable-next-line:cognitive-complexity function is not complicated.
+//revive:disable-next-line:cognitive-complexity from base.
 func (s *Weighted) acquireWithInserter(ctx context.Context, n int64, inserter func(waiter) *list.Element) error {
 	done := ctx.Done()
 
@@ -165,6 +165,12 @@ func (s *Weighted) acquireWithInserter(ctx context.Context, n int64, inserter fu
 		default:
 			isFront := s.waiters.Front() == elem
 			if elem == s.lastPri {
+				// Priority waiters always form a contiguous prefix of the
+				// queue (every new priority waiter is inserted either at the
+				// front or right after the current lastPri). Therefore, if the
+				// cancelled element is lastPri, its Prev() is either nil (it
+				// was the only/front priority waiter) or another priority
+				// waiter which becomes the new tail of the priority prefix.
 				if isFront {
 					s.lastPri = nil
 				} else {

--- a/pp/go/util/locker/priweighted.go
+++ b/pp/go/util/locker/priweighted.go
@@ -114,6 +114,7 @@ func (s *Weighted) Resize(n int64) {
 
 //revive:disable-next-line:function-length from base.
 //revive:disable-next-line:cyclomatic from base.
+//revive:disable-next-line:cognitive-complexity function is not complicated.
 func (s *Weighted) acquireWithInserter(ctx context.Context, n int64, inserter func(waiter) *list.Element) error {
 	done := ctx.Done()
 
@@ -163,6 +164,13 @@ func (s *Weighted) acquireWithInserter(ctx context.Context, n int64, inserter fu
 			s.notifyWaiters()
 		default:
 			isFront := s.waiters.Front() == elem
+			if elem == s.lastPri {
+				if isFront {
+					s.lastPri = nil
+				} else {
+					s.lastPri = elem.Prev()
+				}
+			}
 			s.waiters.Remove(elem)
 			// If we're at the front and there're extra tokens left, notify other waiters.
 			if isFront && s.size > s.cur {

--- a/pp/go/util/locker/priweighted_test.go
+++ b/pp/go/util/locker/priweighted_test.go
@@ -1,0 +1,696 @@
+package locker_test
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/prometheus/prometheus/pp/go/util/locker"
+	"github.com/stretchr/testify/suite"
+)
+
+type WeightedSuite struct {
+	suite.Suite
+}
+
+func TestWeightedSuite(t *testing.T) {
+	suite.Run(t, new(WeightedSuite))
+}
+
+func (s *WeightedSuite) TestWeighted() {
+	s.T().Parallel()
+
+	n := runtime.GOMAXPROCS(0)
+	loops := 1000 / n
+	l := locker.NewWeighted(int64(n))
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		rw := i%2 == 0
+		go func() {
+			defer wg.Done()
+
+			var unlock func()
+			for range loops {
+				if rw {
+					unlock, _ = l.RLock(context.Background())
+				} else {
+					unlock, _ = l.Lock(context.Background())
+				}
+
+				time.Sleep(time.Duration(rand.Int64N(int64(1*time.Millisecond/time.Nanosecond))) * time.Nanosecond)
+				unlock()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (s *WeightedSuite) TestClose() {
+	ctx := s.T().Context()
+	l := locker.NewWeighted(1)
+	s.Require().NoError(l.Close())
+
+	_, err := l.Lock(ctx)
+	s.Require().ErrorIs(err, locker.ErrSemaphoreClosed)
+
+	_, err = l.RLock(ctx)
+	s.Require().ErrorIs(err, locker.ErrSemaphoreClosed)
+
+	_, err = l.LockWithPriority(ctx)
+	s.Require().ErrorIs(err, locker.ErrSemaphoreClosed)
+
+	_, err = l.RLockWithPriority(ctx)
+	s.Require().ErrorIs(err, locker.ErrSemaphoreClosed)
+}
+
+func (s *WeightedSuite) TestCloseLocked() {
+	synctest.Test(s.T(), func(t *testing.T) {
+		ctx := context.Background()
+		l := locker.NewWeighted(2)
+		var counter uint32
+		var closed bool
+
+		// Hold the whole semaphore exclusively so RLock waiters cannot take a slot
+		// before Close acquires the priority writer lock.
+		unlockHold, err := l.Lock(ctx)
+		s.Require().NoError(err)
+
+		for range 10 {
+			go func() {
+				unlockG, errG := l.RLock(ctx)
+				if errG != nil {
+					s.Require().ErrorIs(errG, locker.ErrSemaphoreClosed)
+					return
+				}
+				atomic.AddUint32(&counter, 1)
+				unlockG()
+			}()
+			synctest.Wait()
+		}
+
+		go func() {
+			t.Log("close")
+			s.Require().NoError(l.Close())
+			t.Log("closed")
+			closed = true
+		}()
+		synctest.Wait()
+
+		s.Require().False(closed)
+		t.Log("unlock hold")
+		unlockHold()
+		t.Log("unlocked")
+		synctest.Wait()
+
+		s.Require().True(closed)
+		s.Require().Equal(uint32(0), atomic.LoadUint32(&counter))
+	})
+}
+
+func (s *WeightedSuite) TestPriorityCancelTailUpdatesLastPri() {
+	synctest.Test(s.T(), func(t *testing.T) {
+		ctxBase := context.Background()
+		l := locker.NewWeighted(2)
+
+		unlockHold1, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+		unlockHold2, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+
+		ctx1, cancel1 := context.WithCancel(ctxBase)
+		ctx2, cancel2 := context.WithCancel(ctxBase)
+		t.Cleanup(cancel1)
+		t.Cleanup(cancel2)
+
+		unlocks := make(chan func(), 2)
+
+		go func() {
+			u, errP := l.RLockWithPriority(ctx1)
+			s.Require().NoError(errP)
+			unlocks <- u
+		}()
+		synctest.Wait()
+
+		go func() {
+			_, errP := l.RLockWithPriority(ctx2)
+			s.Require().ErrorIs(errP, context.Canceled)
+		}()
+		synctest.Wait()
+
+		go cancel2()
+		synctest.Wait()
+
+		unlockHold1()
+		synctest.Wait()
+
+		unlockHold2()
+		synctest.Wait()
+
+		go func() {
+			unlockPriority, errP := l.RLockWithPriority(ctxBase)
+			s.Require().NoError(errP)
+			unlocks <- unlockPriority
+		}()
+		synctest.Wait()
+
+		(<-unlocks)()
+		(<-unlocks)()
+
+		cancel1()
+	})
+}
+
+func (s *WeightedSuite) TestAllocCancelDoesntStarve() {
+	synctest.Test(s.T(), func(*testing.T) {
+		l := locker.NewWeighted(10)
+
+		unlock1, err := l.RLock(context.Background())
+		s.Require().NoError(err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			_, errW := l.Lock(ctx)
+			s.Require().ErrorIs(errW, context.Canceled)
+		}()
+		synctest.Wait()
+
+		go cancel()
+
+		go func() {
+			unlockW, errW := l.Lock(context.Background())
+			s.Require().NoError(errW)
+			unlockW()
+		}()
+		synctest.Wait()
+
+		unlock1()
+		unlock2, err := l.RLock(context.Background())
+		s.Require().NoError(err)
+
+		unlock2()
+	})
+}
+
+func (s *WeightedSuite) TestResizeNoOpSameNUnderExclusive() {
+	ctx := context.Background()
+	l := locker.NewWeighted(5)
+
+	unlock, err := l.Lock(ctx)
+	s.Require().NoError(err)
+
+	l.Resize(5)
+	l.Resize(5)
+
+	unlock()
+
+	unlock2, err := l.RLock(ctx)
+	s.Require().NoError(err)
+	unlock2()
+}
+
+func (s *WeightedSuite) TestResizeUnderExclusiveExpandsSlots() {
+	ctx := context.Background()
+	l := locker.NewWeighted(2)
+
+	unlock, err := l.Lock(ctx)
+	s.Require().NoError(err)
+
+	l.Resize(5)
+	unlock()
+
+	var wg sync.WaitGroup
+	for range 5 {
+		wg.Go(func() {
+			unlockR, errR := l.RLock(ctx)
+			s.Require().NoError(errR)
+			unlockR()
+		})
+	}
+	wg.Wait()
+}
+
+func (s *WeightedSuite) TestResizeUnderExclusiveShrinkSetsCurToSize() {
+	ctx := context.Background()
+	l := locker.NewWeighted(5)
+
+	unlock, err := l.Lock(ctx)
+	s.Require().NoError(err)
+
+	l.Resize(2)
+	unlock()
+
+	// After shrink under exclusive, at most two concurrent readers fit.
+	var wg sync.WaitGroup
+	started := make(chan struct{}, 2)
+	for range 2 {
+		wg.Go(func() {
+			unlockR, errR := l.RLock(ctx)
+			s.Require().NoError(errR)
+			started <- struct{}{}
+			unlockR()
+		})
+	}
+
+	for range 2 {
+		<-started
+	}
+
+	wg.Wait()
+}
+
+func (s *WeightedSuite) TestResizeWithoutExclusiveDoesNotResetCur() {
+	ctx := context.Background()
+	l := locker.NewWeighted(2)
+	unlock1, err := l.RLock(ctx)
+	s.Require().NoError(err)
+	unlock2, err := l.RLock(ctx)
+	s.Require().NoError(err)
+
+	l.Resize(1)
+
+	acquired := make(chan struct{})
+	go func() {
+		unlock3, errR := l.RLock(ctx)
+		s.Require().NoError(errR)
+		close(acquired)
+		unlock3()
+	}()
+
+	// With size=1 and cur=2, a new reader needs both slots released.
+	unlock1()
+	unlock2()
+
+	<-acquired
+}
+
+func (s *WeightedSuite) TestAcquireAlreadyCanceledContext() {
+	ctx := context.Background()
+	l := locker.NewWeighted(2)
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := l.RLock(canceled)
+	s.Require().ErrorIs(err, context.Canceled)
+
+	_, err = l.Lock(canceled)
+	s.Require().ErrorIs(err, context.Canceled)
+
+	_, err = l.RLockWithPriority(canceled)
+	s.Require().ErrorIs(err, context.Canceled)
+
+	_, err = l.LockWithPriority(canceled)
+	s.Require().ErrorIs(err, context.Canceled)
+}
+
+func (s *WeightedSuite) TestAcquireAlreadyCanceledDoesNotConsumeSlot() {
+	ctx := context.Background()
+	l := locker.NewWeighted(1)
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := l.RLock(canceled)
+	s.Require().ErrorIs(err, context.Canceled)
+
+	unlock, err := l.RLock(ctx)
+	s.Require().NoError(err)
+	unlock()
+}
+
+func (s *WeightedSuite) TestCloseTwice() {
+	l := locker.NewWeighted(1)
+	s.Require().NoError(l.Close())
+	s.Require().ErrorIs(l.Close(), locker.ErrSemaphoreClosed)
+}
+
+func (s *WeightedSuite) TestRLockWakesToErrSemaphoreClosedAfterClose() {
+	synctest.Test(s.T(), func(*testing.T) {
+		ctx := context.Background()
+		l := locker.NewWeighted(1)
+
+		unlockHold, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		waitAcquire := make(chan error, 1)
+		go func() {
+			_, errA := l.RLock(ctx)
+			waitAcquire <- errA
+		}()
+		synctest.Wait()
+
+		closeErr := make(chan error, 1)
+		go func() {
+			closeErr <- l.Close()
+		}()
+		synctest.Wait()
+
+		unlockHold()
+		synctest.Wait()
+
+		s.Require().NoError(<-closeErr)
+		s.Require().ErrorIs(<-waitAcquire, locker.ErrSemaphoreClosed)
+
+		_, err = l.RLock(ctx)
+		s.Require().ErrorIs(err, locker.ErrSemaphoreClosed)
+	})
+}
+
+func (s *WeightedSuite) TestAcquireAfterReadyContextCanceledReleases() {
+	if testing.Short() {
+		s.T().Skip("timing-dependent cancellation path")
+	}
+
+	ctx := context.Background()
+	for range 600 {
+		l := locker.NewWeighted(1)
+
+		unlockHold, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		ctxW, cancelW := context.WithCancel(ctx)
+		errCh := make(chan error, 1)
+		go func() {
+			unlockR1, errW := l.RLock(ctxW)
+			if errW != nil {
+				errCh <- errW
+				return
+			}
+
+			unlockR1()
+			errCh <- nil
+		}()
+
+		for range 20 {
+			runtime.Gosched()
+		}
+
+		if rand.IntN(2) == 0 {
+			unlockHold()
+			cancelW()
+		} else {
+			cancelW()
+			unlockHold()
+		}
+
+		for range 20 {
+			runtime.Gosched()
+		}
+
+		var errW error
+		select {
+		case errW = <-errCh:
+		case <-time.After(time.Second):
+			s.FailNow("deadlock waiting for RLock waiter")
+		}
+
+		if errors.Is(errW, context.Canceled) {
+			unlockR2, err2 := l.RLock(ctx)
+			s.Require().NoError(err2)
+			unlockR2()
+			return
+		}
+
+		s.Require().NoError(errW)
+	}
+	s.FailNow("did not observe context.Canceled after acquire race within iterations")
+}
+
+func (s *WeightedSuite) TestTwoRLockWithPriorityOrder() {
+	synctest.Test(s.T(), func(*testing.T) {
+		ctx := context.Background()
+		l := locker.NewWeighted(2)
+
+		unlock1, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		unlock2, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		got := make(chan int, 2)
+
+		go func() {
+			unlockRP1, errP := l.RLockWithPriority(ctx)
+			s.Require().NoError(errP)
+			got <- 1
+			unlockRP1()
+		}()
+		synctest.Wait()
+
+		go func() {
+			unlockRP2, errP := l.RLockWithPriority(ctx)
+			s.Require().NoError(errP)
+			got <- 2
+			unlockRP2()
+		}()
+		synctest.Wait()
+
+		unlock1()
+		synctest.Wait()
+		s.Require().Equal(1, <-got)
+
+		unlock2()
+		synctest.Wait()
+		s.Require().Equal(2, <-got)
+	})
+}
+
+func (s *WeightedSuite) TestLockWithPriorityBeforeOrdinaryLockWhenBothWait() {
+	synctest.Test(s.T(), func(*testing.T) {
+		ctx := context.Background()
+		l := locker.NewWeighted(2)
+
+		unlock1, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		unlock2, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		got := make(chan string, 2)
+
+		go func() {
+			unlockOrdinary, errL := l.Lock(ctx)
+			s.Require().NoError(errL)
+			got <- "ordinary"
+			unlockOrdinary()
+		}()
+		synctest.Wait()
+
+		go func() {
+			unlockPriority, errL := l.LockWithPriority(ctx)
+			s.Require().NoError(errL)
+			got <- "priority"
+			unlockPriority()
+		}()
+		synctest.Wait()
+
+		unlock1()
+		unlock2()
+		synctest.Wait()
+		s.Require().Equal("priority", <-got)
+
+		synctest.Wait()
+		s.Require().Equal("ordinary", <-got)
+	})
+}
+
+func (s *WeightedSuite) TestPriorityCancelFrontClearsLastPri() {
+	synctest.Test(s.T(), func(t *testing.T) {
+		ctxBase := context.Background()
+		l := locker.NewWeighted(2)
+
+		unlockHold1, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+
+		unlockHold2, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+
+		ctxPri, cancelPri := context.WithCancel(ctxBase)
+		t.Cleanup(cancelPri)
+
+		go func() {
+			_, errP := l.RLockWithPriority(ctxPri)
+			s.Require().ErrorIs(errP, context.Canceled)
+		}()
+		synctest.Wait()
+
+		go cancelPri()
+		synctest.Wait()
+
+		unlocks := make(chan func(), 1)
+		go func() {
+			unlockRP, errP := l.RLockWithPriority(ctxBase)
+			s.Require().NoError(errP)
+			unlocks <- unlockRP
+		}()
+		synctest.Wait()
+
+		unlockHold1()
+		synctest.Wait()
+
+		unlockHold2()
+		synctest.Wait()
+
+		(<-unlocks)()
+	})
+}
+
+func (s *WeightedSuite) TestPriorityCancelMiddleUpdatesLastPriToPrev() {
+	synctest.Test(s.T(), func(t *testing.T) {
+		ctxBase := context.Background()
+		l := locker.NewWeighted(2)
+
+		unlockHold1, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+
+		unlockHold2, err := l.RLock(ctxBase)
+		s.Require().NoError(err)
+
+		ctxA, cancelA := context.WithCancel(ctxBase)
+		ctxB, cancelB := context.WithCancel(ctxBase)
+		t.Cleanup(cancelA)
+		t.Cleanup(cancelB)
+
+		go func() {
+			_, errP := l.RLockWithPriority(ctxA)
+			s.Require().ErrorIs(errP, context.Canceled)
+		}()
+		synctest.Wait()
+
+		go func() {
+			unlockRP, errP := l.RLockWithPriority(ctxBase)
+			s.Require().NoError(errP)
+			unlockRP()
+		}()
+		synctest.Wait()
+
+		go func() {
+			_, errP := l.RLockWithPriority(ctxB)
+			s.Require().ErrorIs(errP, context.Canceled)
+		}()
+		synctest.Wait()
+
+		go cancelA()
+		synctest.Wait()
+
+		go cancelB()
+		synctest.Wait()
+
+		unlockHold1()
+		synctest.Wait()
+
+		unlockHold2()
+		synctest.Wait()
+	})
+}
+
+func (s *WeightedSuite) TestCancelAcquireAfterReadyRollbackNotifiesNext() {
+	if testing.Short() {
+		s.T().Skip("timing-dependent rollback path")
+	}
+
+	ctx := context.Background()
+	for range 800 {
+		l := locker.NewWeighted(1)
+
+		unlockHold, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		ctxW, cancelW := context.WithCancel(ctx)
+		errCh := make(chan error, 1)
+		go func() {
+			unlockR, errW := l.RLock(ctxW)
+			if errW != nil {
+				errCh <- errW
+				return
+			}
+
+			unlockR()
+			errCh <- nil
+		}()
+
+		for range 20 {
+			runtime.Gosched()
+		}
+
+		if rand.IntN(2) == 0 {
+			cancelW()
+			unlockHold()
+		} else {
+			unlockHold()
+			cancelW()
+		}
+
+		for range 20 {
+			runtime.Gosched()
+		}
+
+		var errW error
+		select {
+		case errW = <-errCh:
+		case <-time.After(time.Second):
+			s.FailNow("deadlock waiting for RLock waiter")
+		}
+
+		if errors.Is(errW, context.Canceled) {
+			unlockR, err2 := l.RLock(ctx)
+			s.Require().NoError(err2)
+			unlockR()
+			return
+		}
+
+		s.Require().NoError(errW)
+	}
+
+	s.FailNow("did not observe cancel while acquiring path")
+}
+
+func (s *WeightedSuite) TestLargeAcquireDoesntStarve() {
+	s.T().Parallel()
+
+	ctx := s.T().Context()
+	n := int64(runtime.GOMAXPROCS(0))
+	l := locker.NewWeighted(n)
+	var running atomic.Bool
+	running.Store(true)
+
+	var wg sync.WaitGroup
+	wg.Add(int(n))
+
+	var runWG sync.WaitGroup
+	runWG.Add(int(n))
+
+	for i := n; i > 0; i-- {
+		loopUnlock, err := l.RLock(ctx)
+		s.Require().NoError(err)
+
+		go func() {
+			runWG.Done()
+			defer func() {
+				wg.Done()
+			}()
+			loopUnlock()
+
+			for running.Load() {
+				unlock, err := l.RLock(ctx)
+				s.Require().NoError(err)
+				time.Sleep(1 * time.Millisecond)
+				unlock()
+			}
+		}()
+	}
+	runWG.Wait()
+
+	unlock, err := l.Lock(ctx)
+	s.Require().NoError(err)
+	running.Store(false)
+	unlock()
+	wg.Wait()
+}

--- a/pp/go/util/locker/priweighted_test.go
+++ b/pp/go/util/locker/priweighted_test.go
@@ -2,7 +2,6 @@ package locker_test
 
 import (
 	"context"
-	"errors"
 	"math/rand/v2"
 	"runtime"
 	"sync"
@@ -49,7 +48,6 @@ func (s *WeightedSuite) TestCloseLocked() {
 		l := locker.NewWeighted(2)
 		var counter uint32
 		var closed atomic.Bool
-		closed.Store(false)
 
 		// Hold the whole semaphore exclusively so RLock waiters cannot take a slot
 		// before Close acquires the priority writer lock.
@@ -88,6 +86,12 @@ func (s *WeightedSuite) TestCloseLocked() {
 	})
 }
 
+// TestPriorityCancelTailUpdatesLastPri ensures that when the lastPri priority
+// waiter is cancelled, the next priority waiter enqueued via the slow path
+// (while all slots are still held) is correctly inserted after the remaining
+// priority prefix. Without the fix in acquireWithInserter, lastPri would keep
+// dangling at the removed element and InsertAfter would return nil, silently
+// dropping the new waiter and deadlocking the goroutine.
 func (s *WeightedSuite) TestPriorityCancelTailUpdatesLastPri() {
 	synctest.Test(s.T(), func(t *testing.T) {
 		ctxBase := context.Background()
@@ -98,51 +102,53 @@ func (s *WeightedSuite) TestPriorityCancelTailUpdatesLastPri() {
 		unlockHold2, err := l.RLock(ctxBase)
 		s.Require().NoError(err)
 
-		ctx1, cancel1 := context.WithCancel(ctxBase)
-		ctx2, cancel2 := context.WithCancel(ctxBase)
-		t.Cleanup(cancel1)
-		t.Cleanup(cancel2)
+		ctxTail, cancelTail := context.WithCancel(ctxBase)
+		t.Cleanup(cancelTail)
 
 		unlocks := make(chan func(), 2)
 
+		// p1 — first priority waiter, becomes initial lastPri.
 		go func() {
-			unlockRP, errP := l.RLockWithPriority(ctx1)
+			unlockRP, errP := l.RLockWithPriority(ctxBase)
 			require.NoError(t, errP)
 			unlocks <- unlockRP
 		}()
 		synctest.Wait()
 
+		// p2 — tail priority waiter, becomes lastPri, will be cancelled.
 		go func() {
-			_, errP := l.RLockWithPriority(ctx2)
+			_, errP := l.RLockWithPriority(ctxTail)
 			require.ErrorIs(t, errP, context.Canceled)
 		}()
 		synctest.Wait()
 
-		go cancel2()
+		// Cancel the tail. lastPri must be advanced back to p1; otherwise it
+		// will dangle at the removed element.
+		cancelTail()
 		synctest.Wait()
 
-		unlockHold1()
-		synctest.Wait()
-
-		unlockHold2()
-		synctest.Wait()
-
+		// p3 — enqueued while both slots are still held, so this forces the
+		// slow-path InsertAfter(lastPri). If lastPri still pointed to the
+		// removed p2, InsertAfter would return nil and this goroutine would
+		// hang forever.
 		go func() {
-			unlockPriority, errP := l.RLockWithPriority(ctxBase)
-			s.Require().NoError(errP)
-			unlocks <- unlockPriority
+			unlockRP, errP := l.RLockWithPriority(ctxBase)
+			require.NoError(t, errP)
+			unlocks <- unlockRP
 		}()
 		synctest.Wait()
 
-		(<-unlocks)()
-		(<-unlocks)()
+		unlockHold1()
+		unlockHold2()
+		synctest.Wait()
 
-		cancel1()
+		(<-unlocks)()
+		(<-unlocks)()
 	})
 }
 
 func (s *WeightedSuite) TestAllocCancelDoesntStarve() {
-	synctest.Test(s.T(), func(*testing.T) {
+	synctest.Test(s.T(), func(t *testing.T) {
 		l := locker.NewWeighted(10)
 
 		unlock1, err := l.RLock(context.Background())
@@ -153,15 +159,15 @@ func (s *WeightedSuite) TestAllocCancelDoesntStarve() {
 
 		go func() {
 			_, errW := l.Lock(ctx)
-			s.Require().ErrorIs(errW, context.Canceled)
+			require.ErrorIs(t, errW, context.Canceled)
 		}()
 		synctest.Wait()
 
-		go cancel()
+		cancel()
 
 		go func() {
 			unlockW, errW := l.Lock(context.Background())
-			s.Require().NoError(errW)
+			require.NoError(t, errW)
 			unlockW()
 		}()
 		synctest.Wait()
@@ -337,65 +343,6 @@ func (s *WeightedSuite) TestRLockWakesToErrSemaphoreClosedAfterClose() {
 	})
 }
 
-func (s *WeightedSuite) TestAcquireAfterReadyContextCanceledReleases() {
-	if testing.Short() {
-		s.T().Skip("timing-dependent cancellation path")
-	}
-
-	ctx := context.Background()
-	for range 600 {
-		l := locker.NewWeighted(1)
-
-		unlockHold, err := l.RLock(ctx)
-		s.Require().NoError(err)
-
-		ctxW, cancelW := context.WithCancel(ctx)
-		errCh := make(chan error, 1)
-		go func() {
-			unlockR1, errW := l.RLock(ctxW)
-			if errW != nil {
-				errCh <- errW
-				return
-			}
-
-			unlockR1()
-			errCh <- nil
-		}()
-
-		for range 20 {
-			runtime.Gosched()
-		}
-
-		if rand.IntN(2) == 0 {
-			unlockHold()
-			cancelW()
-		} else {
-			cancelW()
-			unlockHold()
-		}
-
-		for range 20 {
-			runtime.Gosched()
-		}
-
-		var errW error
-		select {
-		case errW = <-errCh:
-		case <-time.After(time.Second):
-			s.FailNow("deadlock waiting for RLock waiter")
-		}
-
-		if errors.Is(errW, context.Canceled) {
-			unlockR2, err2 := l.RLock(ctx)
-			s.Require().NoError(err2)
-			unlockR2()
-			return
-		}
-
-		s.Require().NoError(errW)
-	}
-	s.FailNow("did not observe context.Canceled after acquire race within iterations")
-}
 
 func (s *WeightedSuite) TestTwoRLockWithPriorityOrder() {
 	synctest.Test(s.T(), func(t *testing.T) {
@@ -491,17 +438,17 @@ func (s *WeightedSuite) TestPriorityCancelFrontClearsLastPri() {
 
 		go func() {
 			_, errP := l.RLockWithPriority(ctxPri)
-			s.Require().ErrorIs(errP, context.Canceled)
+			require.ErrorIs(t, errP, context.Canceled)
 		}()
 		synctest.Wait()
 
-		go cancelPri()
+		cancelPri()
 		synctest.Wait()
 
 		unlocks := make(chan func(), 1)
 		go func() {
 			unlockRP, errP := l.RLockWithPriority(ctxBase)
-			s.Require().NoError(errP)
+			require.NoError(t, errP)
 			unlocks <- unlockRP
 		}()
 		synctest.Wait()
@@ -516,7 +463,11 @@ func (s *WeightedSuite) TestPriorityCancelFrontClearsLastPri() {
 	})
 }
 
-func (s *WeightedSuite) TestPriorityCancelMiddleUpdatesLastPriToPrev() {
+// TestPriorityCancelTailWithPrevPriority verifies that when both the front and
+// the tail priority waiters get cancelled while a middle priority waiter
+// remains, lastPri is correctly repositioned to the remaining middle waiter
+// (via elem.Prev()) rather than being cleared.
+func (s *WeightedSuite) TestPriorityCancelTailWithPrevPriority() {
 	synctest.Test(s.T(), func(t *testing.T) {
 		ctxBase := context.Background()
 		l := locker.NewWeighted(2)
@@ -534,27 +485,27 @@ func (s *WeightedSuite) TestPriorityCancelMiddleUpdatesLastPriToPrev() {
 
 		go func() {
 			_, errP := l.RLockWithPriority(ctxA)
-			s.Require().ErrorIs(errP, context.Canceled)
+			require.ErrorIs(t, errP, context.Canceled)
 		}()
 		synctest.Wait()
 
 		go func() {
 			unlockRP, errP := l.RLockWithPriority(ctxBase)
-			s.Require().NoError(errP)
+			require.NoError(t, errP)
 			unlockRP()
 		}()
 		synctest.Wait()
 
 		go func() {
 			_, errP := l.RLockWithPriority(ctxB)
-			s.Require().ErrorIs(errP, context.Canceled)
+			require.ErrorIs(t, errP, context.Canceled)
 		}()
 		synctest.Wait()
 
-		go cancelA()
+		cancelA()
 		synctest.Wait()
 
-		go cancelB()
+		cancelB()
 		synctest.Wait()
 
 		unlockHold1()
@@ -565,13 +516,21 @@ func (s *WeightedSuite) TestPriorityCancelMiddleUpdatesLastPriToPrev() {
 	})
 }
 
-func (s *WeightedSuite) TestCancelAcquireAfterReadyRollbackNotifiesNext() {
+// TestAcquireCancellationRace stresses the race between ctx cancellation and
+// notifyWaiters closing the ready channel. The scheduler-dependent timing is
+// driven by runtime.Gosched and a random ordering of the two events, so the
+// test may hit different branches (ctx wins, ready wins, or both fire before
+// the waiter wakes up) on different runs. The goal is not to assert that a
+// specific rare branch executes, but that the semaphore never deadlocks and
+// remains usable for subsequent acquires regardless of which branch wins.
+func (s *WeightedSuite) TestAcquireCancellationRace() {
 	if testing.Short() {
-		s.T().Skip("timing-dependent rollback path")
+		s.T().Skip("timing-dependent cancellation path")
 	}
 
 	ctx := context.Background()
-	for range 800 {
+	const iterations = 800
+	for range iterations {
 		l := locker.NewWeighted(1)
 
 		unlockHold, err := l.RLock(ctx)
@@ -585,7 +544,6 @@ func (s *WeightedSuite) TestCancelAcquireAfterReadyRollbackNotifiesNext() {
 				errCh <- errW
 				return
 			}
-
 			unlockR()
 			errCh <- nil
 		}()
@@ -613,21 +571,20 @@ func (s *WeightedSuite) TestCancelAcquireAfterReadyRollbackNotifiesNext() {
 			s.FailNow("deadlock waiting for RLock waiter")
 		}
 
-		if errors.Is(errW, context.Canceled) {
-			unlockR, err2 := l.RLock(ctx)
-			s.Require().NoError(err2)
-			unlockR()
-			return
+		if errW != nil {
+			s.Require().ErrorIs(errW, context.Canceled)
 		}
 
-		s.Require().NoError(errW)
+		// Regardless of which branch fired, the semaphore must remain usable.
+		unlock, err := l.RLock(ctx)
+		s.Require().NoError(err)
+		unlock()
 	}
-
-	s.FailNow("did not observe cancel while acquiring path")
 }
 
+// TestWeighted is a stress test kept outside WeightedSuite because testify v1
+// does not support parallel execution for suite methods.
 func TestWeighted(t *testing.T) {
-	// testify v1 does not support suite's parallel tests and subtests
 	t.Parallel()
 
 	ctx := t.Context()
@@ -657,8 +614,9 @@ func TestWeighted(t *testing.T) {
 	wg.Wait()
 }
 
+// TestLargeAcquireDoesntStarve is a stress test kept outside WeightedSuite
+// because testify v1 does not support parallel execution for suite methods.
 func TestLargeAcquireDoesntStarve(t *testing.T) {
-	// testify v1 does not support suite's parallel tests and subtests
 	t.Parallel()
 
 	ctx := context.Background()

--- a/pp/go/util/locker/priweighted_test.go
+++ b/pp/go/util/locker/priweighted_test.go
@@ -11,8 +11,10 @@ import (
 	"testing/synctest"
 	"time"
 
-	"github.com/prometheus/prometheus/pp/go/util/locker"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/prometheus/prometheus/pp/go/util/locker"
 )
 
 type WeightedSuite struct {
@@ -21,35 +23,6 @@ type WeightedSuite struct {
 
 func TestWeightedSuite(t *testing.T) {
 	suite.Run(t, new(WeightedSuite))
-}
-
-func (s *WeightedSuite) TestWeighted() {
-	s.T().Parallel()
-
-	n := runtime.GOMAXPROCS(0)
-	loops := 1000 / n
-	l := locker.NewWeighted(int64(n))
-	var wg sync.WaitGroup
-	wg.Add(n)
-	for i := range n {
-		rw := i%2 == 0
-		go func() {
-			defer wg.Done()
-
-			var unlock func()
-			for range loops {
-				if rw {
-					unlock, _ = l.RLock(context.Background())
-				} else {
-					unlock, _ = l.Lock(context.Background())
-				}
-
-				time.Sleep(time.Duration(rand.Int64N(int64(1*time.Millisecond/time.Nanosecond))) * time.Nanosecond)
-				unlock()
-			}
-		}()
-	}
-	wg.Wait()
 }
 
 func (s *WeightedSuite) TestClose() {
@@ -75,7 +48,8 @@ func (s *WeightedSuite) TestCloseLocked() {
 		ctx := context.Background()
 		l := locker.NewWeighted(2)
 		var counter uint32
-		var closed bool
+		var closed atomic.Bool
+		closed.Store(false)
 
 		// Hold the whole semaphore exclusively so RLock waiters cannot take a slot
 		// before Close acquires the priority writer lock.
@@ -86,7 +60,7 @@ func (s *WeightedSuite) TestCloseLocked() {
 			go func() {
 				unlockG, errG := l.RLock(ctx)
 				if errG != nil {
-					s.Require().ErrorIs(errG, locker.ErrSemaphoreClosed)
+					require.ErrorIs(t, errG, locker.ErrSemaphoreClosed)
 					return
 				}
 				atomic.AddUint32(&counter, 1)
@@ -97,19 +71,19 @@ func (s *WeightedSuite) TestCloseLocked() {
 
 		go func() {
 			t.Log("close")
-			s.Require().NoError(l.Close())
+			require.NoError(t, l.Close())
 			t.Log("closed")
-			closed = true
+			closed.Store(true)
 		}()
 		synctest.Wait()
 
-		s.Require().False(closed)
+		s.Require().False(closed.Load())
 		t.Log("unlock hold")
 		unlockHold()
 		t.Log("unlocked")
 		synctest.Wait()
 
-		s.Require().True(closed)
+		s.Require().True(closed.Load())
 		s.Require().Equal(uint32(0), atomic.LoadUint32(&counter))
 	})
 }
@@ -132,15 +106,15 @@ func (s *WeightedSuite) TestPriorityCancelTailUpdatesLastPri() {
 		unlocks := make(chan func(), 2)
 
 		go func() {
-			u, errP := l.RLockWithPriority(ctx1)
-			s.Require().NoError(errP)
-			unlocks <- u
+			unlockRP, errP := l.RLockWithPriority(ctx1)
+			require.NoError(t, errP)
+			unlocks <- unlockRP
 		}()
 		synctest.Wait()
 
 		go func() {
 			_, errP := l.RLockWithPriority(ctx2)
-			s.Require().ErrorIs(errP, context.Canceled)
+			require.ErrorIs(t, errP, context.Canceled)
 		}()
 		synctest.Wait()
 
@@ -424,21 +398,21 @@ func (s *WeightedSuite) TestAcquireAfterReadyContextCanceledReleases() {
 }
 
 func (s *WeightedSuite) TestTwoRLockWithPriorityOrder() {
-	synctest.Test(s.T(), func(*testing.T) {
+	synctest.Test(s.T(), func(t *testing.T) {
 		ctx := context.Background()
 		l := locker.NewWeighted(2)
 
 		unlock1, err := l.RLock(ctx)
-		s.Require().NoError(err)
+		require.NoError(t, err)
 
 		unlock2, err := l.RLock(ctx)
-		s.Require().NoError(err)
+		require.NoError(t, err)
 
 		got := make(chan int, 2)
 
 		go func() {
 			unlockRP1, errP := l.RLockWithPriority(ctx)
-			s.Require().NoError(errP)
+			require.NoError(t, errP)
 			got <- 1
 			unlockRP1()
 		}()
@@ -446,7 +420,7 @@ func (s *WeightedSuite) TestTwoRLockWithPriorityOrder() {
 
 		go func() {
 			unlockRP2, errP := l.RLockWithPriority(ctx)
-			s.Require().NoError(errP)
+			require.NoError(t, errP)
 			got <- 2
 			unlockRP2()
 		}()
@@ -463,7 +437,7 @@ func (s *WeightedSuite) TestTwoRLockWithPriorityOrder() {
 }
 
 func (s *WeightedSuite) TestLockWithPriorityBeforeOrdinaryLockWhenBothWait() {
-	synctest.Test(s.T(), func(*testing.T) {
+	synctest.Test(s.T(), func(t *testing.T) {
 		ctx := context.Background()
 		l := locker.NewWeighted(2)
 
@@ -477,7 +451,7 @@ func (s *WeightedSuite) TestLockWithPriorityBeforeOrdinaryLockWhenBothWait() {
 
 		go func() {
 			unlockOrdinary, errL := l.Lock(ctx)
-			s.Require().NoError(errL)
+			require.NoError(t, errL)
 			got <- "ordinary"
 			unlockOrdinary()
 		}()
@@ -485,7 +459,7 @@ func (s *WeightedSuite) TestLockWithPriorityBeforeOrdinaryLockWhenBothWait() {
 
 		go func() {
 			unlockPriority, errL := l.LockWithPriority(ctx)
-			s.Require().NoError(errL)
+			require.NoError(t, errL)
 			got <- "priority"
 			unlockPriority()
 		}()
@@ -652,10 +626,42 @@ func (s *WeightedSuite) TestCancelAcquireAfterReadyRollbackNotifiesNext() {
 	s.FailNow("did not observe cancel while acquiring path")
 }
 
-func (s *WeightedSuite) TestLargeAcquireDoesntStarve() {
-	s.T().Parallel()
+func TestWeighted(t *testing.T) {
+	// testify v1 does not support suite's parallel tests and subtests
+	t.Parallel()
 
-	ctx := s.T().Context()
+	ctx := t.Context()
+	n := runtime.GOMAXPROCS(0)
+	loops := 1000 / n
+	l := locker.NewWeighted(int64(n))
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range n {
+		rw := i%2 == 0
+		go func() {
+			defer wg.Done()
+
+			var unlock func()
+			for range loops {
+				if rw {
+					unlock, _ = l.RLock(ctx)
+				} else {
+					unlock, _ = l.Lock(ctx)
+				}
+
+				time.Sleep(time.Duration(rand.Int64N(int64(1*time.Millisecond/time.Nanosecond))) * time.Nanosecond)
+				unlock()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestLargeAcquireDoesntStarve(t *testing.T) {
+	// testify v1 does not support suite's parallel tests and subtests
+	t.Parallel()
+
+	ctx := context.Background()
 	n := int64(runtime.GOMAXPROCS(0))
 	l := locker.NewWeighted(n)
 	var running atomic.Bool
@@ -669,27 +675,27 @@ func (s *WeightedSuite) TestLargeAcquireDoesntStarve() {
 
 	for i := n; i > 0; i-- {
 		loopUnlock, err := l.RLock(ctx)
-		s.Require().NoError(err)
+		require.NoError(t, err)
 
-		go func() {
+		go func(lUnlock func()) {
 			runWG.Done()
 			defer func() {
 				wg.Done()
 			}()
-			loopUnlock()
+			lUnlock()
 
 			for running.Load() {
 				unlock, err := l.RLock(ctx)
-				s.Require().NoError(err)
+				require.NoError(t, err)
 				time.Sleep(1 * time.Millisecond)
 				unlock()
 			}
-		}()
+		}(loopUnlock)
 	}
 	runWG.Wait()
 
 	unlock, err := l.Lock(ctx)
-	s.Require().NoError(err)
+	require.NoError(t, err)
 	running.Store(false)
 	unlock()
 	wg.Wait()


### PR DESCRIPTION
## Description
fix: update lastPri handling in acquireWithInserter method

Enhanced the logic in the acquireWithInserter method to correctly manage the lastPri pointer when removing waiters from the queue. This change ensures that lastPri is updated appropriately based on the position of the removed element, improving the overall functionality of the weighted locker.