### PR TITLE
fix(catalog): de-flake TestCompact_SortsTwoRecordsByCreatedAt

### DIFF
--- a/pp/go/storage/catalog/catalog_test.go
+++ b/pp/go/storage/catalog/catalog_test.go
@@ -714,10 +714,17 @@ func (s *CatalogSuite) TestCompact_SortsTwoRecordsByCreatedAt() {
 	s.Require().Less(t1, t2)
 
 	s.Require().NoError(c.Compact())
-	records := c.List(nil, nil)
-	s.Require().Len(records, 2)
-	s.Require().Equal(t1, records[0].CreatedAt())
-	s.Require().Equal(t2, records[1].CreatedAt())
+
+	// Verify Compact rewrote the log with records sorted by createdAt by
+	// inspecting the slice passed to Log.ReWrite. We can't rely on
+	// catalog.List(nil, nil) here because the catalog backs records with a
+	// Go map and List preserves map iteration order when no sortLess is
+	// given — that order is intentionally randomized.
+	calls := l.ReWriteCalls()
+	s.Require().Len(calls, 1)
+	s.Require().Len(calls[0].Srecords, 2)
+	s.Require().Same(&r1.SerializedRecord, calls[0].Srecords[0])
+	s.Require().Same(&r2.SerializedRecord, calls[0].Srecords[1])
 }
 
 func (s *CatalogSuite) TestCompact_ReWriteError() {


### PR DESCRIPTION
## Summary

`TestCatalogSuite/TestCompact_SortsTwoRecordsByCreatedAt` (introduced in #296, 2026-04-21) was flaky and has been failing roughly once per CI matrix run on `fsn-dev-perftest-runner` ever since. Examples:

- run [24726226620](https://github.com/deckhouse/prompp/actions/runs/24726226620) — `pp` push that merged #296 itself
- run [24773583978](https://github.com/deckhouse/prompp/actions/runs/24773583978) — `pp` push (`changelog: v0.8.0-rc2`)
- run [24892378547](https://github.com/deckhouse/prompp/actions/runs/24892378547) — renovate PR
- run [24993613568](https://github.com/deckhouse/prompp/actions/runs/24993613568) — PR #302

All four hit the same assertion at `catalog_test.go:719`: `expected: 1000`, `actual: 3601000`.

### Root cause

The test asserted that `Catalog.Compact` sorts records by `createdAt` by checking the order returned from `c.List(nil, nil)`. But `Catalog.listWithFilter` iterates the in-memory `map[string]*Record` and returns records in Go map iteration order — intentionally randomized per binary by the runtime. `Compact` doesn't touch that map; it only sorts the slice it passes to `Log.ReWrite`. So the original assertion was checking something `Compact` doesn't actually guarantee.

### Fix

Switch the assertion to inspect what `Compact` really does — the `*SerializedRecord` slice forwarded to `Log.ReWrite`, which `compactLog` explicitly sorts by `createdAt` before calling `ReWrite`:

\`\`\`go
calls := l.ReWriteCalls()
s.Require().Len(calls, 1)
s.Require().Len(calls[0].Srecords, 2)
s.Require().Same(&r1.SerializedRecord, calls[0].Srecords[0])
s.Require().Same(&r2.SerializedRecord, calls[0].Srecords[1])
\`\`\`

This compares pointer identity to the embedded \`SerializedRecord\` of the records returned by \`Create\`, so the test now fails iff \`Compact\` really did not sort the rewrite payload — which is the original test's intent.

No production code change.

## Test plan

- [x] \`go test -count=1 ./go/storage/catalog/...\` — pass
- [x] \`go test -count=1 -race ./go/storage/catalog/...\` — pass
- [x] Run target test 5x with varied \`GODEBUG=randmapseed=N\` — pass deterministically (previously this was the failure mode)
- [x] \`go vet ./go/storage/catalog/...\` — clean
- [ ] CI green on this branch

Made with [Cursor](https://cursor.com)