### PR TITLE
chore(web-ui): add .npmrc with legacy-peer-deps=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,12 @@ upgrade-npm-deps:
 .PHONY: ui-bump-version
 ui-bump-version:
 	version=$$(sed s/2/0/ < VERSION) && ./scripts/ui_release.sh --bump-version "$${version}"
-	cd web/ui && npm install --legacy-peer-deps
+	cd web/ui && npm install
 	git add "./web/ui/package-lock.json" "./**/package.json"
 
 .PHONY: ui-install
 ui-install:
-	cd $(UI_PATH) && npm install --legacy-peer-deps
+	cd $(UI_PATH) && npm install
 
 .PHONY: ui-build
 ui-build:

--- a/web/ui/.npmrc
+++ b/web/ui/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Add `web/ui/.npmrc` with `legacy-peer-deps=true` so any `npm install` in `web/ui/` uses legacy peer-dep resolution automatically.
- Drop the now-redundant `--legacy-peer-deps` flag from the `ui-install` and `ui-bump-version` targets in `Makefile`.

## Why

`web/ui/` has a long-standing peer-dependency conflict between `typescript@^5.0.0` (declared at the workspace root) and `react-scripts@5.0.1` (used by the `react-app` workspace, which still pins TypeScript to `^3 || ^4`). On modern npm a clean install fails with `ERESOLVE`:

```
While resolving: react-scripts@5.0.1
Found: typescript@5.9.3
peerOptional typescript@"^3.2.1 || ^4" from react-scripts@5.0.1
```

We already worked around this in `Makefile` by passing `--legacy-peer-deps`, but **Renovate** drives `npm install` directly (without that flag) when refreshing `package-lock.json` after a dependency bump, which causes Renovate to skip the lock-file update and post a comment instead — see e.g. #304.

Committing the flag to `.npmrc` fixes this for all callers (Renovate, CI, local devs) and removes the need to remember the flag manually. After this lands, Renovate should be able to regenerate `web/ui/package-lock.json` automatically on the next run.

## Test plan

- [ ] CI green on this PR.
- [ ] Verify `make ui-install` still works locally (no flag needed).
- [ ] Verify Renovate updates the lock file on the next dependency PR (e.g. retrigger #304).