### PR TITLE
chore(pp): clang-tidy aspect-tweaks patch + tidy FP suppression

### DIFF
--- a/pp/MODULE.bazel
+++ b/pp/MODULE.bazel
@@ -23,7 +23,7 @@ git_override(
     commit = "c4d35e0d0b838309358e57a2efed831780f85cd0",
     patch_strip = 1,
     patches = [
-        "//third_party/patches/bazel_clang_tidy:0001-preserve-old-behavior.patch",
+        "//third_party/patches/bazel_clang_tidy:0001-clang-tidy-aspect-tweaks.patch",
     ],
     remote = "https://github.com/erenon/bazel_clang_tidy.git",
 )

--- a/pp/bare_bones/tests/vector_tests.cpp
+++ b/pp/bare_bones/tests/vector_tests.cpp
@@ -62,7 +62,10 @@ TEST_F(BareBonesVectorAllocatedMemoryFixture, PointerWithAllocatedMemoryMethod) 
   const auto allocated_memory = vector.allocated_memory();
 
   // Assert
-  EXPECT_EQ(vector.capacity() * sizeof(Vector::value_type) + vector.size() * kObjectAllocatedMemory, allocated_memory);
+  EXPECT_EQ(
+      vector.capacity() * sizeof(Vector::value_type)  // NOLINT(bugprone-sizeof-expression): value_type is intentionally a pointer; we want the pointer size.
+          + vector.size() * kObjectAllocatedMemory,
+      allocated_memory);
 }
 
 TEST_F(BareBonesVectorAllocatedMemoryFixture, DereferencableWithAllocatedMemoryMethod) {

--- a/pp/third_party/patches/bazel_clang_tidy/0001-clang-tidy-aspect-tweaks.patch
+++ b/pp/third_party/patches/bazel_clang_tidy/0001-clang-tidy-aspect-tweaks.patch
@@ -1,14 +1,15 @@
-Subject: [PATCH] Preserve pre-c4d35e0 behavior for clang-tidy aspect
+Subject: [PATCH] Adjust clang-tidy aspect: opt-in header lint, skip builtin -isystem
 
-Upstream commit c4d35e0 introduced two behavioral changes that don't fit
-this project's setup. This patch reverts both:
+Upstream commit c4d35e0 introduced two behavioral changes in the
+`clang_tidy_aspect` that don't fit this project's setup. This patch
+keeps both changes off:
 
-1. Header files are now linted by default (the aspect treats every public
-   header as a main translation unit). For this repository that would
-   require fixing a large number of pre-existing IWYU and enum-size
-   findings that have never been visible before. Gate the new behavior
-   behind the explicit `clang-tidy-headers` tag so header linting stays
-   off by default and we can opt-in per-target later.
+1. Header files are now linted by default (the aspect treats every
+   public header as a main translation unit). For this repository that
+   would require fixing a large number of pre-existing IWYU and
+   enum-size findings that have never been visible before. Gate the new
+   behavior behind an explicit `clang-tidy-headers` tag so header
+   linting stays off by default and we can opt-in per-target later.
 
 2. The aspect now injects one `-isystem` flag per entry in
    `cc_toolchain.built_in_include_directories`. For this project's


### PR DESCRIPTION
## Summary

Cosmetic-only changes around our local `bazel_clang_tidy` patch, plus a follow-up fix for `make tidy`.

* **Rename** `pp/third_party/patches/bazel_clang_tidy/0001-preserve-old-behavior.patch` → `0001-clang-tidy-aspect-tweaks.patch`. The new name better reflects what we actually do: keep both upstream changes in commit `c4d35e0` switched off (header linting on by default; `-isystem` injection of `cc_toolchain.built_in_include_directories`). Patch contents are functionally identical — only the filename and description text were updated.

* **Suppress** a `bugprone-sizeof-expression` false positive in `pp/bare_bones/tests/vector_tests.cpp`. The test intentionally uses ` sizeof(Vector::value_type)` where `value_type` is a raw `Object*` — that's the size we want for the vector's own buffer accounting. After the `bazel_clang_tidy` update in #299 this started failing `make tidy`. Added a `// NOLINT(bugprone-sizeof-expression)` with a comment explaining the intent.

Both `rules_foreign_cc` (`0.15.1`) and `bazel_clang_tidy` (`c4d35e0d0b8`) are already on the latest version available, so there is no version bump in this PR.

## Test plan

- [x] `make tidy` passes inside the devcontainer (231/231 actions, no errors).
- [ ] CI green.

Made with [Cursor](https://cursor.com)