### PR TITLE
fix: match aarch64 toolchain for jemalloc page size

### DIFF
--- a/pp/bazel/toolchain/BUILD
+++ b/pp/bazel/toolchain/BUILD
@@ -5,7 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 config_setting(
     name = "arm64",
-    values = {"cpu": "arm"},
+    values = {"cpu": "aarch64"},
 )
 
 config_setting(


### PR DESCRIPTION
## Summary
- Change the ARM64 Bazel `config_setting` CPU from `arm` to `aarch64`.
- This makes ARM64 builds select jemalloc `--with-lg-page="16"` instead of falling through to the default `--with-lg-page="12"`.

## Why
The toolchain suite uses `aarch64` for ARM64. With the previous `cpu = "arm"` selector, ARM64 builds could use a 4 KiB jemalloc page size and abort on Raspberry Pi 5 / 16 KiB page-size hosts with:

```text
<jemalloc>: Unsupported system page size
```

## Verification
- Bazel 7.4.1 `cquery --cpu=aarch64 @jemalloc//:make_jemalloc` resolves `--with-lg-page="16"`.
- Bazel 7.4.1 `cquery --cpu=x86 @jemalloc//:make_jemalloc` still resolves `--with-lg-page="12"`.
- A patched ARM64 image is actively running as the Prometheus server in a Raspberry Pi 5 K3s cluster; readiness, buildinfo, and a basic `up` query all succeed without the jemalloc page-size abort.
