### PR TITLE
fix(remote): reject snappy bombs in /api/v1/read (CVE-2026-42154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,11 @@
 9. **Jemalloc arena pool recycling.** Arenas returned to the free pool are now reset and purged instead of being destroyed, with updated jemalloc build options. New metrics report arena pool releases and reclaimed bytes (`prompp_common_jemalloc_arena_pool_*`). Carried over from v0.7.11.
 
 ### Fixes
-1. **OpenTelemetry security update.** Upgraded `go.opentelemetry.io/otel/sdk` and the `otlptracehttp` exporter to v1.43.0 — mitigates a PATH hijacking CVE (GHSA-hfvc-g4fc-pqhx) in the BSD host-id detector and adds a 4 MiB response body limit to OTLP HTTP exporters, protecting against memory exhaustion from a misbehaving collector.
-2. **Close WAL on shard rotation.** Shard rotation now explicitly closes the outgoing WAL via a dedicated `ClosedWal` sentinel instead of leaking the handle, preventing stale WAL readers from racing with newly-rotated shards.
-3. **Go 1.26.3.** Bumped Go to 1.26.3, pulling in stdlib security fixes from the 1.26.x series.
-4. **aarch64 jemalloc page size.** Aligned the jemalloc build with the aarch64 host page size so ARM64 builds no longer hit a configuration mismatch under the GCC 14 toolchain.
+1. **Remote-read snappy DoS (CVE-2026-42154).** Backported the upstream fix (GHSA-8rm2-7qqf-34qm) — `/api/v1/read` now rejects snappy-compressed payloads whose declared decoded length exceeds the 32 MiB decode limit before allocation, preventing memory exhaustion via crafted small requests.
+2. **OpenTelemetry security update.** Upgraded `go.opentelemetry.io/otel/sdk` and the `otlptracehttp` exporter to v1.43.0 — mitigates a PATH hijacking CVE (GHSA-hfvc-g4fc-pqhx) in the BSD host-id detector and adds a 4 MiB response body limit to OTLP HTTP exporters, protecting against memory exhaustion from a misbehaving collector.
+3. **Close WAL on shard rotation.** Shard rotation now explicitly closes the outgoing WAL via a dedicated `ClosedWal` sentinel instead of leaking the handle, preventing stale WAL readers from racing with newly-rotated shards.
+4. **Go 1.26.3.** Bumped Go to 1.26.3, pulling in stdlib security fixes from the 1.26.x series.
+5. **aarch64 jemalloc page size.** Aligned the jemalloc build with the aarch64 host page size so ARM64 builds no longer hit a configuration mismatch under the GCC 14 toolchain.
 
 ### Other
 1. **Bazel Bzlmod migration.** Migrated `pp/` to Bzlmod and refreshed `rules_cc`, `rules_foreign_cc`, and `bazel_clang_tidy` to resolve dependency conflicts that had blocked further updates of the C++ build stack.

--- a/storage/remote/codec.go
+++ b/storage/remote/codec.go
@@ -67,6 +67,14 @@ func DecodeReadRequest(r *http.Request) (*prompb.ReadRequest, error) {
 		return nil, err
 	}
 
+	decodedLen, err := snappy.DecodedLen(compressed)
+	if err != nil {
+		return nil, err
+	}
+	if decodedLen > decodeReadLimit {
+		return nil, fmt.Errorf("snappy: decoded length %d exceeds limit %d", decodedLen, decodeReadLimit)
+	}
+
 	reqBuf, err := snappy.Decode(nil, compressed)
 	if err != nil {
 		return nil, err

--- a/storage/remote/codec_test.go
+++ b/storage/remote/codec_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -571,6 +572,17 @@ func TestMergeLabels(t *testing.T) {
 	} {
 		require.Equal(t, tc.expected, MergeLabels(tc.primary, tc.secondary))
 	}
+}
+
+func TestDecodeReadRequestTooLarge(t *testing.T) {
+	// 5-byte snappy stream whose header claims 256 MiB decoded length,
+	// well above decodeReadLimit (32 MiB).
+	bomb := []byte{0x80, 0x80, 0x80, 0x80, 0x01}
+	req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(bomb))
+	require.NoError(t, err)
+
+	_, err = DecodeReadRequest(req)
+	require.ErrorContains(t, err, "exceeds limit")
 }
 
 func TestDecodeWriteRequest(t *testing.T) {


### PR DESCRIPTION
## Summary

Backports the upstream Prometheus security fix [prometheus/prometheus#18584](https://github.com/prometheus/prometheus/pull/18584) (GHSA-8rm2-7qqf-34qm / CVE-2026-42154) to our fork.

The remote-read endpoint (`/api/v1/read`) decompresses the snappy-encoded request body via `storage/remote.DecodeReadRequest` without checking the declared decoded length. A small crafted payload can claim a huge decoded size and force a multi-GB heap allocation per request; under concurrent load this exhausts memory and crashes the process. The fix calls `snappy.DecodedLen` first and rejects anything above the existing 32 MiB `decodeReadLimit` before allocating.

`pp/tools/block_converter` (the path Dependabot flagged on alert [#186](https://github.com/deckhouse/prompp/security/dependabot/186)) is an offline CLI that only uses `tsdb`/`labels`/`chunks` and never reaches this code path, so that alert is unaffected by this PR — this PR fixes the same class of vulnerability inside our own Prometheus fork tree, which Dependabot doesn't see.

### Changes
- `storage/remote/codec.go`: validate `snappy.DecodedLen(compressed)` against `decodeReadLimit` before calling `snappy.Decode`.
- `storage/remote/codec_test.go`: add `TestDecodeReadRequestTooLarge` — a 5-byte snappy header claiming 256 MiB decoded length is rejected with `exceeds limit`.
- `CHANGELOG.md`: entry under `v0.8.0` → `Fixes`.

## Test plan

- [x] `go test -tags stringlabels -run TestDecodeReadRequest ./storage/remote/` (new test passes)
- [x] `go test -tags stringlabels ./storage/remote/...` (full package, 48s, all green)


Made with [Cursor](https://cursor.com)