### PR TITLE
fix(remote/azuread): redact OAuth client_secret in config API (CVE-2026-42151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 9. **Jemalloc arena pool recycling.** Arenas returned to the free pool are now reset and purged instead of being destroyed, with updated jemalloc build options. New metrics report arena pool releases and reclaimed bytes (`prompp_common_jemalloc_arena_pool_*`). Carried over from v0.7.11.
 
 ### Fixes
-1. **OpenTelemetry security update.** Upgraded `go.opentelemetry.io/otel/sdk` and the `otlptracehttp` exporter to v1.43.0 — mitigates a PATH hijacking CVE (GHSA-hfvc-g4fc-pqhx) in the BSD host-id detector and adds a 4 MiB response body limit to OTLP HTTP exporters, protecting against memory exhaustion from a misbehaving collector.
+1. **Azure AD remote-write client_secret redaction (CVE-2026-42151).** Backported the upstream fix (GHSA-wg65-39gg-5wfj) — `OAuthConfig.ClientSecret` in `storage/remote/azuread` is now typed as `config.Secret` instead of a plain `string`, so the value is redacted (`<secret>`) when serving the configuration via the `/-/config` HTTP API.
+2. **OpenTelemetry security update.** Upgraded `go.opentelemetry.io/otel/sdk` and the `otlptracehttp` exporter to v1.43.0 — mitigates a PATH hijacking CVE (GHSA-hfvc-g4fc-pqhx) in the BSD host-id detector and adds a 4 MiB response body limit to OTLP HTTP exporters, protecting against memory exhaustion from a misbehaving collector.
 2. **Close WAL on shard rotation.** Shard rotation now explicitly closes the outgoing WAL via a dedicated `ClosedWal` sentinel instead of leaking the handle, preventing stale WAL readers from racing with newly-rotated shards.
 3. **Go 1.26.3.** Bumped Go to 1.26.3, pulling in stdlib security fixes from the 1.26.x series.
 4. **aarch64 jemalloc page size.** Aligned the jemalloc build with the aarch64 host page size so ARM64 builds no longer hit a configuration mismatch under the GCC 14 toolchain.

--- a/storage/remote/azuread/azuread.go
+++ b/storage/remote/azuread/azuread.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/google/uuid"
+	config_util "github.com/prometheus/common/config"
 )
 
 // Clouds.
@@ -57,7 +58,7 @@ type OAuthConfig struct {
 	ClientID string `yaml:"client_id,omitempty"`
 
 	// ClientSecret is the clientSecret of the azure active directory application that is being used to authenticate.
-	ClientSecret string `yaml:"client_secret,omitempty"`
+	ClientSecret config_util.Secret `yaml:"client_secret,omitempty"`
 
 	// TenantID is the tenantId of the azure active directory application that is being used to authenticate.
 	TenantID string `yaml:"tenant_id,omitempty"`
@@ -278,7 +279,7 @@ func newManagedIdentityTokenCredential(clientOpts *azcore.ClientOptions, managed
 // newOAuthTokenCredential returns new OAuth token credential.
 func newOAuthTokenCredential(clientOpts *azcore.ClientOptions, oAuthConfig *OAuthConfig) (azcore.TokenCredential, error) {
 	opts := &azidentity.ClientSecretCredentialOptions{ClientOptions: *clientOpts}
-	return azidentity.NewClientSecretCredential(oAuthConfig.TenantID, oAuthConfig.ClientID, oAuthConfig.ClientSecret, opts)
+	return azidentity.NewClientSecretCredential(oAuthConfig.TenantID, oAuthConfig.ClientID, string(oAuthConfig.ClientSecret), opts)
 }
 
 // newSDKTokenCredential returns new SDK token credential.

--- a/storage/remote/azuread/azuread_test.go
+++ b/storage/remote/azuread/azuread_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	config_util "github.com/prometheus/common/config"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -32,11 +33,11 @@ import (
 )
 
 const (
-	dummyAudience     = "dummyAudience"
-	dummyClientID     = "00000000-0000-0000-0000-000000000000"
-	dummyClientSecret = "Cl1ent$ecret!"
-	dummyTenantID     = "00000000-a12b-3cd4-e56f-000000000000"
-	testTokenString   = "testTokenString"
+	dummyAudience                        = "dummyAudience"
+	dummyClientID                        = "00000000-0000-0000-0000-000000000000"
+	dummyClientSecret config_util.Secret = "Cl1ent$ecret!"
+	dummyTenantID                        = "00000000-a12b-3cd4-e56f-000000000000"
+	testTokenString                      = "testTokenString"
 )
 
 func testTokenExpiry() time.Time { return time.Now().Add(5 * time.Second) }


### PR DESCRIPTION
## Summary

Backports the upstream Prometheus fix [prometheus/prometheus#18586](https://github.com/prometheus/prometheus/pull/18586) (GHSA-wg65-39gg-5wfj / CVE-2026-42151) to our fork.

`OAuthConfig.ClientSecret` in `storage/remote/azuread` was typed as a plain `string`, so the value leaked verbatim through the `/-/config` HTTP API endpoint. Prometheus redacts fields of type `config.Secret` to `<secret>` via that type's `MarshalYAML` / `MarshalJSON` methods; switching the field to `Secret` plugs the leak. The string value is explicitly recovered only at the `azidentity.NewClientSecretCredential` boundary, where a literal string is required.

### Changes
- \`storage/remote/azuread/azuread.go\`: import \`config_util \"github.com/prometheus/common/config\"\`, change \`ClientSecret string\` → \`ClientSecret config_util.Secret\`, wrap with \`string(...)\` at the credential call site.
- \`storage/remote/azuread/azuread_test.go\`: typed \`dummyClientSecret\` as \`config_util.Secret\` so existing tests still type-check.
- \`CHANGELOG.md\`: entry under \`v0.8.0\` → \`Fixes\`.

### Why Dependabot couldn't reach this
Alerts [#183](https://github.com/deckhouse/prompp/security/dependabot/183) and [#184](https://github.com/deckhouse/prompp/security/dependabot/184) pin the advisory to \`pp/tools/block_converter/go.mod\` and \`documentation/examples/remote_storage/go.mod\` — those are offline tools / examples that don't load Azure AD config and don't expose \`/-/config\`. The actual vulnerable code lives inside our Prometheus fork tree, which Dependabot doesn't watch because we are not an external consumer of \`github.com/prometheus/prometheus\`. They can be dismissed as \`not used\` once this PR ships.

## Test plan

- [x] \`go test -tags stringlabels ./storage/remote/azuread/...\` in devcontainer — all tests pass.
- [x] \`prometheus/common@v0.59.1\` already used by the main go.mod (\`type Secret string\` with redacting \`MarshalYAML\`/\`MarshalJSON\`) — no module bump needed.


Made with [Cursor](https://cursor.com)