### PR TITLE
chore(bazel): mark test/lint-only deps as dev_dependency

### DIFF
--- a/pp/MODULE.bazel
+++ b/pp/MODULE.bazel
@@ -17,7 +17,10 @@ bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
 
 # --- Tools not published to BCR (use git_override) ----------------------------
-bazel_dep(name = "bazel_clang_tidy")
+# bazel_clang_tidy is only used by `make tidy` (clang-tidy aspect); it never
+# enters the production entrypoint build, so it is a dev-only dependency. This
+# lets closed-loop builds skip mirroring it via `--ignore_dev_dependency`.
+bazel_dep(name = "bazel_clang_tidy", dev_dependency = True)
 git_override(
     module_name = "bazel_clang_tidy",
     commit = "c4d35e0d0b838309358e57a2efed831780f85cd0",
@@ -59,16 +62,15 @@ register_toolchains(
 
 # --- Third-party C/C++ libraries (local module extension) ---------------------
 # These libraries are not consumed from BCR because we maintain custom BUILD
-# files and/or local patches for them. The extension below mirrors the former
-# WORKSPACE declarations.
+# files and/or local patches for them. Two extensions are used so that the
+# dev-only set (gtest, google_benchmark, tracy) can be skipped via
+# `--ignore_dev_dependency` in closed-loop production builds.
 third_party = use_extension("//third_party:deps.bzl", "third_party_deps")
 use_repo(
     third_party,
     "cedar",
     "com_google_absl",
     "fastfloat_header",
-    "google_benchmark",
-    "gtest",
     "jemalloc",
     "lz4",
     "parallel_hashmap",
@@ -78,6 +80,20 @@ use_repo(
     "scope_exit",
     "simdutf",
     "snappy",
-    "tracy",
     "xxHash",
+)
+
+# Dev-only third-party libs: gtest (cc_test rules), google_benchmark
+# (//:benchmark and benchmark binaries) and tracy (//:profiling, only consumed
+# by benchmark targets).
+third_party_dev = use_extension(
+    "//third_party:deps.bzl",
+    "third_party_dev_deps",
+    dev_dependency = True,
+)
+use_repo(
+    third_party_dev,
+    "google_benchmark",
+    "gtest",
+    "tracy",
 )

--- a/pp/third_party/deps.bzl
+++ b/pp/third_party/deps.bzl
@@ -1,17 +1,26 @@
-"""Module extension declaring third-party C/C++ dependencies with custom BUILD
+"""Module extensions declaring third-party C/C++ dependencies with custom BUILD
 files and/or local patches.
 
 These declarations live here (rather than in BCR) because we maintain custom
 BUILD files and/or local patches per repository. For each repository we keep
 its canonical name so that existing `@name//:target` references in BUILD files
-and patches resolve correctly after `use_repo(third_party_deps, "name")` in
+and patches resolve correctly after `use_repo(<extension>, "name")` in
 MODULE.bazel.
+
+Two extensions are exposed:
+
+* `third_party_deps` — declares libraries reachable from the production
+  entrypoint build (`//:entrypoint_aio` / `//:entrypoint_init_aio`).
+* `third_party_dev_deps` — declares libraries used only by tests, benchmarks
+  and profiling (gtest, google_benchmark, tracy). MODULE.bazel pulls this
+  extension in with `dev_dependency = True` so closed-loop / production builds
+  do not need to mirror these archives (`--ignore_dev_dependency` skips them).
 """
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 
-def _third_party_deps_impl(_ctx):
+def _third_party_dev_deps_impl(_ctx):
     git_repository(
         name = "gtest",
         commit = "d72f9c8aea6817cdf1ca0ac10887f328de7f3da2",
@@ -40,6 +49,9 @@ def _third_party_deps_impl(_ctx):
         url = "https://github.com/wolfpld/tracy/archive/refs/tags/v0.12.0.tar.gz",
     )
 
+third_party_dev_deps = module_extension(implementation = _third_party_dev_deps_impl)
+
+def _third_party_deps_impl(_ctx):
     http_archive(
         name = "jemalloc",
         build_file = Label("//third_party:jemalloc.BUILD"),


### PR DESCRIPTION
## Summary

Marks Bazel module dependencies that are not reachable from the production entrypoint as `dev_dependency`, so closed-loop / production builds invoked with `--ignore_dev_dependency` no longer need to mirror these archives:

- `bazel_clang_tidy` (top-level `bazel_dep`) — used only by `make tidy` (clang-tidy aspect).
- `gtest` — used only by `cc_test` rules and test binaries (`integration_tests`, `performance_tests_bin`).
- `google_benchmark` — used only by `:benchmark`, `wal_benchmark`, `benchmarks_all`.
- `tracy` — used only by `:profiling`, which is consumed only by benchmark targets.

The `third_party` module extension is split into a prod extension and a dev extension (`third_party_dev_deps`, pulled in with `dev_dependency = True`). Repository names are unchanged so existing `@gtest//...`, `@tracy//...` and `@google_benchmark//...` references in BUILD files continue to resolve.

`hedron_compile_commands` was already `dev_dependency = True`. All other deps (`bazel_skylib`, `platforms`, `rules_cc`, `rules_foreign_cc` and the third-party libs `cedar`, `com_google_absl`, `fastfloat_header`, `jemalloc`, `lz4`, `parallel_hashmap`, `quasis_crypto`, `re2`, `roaring`, `scope_exit`, `simdutf`, `snappy`, `xxHash`) stay non-dev — they are reachable from `//:entrypoint_aio`.

## Verification (ARM devcontainer)

- `bazel mod graph --ignore_dev_dependency` — `bazel_clang_tidy` and `hedron_compile_commands` no longer appear in the graph.
- `bazel query --ignore_dev_dependency '@gtest//:gtest_main'` / `'@tracy//:tracy_headers'` / `'@google_benchmark//:benchmark_main'` — all return "No repository visible", confirming closed-loop builds do not need these archives mirrored.
- `bazel build --ignore_dev_dependency //:entrypoint_init_aio` — OK.
- `bazel build --ignore_dev_dependency //:entrypoint_aio` — OK (full entrypoint built in ~80s).
- `bazel build //:bare_bones_test //:wal_benchmark //:benchmarks_all` (no flag) — OK.
- `bazel build --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect ... //:bare_bones` (no flag) — OK; `make tidy` still works.

## Test plan

- [ ] CI green on this branch
- [ ] Closed-loop build pipeline confirms `gtest`, `google_benchmark`, `tracy`, `bazel_clang_tidy` no longer need mirroring (use `--ignore_dev_dependency` for prod build)

Made with [Cursor](https://cursor.com)