### PR TITLE
Remove Crane from setup step in CI

### DIFF
--- a/.github/actions/setup-werf/action.yaml
+++ b/.github/actions/setup-werf/action.yaml
@@ -21,16 +21,9 @@ runs:
       with:
         channel: ${{ inputs.channel }}
 
-    - uses: imjasonh/setup-crane@v0.4
-
     - name: Print werf version
       shell: bash
       run: werf version
-
-    - name: Print crane version
-      shell: bash
-      run: crane version
-
 
     - name: Login into registry ${{ inputs.registry }}
       shell: bash


### PR DESCRIPTION
## Description
Remove Crane from setup step in CI
  
  ## Why do we need it, and what problem does it solve?
Crane is useless in our CI
  
  ## Why do we need it in the patch release (if we do)?
  
Not necessarily

## Checklist
   - [ ] The code is covered by unit tests.
   - [ ] e2e tests passed.
   - [ ] Documentation updated according to the changes.
   - [ ] Changes were tested in the Kubernetes cluster manually.

## Changelog entries
  <!---
  Describe the changes so they will be included in a release changelog.

  Find examples and documentation below, or visit the [Guidelines for working with PRs](https://github.com/deckhouse/deckhouse/wiki/Guidelines-for-working-with-PRs).
  -->
  
  ```changes
   type: fix 
   summary: Remove Crane from setup step in CI
   impact_level: low
  ```
  
  <!---
  `impact_level: default` adds to changelog as usual, this is the default that can be omitted
  `impact_level: high`    something important for users, the impact will be copied to "Know Before Update" section
  `impact_level: low`     omitted in changelog YAML; note there is `type:chore` for chores
  -->