### PR TITLE
chore(renovate): enforce 90-day cool-down with trusted-vendor allowlist

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,84 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "minimumReleaseAge": "90 days",
+  "internalChecksFilter": "strict",
+
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": "0 days",
+    "labels": ["security"],
+    "prPriority": 5
+  },
+  "osvVulnerabilityAlerts": true,
+
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+
   "packageRules": [
+    {
+      "description": "Trusted vendors (large orgs / foundations with strong release discipline). Shorten the 90-day cool-down to 14 days: enough time for the upstream to yank or patch a bad release (e.g. aws-sdk-go v1.55.6), but no longer than that. CVEs still flow through the vulnerabilityAlerts channel without any delay.",
+      "matchSourceUrlPrefixes": [
+        "https://github.com/google/",
+        "https://github.com/googleapis/",
+        "https://github.com/grpc/",
+        "https://github.com/grpc-ecosystem/",
+        "https://github.com/golang/",
+
+        "https://github.com/aws/",
+
+        "https://github.com/moby/",
+
+        "https://github.com/Azure/",
+        "https://github.com/Microsoft/",
+        "https://github.com/microsoft/",
+
+        "https://github.com/hashicorp/",
+
+        "https://github.com/envoyproxy/",
+        "https://github.com/prometheus/",
+        "https://github.com/kubernetes/",
+        "https://github.com/kubernetes-sigs/",
+        "https://github.com/opencontainers/",
+
+        "https://github.com/uber/",
+        "https://github.com/uber-go/",
+
+        "https://github.com/digitalocean/",
+        "https://github.com/hetznercloud/",
+        "https://github.com/linode/",
+        "https://github.com/ovh/",
+        "https://github.com/scaleway/",
+        "https://github.com/ionos-cloud/",
+        "https://github.com/vultr/",
+        "https://github.com/gophercloud/",
+
+        "https://github.com/grafana/"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+    {
+      "description": "Trusted Go-module paths that don't live on github.com. Same 14-day cool-down rationale as the trusted-vendors rule above.",
+      "matchPackageNames": [
+        "google.golang.org/**",
+        "cloud.google.com/**",
+        "golang.org/x/**",
+        "k8s.io/**",
+        "go.opentelemetry.io/**",
+        "go.uber.org/**"
+      ],
+      "minimumReleaseAge": "14 days"
+    },
+
     {
       "description": "Pin github.com/prometheus/prometheus to the v2.x line (Go module versions < v0.300.0). v3.x releases are published as v0.300.0+ and require major migration work, so we stay on the latest v2.x until migration is planned.",
       "matchPackageNames": ["github.com/prometheus/prometheus"],
       "allowedVersions": "<0.300.0"
+    },
+    {
+      "description": "Stay on aws-sdk-go v1.55.5: newer v1.55.x revisions added package-level // Deprecated: annotations that staticcheck (SA1019) reports as fatal across upstream discovery/aws/*. Bump only after migrating to aws-sdk-go-v2 (see #330).",
+      "matchPackageNames": ["github.com/aws/aws-sdk-go"],
+      "allowedVersions": "<1.55.6"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Make Renovate wait for fresh releases to settle before opening update PRs.
Security updates still land immediately.

### Cool-down matrix

| Category | Wait |
|---|---|
| CVE / security alert (Dependabot + OSV.dev) | **0 days** |
| Trusted vendors (Google, AWS, Azure, HashiCorp, CNCF projects, major cloud providers, Grafana Labs, Uber, Moby, …) | **14 days** |
| Everything else | **90 days** |

Vendor allowlist covers the orgs/foundations actually present in `go.mod` (Go) and `pp/third_party/deps.bzl` (Bazel). Releases from these orgs are well-reviewed and broken builds are usually yanked or patched within days — 14 days is enough to catch that without blocking obvious bumps for a full quarter.

Security CVEs bypass everything via `vulnerabilityAlerts` (GitHub Dependabot) and `osvVulnerabilityAlerts` (OSV.dev): immediate PR, `security` label, `prPriority: 5`.

### Other changes

- `prHourlyLimit: 5` / `prConcurrentLimit: 10` to cap bot flood.
- New pin: `github.com/aws/aws-sdk-go` to `<1.55.6` — v1.55.6+ adds package-level `// Deprecated:` annotations that trip staticcheck (SA1019) across upstream `discovery/aws/*`. Bump only after migrating to aws-sdk-go-v2 (see #330).
- Existing pin on `github.com/prometheus/prometheus` to `<0.300.0` kept as is.

## Visible effect

- Renovate will defer PRs for freshly-released libraries (90d, or 14d for trusted vendors).
- The currently-open #330 (`aws-sdk-go` → 1.55.6) will be auto-closed by the bot on its next run.
- CVE PRs continue to arrive instantly.

## Test plan

- [ ] Wait for Renovate's next run on `pp`; it should re-evaluate the open dependency PRs.
- [ ] Verify #330 is auto-closed (or no longer reopened) due to the `aws-sdk-go <1.55.6` allowedVersions rule.
- [ ] Spot-check that a fresh release from an allowlisted org (e.g. `golang.org/x/*`) shows up with a 14-day delay, while a non-allowlisted lib gets the full 90 days.

Made with [Cursor](https://cursor.com)