### PR TITLE
switch to instant_query

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -2238,6 +2238,10 @@ func readPromPPFeatures(logger log.Logger) {
 			)
 
 			remotewriter.DefaultSampleAgeLimit = defaultSampleAgeLimit
+
+		case "enable_instant_query_feature":
+			querier.InstantQueryFeature = true
+			_ = level.Info(logger).Log("msg", "[FEATURE] Instant query feature is enabled.")
 		}
 	}
 }

--- a/pp/go/storage/querier/querier.go
+++ b/pp/go/storage/querier/querier.go
@@ -18,6 +18,9 @@ import (
 	"github.com/prometheus/prometheus/util/annotations"
 )
 
+// InstantQueryFeature is a feature flag for instant query when hints step is 0 and range is 0.
+var InstantQueryFeature = false
+
 const (
 	// lssQueryInstantQuerySelector name of task.
 	lssQueryInstantQuerySelector = "lss_query_instant_query_selector"
@@ -146,6 +149,11 @@ func (q *Querier[TTask, TDataStorage, TLSS, TShard, THead]) Select(
 	if q.mint == q.maxt {
 		return q.selectInstant(ctx, sortSeries, hints, matchers...)
 	}
+
+	if InstantQueryFeature && hints != nil && hints.Step == 0 && hints.Range == 0 {
+		return q.selectInstant(ctx, sortSeries, hints, matchers...)
+	}
+
 	return q.selectRange(ctx, sortSeries, hints, matchers...)
 }
 


### PR DESCRIPTION
## Description
Add switch on instant_query from InstantQuerier when both hints step and range are set to zero.
Add ```PROMPP_FEATURES``` flag ```enable_instant_query_feature``` for enable.