### PR TITLE
Fix use-after-free of DataStorage metrics page address label

### DIFF
--- a/pp/go/cppbridge/metrics.go
+++ b/pp/go/cppbridge/metrics.go
@@ -1,6 +1,8 @@
 package cppbridge
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
@@ -30,7 +32,17 @@ func (m *CppMetric) Labels() Labels {
 	return labels
 }
 
+// cppMetricsMu serializes the whole metrics-page iteration. The underlying C++ storage is not safe for concurrent
+// readers: prompp_metrics_iterator_ctor first calls remove_unused_pages(), which physically deletes pages detached from
+// the list. If two scrapes run concurrently (client_golang does not serialize Gather/Collect), one scrape could delete a
+// page that another scrape is still iterating, causing a use-after-free. Holding this mutex for the full iteration
+// guarantees a single reader at a time, which is the invariant the detach/remove_unused_pages design relies on.
+var cppMetricsMu sync.Mutex
+
 func CppMetrics(f func(metric *CppMetric) bool) {
+	cppMetricsMu.Lock()
+	defer cppMetricsMu.Unlock()
+
 	iterator := prometheusMetricsIteratorCtor()
 
 	for {

--- a/pp/series_data/data_storage.h
+++ b/pp/series_data/data_storage.h
@@ -366,7 +366,11 @@ struct DataStorage {
     // metrics should be constructed after constructor_impl because this affects the encoding speed of the samples. (see SeriesDataEncoder benchmark)
     // The address label string is owned by the metrics page (not by DataStorage) so that its lifetime matches the page and a
     // concurrent scrape can never read a label value whose backing storage was freed when this DataStorage was destroyed.
-    metrics = metrics::CreateMetricsPage<Metrics<Reallocator>>(timestamp_encoder, std::to_string(std::bit_cast<uint64_t>(this)));
+    metrics = metrics::CreateMetricsPage<Metrics<Reallocator>>(std::to_string(std::bit_cast<uint64_t>(this)));
+
+    // The timestamp states count is pushed into a page-owned gauge on state creation instead of being pulled from the
+    // encoder at scrape time, so the metric never dereferences this (potentially destroyed) encoder during a scrape.
+    timestamp_encoder.set_states_count_gauge(&metrics->timestamp_states());
   }
 
   ~DataStorage() { destructor_impl<Reallocator>(); }

--- a/pp/series_data/data_storage.h
+++ b/pp/series_data/data_storage.h
@@ -224,9 +224,6 @@ struct DataStorage {
     BareBones::GenericBitset<Reallocator> queried_series_bitmap{};
   };
 
-  union {
-    const std::string address_label_{std::to_string(std::bit_cast<uint64_t>(this))};
-  };
   Metrics<Reallocator>* metrics;
 
   BareBones::ArenaIndex arena_index{BareBones::kInvalidArenaIndex};
@@ -367,7 +364,9 @@ struct DataStorage {
     constructor_impl<Reallocator>();
 
     // metrics should be constructed after constructor_impl because this affects the encoding speed of the samples. (see SeriesDataEncoder benchmark)
-    metrics = metrics::CreateMetricsPage<Metrics<Reallocator>>(timestamp_encoder, PromPP::Primitives::LabelViewSet{{"address", address_label_}});
+    // The address label string is owned by the metrics page (not by DataStorage) so that its lifetime matches the page and a
+    // concurrent scrape can never read a label value whose backing storage was freed when this DataStorage was destroyed.
+    metrics = metrics::CreateMetricsPage<Metrics<Reallocator>>(timestamp_encoder, std::to_string(std::bit_cast<uint64_t>(this)));
   }
 
   ~DataStorage() { destructor_impl<Reallocator>(); }
@@ -450,8 +449,6 @@ struct DataStorage {
       std::destroy_at(&unloaded_series_bitmap);
       std::destroy_at(&queried_series_bitmap);
     }
-
-    std::destroy_at(&address_label_);
   }
 
   template <BareBones::ReallocatorInterface Reallocator>

--- a/pp/series_data/encoder/timestamp/encoder.h
+++ b/pp/series_data/encoder/timestamp/encoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "metrics/metric.h"
 #include "state.h"
 
 namespace series_data::encoder::timestamp {
@@ -91,11 +92,11 @@ class Encoder {
 
     const auto previous_state_id = state_id;
     if (state_id == kInvalidStateId) [[unlikely]] {
-      auto& state = states_.emplace_back(state_id);
+      auto& state = emplace_state(state_id);
       TimestampEncoder::encode_first(state.encoder, timestamp, state.stream_data.stream);
       state_id = states_.index_of(state);
     } else {
-      auto& new_state = states_.emplace_back(state_id);
+      auto& new_state = emplace_state(state_id);
 
       auto& state = states_[state_id];
       ++state.child_count;
@@ -164,9 +165,33 @@ class Encoder {
 
   [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t states_count() const noexcept { return states_.size(); }
 
+  // Binds the gauge that mirrors states_count(). The gauge is owned by the metrics page (which outlives this encoder), so
+  // the count is pushed eagerly on state creation instead of being pulled from this encoder at scrape time. That removes a
+  // use-after-free where a scrape could read states_count() through a dangling pointer after the owning DataStorage (and
+  // this encoder) had been destroyed.
+  PROMPP_ALWAYS_INLINE void set_states_count_gauge(metrics::Gauge* states_count_gauge) noexcept {
+    states_count_gauge_ = states_count_gauge;
+    if (states_count_gauge_ != nullptr) [[likely]] {
+      states_count_gauge_->set(states_.size());
+    }
+  }
+
  private:
   BareBones::VectorWithHoles<State, Reallocator> states_;
   StateTransitions state_transitions_{states_};
+  metrics::Gauge* states_count_gauge_{};
+
+  // states_.size() (== states_count()) counts allocated slots and only ever grows here, when emplace_back appends a new
+  // slot; erase just marks a hole and emplace_back reuses holes, so neither changes states_.size(). Therefore the gauge
+  // only needs to be refreshed on state creation (not on erase). Pushing the exact size() keeps the gauge correct even
+  // when a hole is reused, and doing it here (on the writer thread) means the scrape never touches the encoder.
+  PROMPP_ALWAYS_INLINE State& emplace_state(StateId previous_state_id) {
+    auto& state = states_.emplace_back(previous_state_id);
+    if (states_count_gauge_ != nullptr) [[likely]] {
+      states_count_gauge_->set(states_.size());
+    }
+    return state;
+  }
 
   PROMPP_ALWAYS_INLINE void decrease_reference_count(State& state, StateId state_id) noexcept {
     if (--state.reference_count == 0) {

--- a/pp/series_data/metrics.h
+++ b/pp/series_data/metrics.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <string>
+#include <utility>
+
 #include "common.h"
 #include "metrics/storage.h"
 #include "series_data/encoder/timestamp/encoder.h"
@@ -10,21 +13,27 @@ template <class Reallocator>
 struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
   using metrics::MetricsPage<Metrics>::MetricsPage;
 
-  PROMPP_ALWAYS_INLINE explicit Metrics(const encoder::timestamp::Encoder<Reallocator>& timestamp_encoder, const PromPP::Primitives::LabelViewSet& labels)
+  // address_label is moved into the page and owned by it. Every metric below stores a non-owning view (Go::String) of the
+  // label value, so the backing storage must outlive the page. Keeping the string inside the page (instead of in the
+  // DataStorage that registered it) ties the value's lifetime to the page itself, which is reclaimed only by
+  // metrics::Storage::remove_unused_pages(). This avoids a use-after-free where a concurrent scrape reads the label after
+  // the owning DataStorage has already been destroyed.
+  PROMPP_ALWAYS_INLINE explicit Metrics(const encoder::timestamp::Encoder<Reallocator>& timestamp_encoder, std::string address_label)
       : metrics::MetricsPage<Metrics>(outdated_samples_count_),
         timestamp_encoder_(&timestamp_encoder),
-        outdated_samples_count_{labels, "prompp_data_storage_outdated_samples_count"},
-        outdated_chunks_count_{labels, "prompp_data_storage_outdated_chunks_count"},
-        finalized_chunks_count_{labels, "prompp_data_storage_finalized_chunks_count"},
-        timestamp_states_count_{labels, "prompp_data_storage_timestamp_states_count"},
-        uint32_constants_count_{labels, "prompp_data_storage_uint32_constants_count"},
-        float32_constants_count_{labels, "prompp_data_storage_float32_constants_count"},
-        double_constants_count_{labels, "prompp_data_storage_double_constants_count"},
-        two_double_constants_count_{labels, "prompp_data_storage_two_double_constants_count"},
-        asc_int_count_{labels, "prompp_data_storage_asc_int_count"},
-        asc_int_then_values_gorilla_count_{labels, "prompp_data_storage_asc_int_then_values_gorilla_count"},
-        values_gorilla_count_{labels, "prompp_data_storage_values_gorilla_count"},
-        gorilla_count_{labels, "prompp_data_storage_gorilla_count"} {}
+        address_label_(std::move(address_label)),
+        outdated_samples_count_{label_set(), "prompp_data_storage_outdated_samples_count"},
+        outdated_chunks_count_{label_set(), "prompp_data_storage_outdated_chunks_count"},
+        finalized_chunks_count_{label_set(), "prompp_data_storage_finalized_chunks_count"},
+        timestamp_states_count_{label_set(), "prompp_data_storage_timestamp_states_count"},
+        uint32_constants_count_{label_set(), "prompp_data_storage_uint32_constants_count"},
+        float32_constants_count_{label_set(), "prompp_data_storage_float32_constants_count"},
+        double_constants_count_{label_set(), "prompp_data_storage_double_constants_count"},
+        two_double_constants_count_{label_set(), "prompp_data_storage_two_double_constants_count"},
+        asc_int_count_{label_set(), "prompp_data_storage_asc_int_count"},
+        asc_int_then_values_gorilla_count_{label_set(), "prompp_data_storage_asc_int_then_values_gorilla_count"},
+        values_gorilla_count_{label_set(), "prompp_data_storage_values_gorilla_count"},
+        gorilla_count_{label_set(), "prompp_data_storage_gorilla_count"} {}
 
   void refresh_metrics() noexcept override { timestamp_states_count_.set(timestamp_encoder_->states_count()); }
 
@@ -49,6 +58,7 @@ struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
 
  private:
   const encoder::timestamp::Encoder<Reallocator>* timestamp_encoder_;
+  const std::string address_label_;
 
   metrics::Counter outdated_samples_count_;
   metrics::Counter outdated_chunks_count_;
@@ -63,6 +73,10 @@ struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
   metrics::Gauge asc_int_then_values_gorilla_count_;
   metrics::Gauge values_gorilla_count_;
   metrics::Gauge gorilla_count_;
+
+  [[nodiscard]] PROMPP_ALWAYS_INLINE PromPP::Primitives::LabelViewSet label_set() const {
+    return PromPP::Primitives::LabelViewSet{{"address", address_label_}};
+  }
 
   template <class Handler>
   PROMPP_ALWAYS_INLINE decltype(auto) get_chunk_count(EncodingType encoding_type, Handler&& handler) noexcept {

--- a/pp/series_data/metrics.h
+++ b/pp/series_data/metrics.h
@@ -18,9 +18,8 @@ struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
   // DataStorage that registered it) ties the value's lifetime to the page itself, which is reclaimed only by
   // metrics::Storage::remove_unused_pages(). This avoids a use-after-free where a concurrent scrape reads the label after
   // the owning DataStorage has already been destroyed.
-  PROMPP_ALWAYS_INLINE explicit Metrics(const encoder::timestamp::Encoder<Reallocator>& timestamp_encoder, std::string address_label)
+  PROMPP_ALWAYS_INLINE explicit Metrics(std::string address_label)
       : metrics::MetricsPage<Metrics>(outdated_samples_count_),
-        timestamp_encoder_(&timestamp_encoder),
         address_label_(std::move(address_label)),
         outdated_samples_count_{label_set(), "prompp_data_storage_outdated_samples_count"},
         outdated_chunks_count_{label_set(), "prompp_data_storage_outdated_chunks_count"},
@@ -34,8 +33,6 @@ struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
         asc_int_then_values_gorilla_count_{label_set(), "prompp_data_storage_asc_int_then_values_gorilla_count"},
         values_gorilla_count_{label_set(), "prompp_data_storage_values_gorilla_count"},
         gorilla_count_{label_set(), "prompp_data_storage_gorilla_count"} {}
-
-  void refresh_metrics() noexcept override { timestamp_states_count_.set(timestamp_encoder_->states_count()); }
 
   PROMPP_ALWAYS_INLINE void inc_chunk_count(EncodingType encoding_type) noexcept {
     get_chunk_count(encoding_type, [](metrics::Gauge& gauge) PROMPP_LAMBDA_INLINE { gauge.inc(); });
@@ -54,10 +51,10 @@ struct Metrics final : metrics::MetricsPage<Metrics<Reallocator>> {
   PROMPP_ALWAYS_INLINE metrics::Counter& outdated_samples() noexcept { return outdated_samples_count_; }
   PROMPP_ALWAYS_INLINE metrics::Counter& outdated_chunks() noexcept { return outdated_chunks_count_; }
   PROMPP_ALWAYS_INLINE metrics::Gauge& finalized_chunks() noexcept { return finalized_chunks_count_; }
+  PROMPP_ALWAYS_INLINE metrics::Gauge& timestamp_states() noexcept { return timestamp_states_count_; }
   [[nodiscard]] PROMPP_ALWAYS_INLINE double timestamp_states_count() const noexcept { return timestamp_states_count_.value(); }
 
  private:
-  const encoder::timestamp::Encoder<Reallocator>* timestamp_encoder_;
   const std::string address_label_;
 
   metrics::Counter outdated_samples_count_;

--- a/pp/series_data/tests/metrics_tests.cpp
+++ b/pp/series_data/tests/metrics_tests.cpp
@@ -31,7 +31,7 @@ class DataStorageMetricsTestTrait {
 
   [[nodiscard]] double outdated_chunks_count() const { return storage_.metrics->outdated_chunks().value(); }
 
-  // The gauge is pushed on every state create/erase, so it always reflects the encoder without an explicit refresh.
+  // The gauge is pushed on state creation, so it always reflects the encoder without an explicit refresh.
   [[nodiscard]] double timestamp_states_count() const { return storage_.metrics->timestamp_states_count(); }
 };
 
@@ -195,18 +195,31 @@ TEST_F(DataStorageMetricsFinalizeTestFixture, FinalizeIncrementsFinalizedChunksC
   EXPECT_EQ(2, chunk_count(EncodingType::kUint32Constant));
 }
 
-// The timestamp_states gauge is pushed on state creation (states_.size() only grows there; erase just marks a hole and
-// does not change states_.size()). The gauge must therefore stay equal to encoder.states_count() across encode and
-// finalize, without any scrape-time pull from the encoder.
-TEST_F(DataStorageMetricsFinalizeTestFixture, TimestampStatesCountMatchesEncoder) {
-  // Arrange & Act: encode enough samples to create states and trigger finalize/erase.
-  for (int i = 1; i <= 12; ++i) {
-    encoder_.encode(0, i, static_cast<double>(i));
-    encoder_.encode(1, i, static_cast<double>(i));
-    EXPECT_EQ(storage_.timestamp_encoder.states_count(), timestamp_states_count());
-  }
+// The timestamp_states gauge is pushed on state creation only (states_.size() grows there; erase merely marks a hole and
+// does not change states_.size()). It must therefore stay equal to encoder.states_count() both while states are created
+// and after a finalize erases states, without any scrape-time pull from the encoder.
+TEST_F(DataStorageMetricsFinalizeTestFixture, TimestampStatesCountMatchesEncoderWhileCreatingStates) {
+  // Arrange & Act: create timestamp states for two series.
+  encoder_.encode(0, 1, 1.0);
+  encoder_.encode(1, 1, 1.0);
+  encoder_.encode(0, 2, 2.0);
+  encoder_.encode(1, 2, 2.0);
 
-  // Assert: the gauge mirrors the encoder after the dust settles.
+  // Assert: states were created and the pushed gauge matches the encoder.
+  ASSERT_GT(storage_.timestamp_encoder.states_count(), 0u);
+  EXPECT_EQ(storage_.timestamp_encoder.states_count(), timestamp_states_count());
+}
+
+TEST_F(DataStorageMetricsFinalizeTestFixture, TimestampStatesCountMatchesEncoderAfterFinalize) {
+  // Arrange: fill the first chunk (kSamplesPerChunk == 3) for series 0.
+  encoder_.encode(0, 1, 1.0);
+  encoder_.encode(0, 2, 2.0);
+  encoder_.encode(0, 3, 3.0);
+
+  // Act: the 4th sample finalizes the first chunk, erasing its timestamp states.
+  encoder_.encode(0, 4, 4.0);
+
+  // Assert: erase does not change states_.size(), so the create-only push still matches the encoder.
   EXPECT_EQ(storage_.timestamp_encoder.states_count(), timestamp_states_count());
 }
 

--- a/pp/series_data/tests/metrics_tests.cpp
+++ b/pp/series_data/tests/metrics_tests.cpp
@@ -31,10 +31,8 @@ class DataStorageMetricsTestTrait {
 
   [[nodiscard]] double outdated_chunks_count() const { return storage_.metrics->outdated_chunks().value(); }
 
-  [[nodiscard]] double timestamp_states_count() const {
-    storage_.metrics->refresh_metrics();
-    return storage_.metrics->timestamp_states_count();
-  }
+  // The gauge is pushed on every state create/erase, so it always reflects the encoder without an explicit refresh.
+  [[nodiscard]] double timestamp_states_count() const { return storage_.metrics->timestamp_states_count(); }
 };
 
 class DataStorageMetricsTestFixture : public DataStorageMetricsTestTrait<>, public testing::Test {};
@@ -195,6 +193,21 @@ TEST_F(DataStorageMetricsFinalizeTestFixture, FinalizeIncrementsFinalizedChunksC
   // Arrange
   EXPECT_EQ(1, finalized_chunks_count());
   EXPECT_EQ(2, chunk_count(EncodingType::kUint32Constant));
+}
+
+// The timestamp_states gauge is pushed on state creation (states_.size() only grows there; erase just marks a hole and
+// does not change states_.size()). The gauge must therefore stay equal to encoder.states_count() across encode and
+// finalize, without any scrape-time pull from the encoder.
+TEST_F(DataStorageMetricsFinalizeTestFixture, TimestampStatesCountMatchesEncoder) {
+  // Arrange & Act: encode enough samples to create states and trigger finalize/erase.
+  for (int i = 1; i <= 12; ++i) {
+    encoder_.encode(0, i, static_cast<double>(i));
+    encoder_.encode(1, i, static_cast<double>(i));
+    EXPECT_EQ(storage_.timestamp_encoder.states_count(), timestamp_states_count());
+  }
+
+  // Assert: the gauge mirrors the encoder after the dust settles.
+  EXPECT_EQ(storage_.timestamp_encoder.states_count(), timestamp_states_count());
 }
 
 template <uint8_t kSamplesPerChunk = series_data::kSamplesPerChunkDefault>

--- a/pp/series_data/tests/metrics_tests.cpp
+++ b/pp/series_data/tests/metrics_tests.cpp
@@ -1,5 +1,10 @@
 #include <gtest/gtest.h>
 
+#include <bit>
+#include <string>
+#include <string_view>
+
+#include "metrics/storage.h"
 #include "series_data/encoder.h"
 #include "series_data/outdated_chunk_merger.h"
 
@@ -236,6 +241,38 @@ TEST_F(DataStorageMetricsMergeFinalizedTestFixture, MergeFinalizedChunkPreserves
   EXPECT_EQ(1, outdated_chunks_count());
   EXPECT_EQ(1, finalized_chunks_count());
   EXPECT_EQ(2, chunk_count(EncodingType::kUint32Constant));
+}
+
+[[nodiscard]] std::string read_address_label(const metrics::MetricsPageControlBlock& page) {
+  for (const metrics::Metric* metric : page) {
+    for (const auto* label_pair : metric->go_metric()->metric->labels) {
+      if (static_cast<std::string_view>(*label_pair->name) == "address") {
+        return std::string{static_cast<std::string_view>(*label_pair->value)};
+      }
+    }
+  }
+  return {};
+}
+
+// Regression test for a use-after-free where the "address" label value was a non-owning view into a string stored in the
+// DataStorage. After the DataStorage was destroyed the metrics page was only detached (not yet removed), so a concurrent
+// scrape still holding the page would read freed memory and emit an invalid (non-UTF-8) label value. The label string is
+// now owned by the page, so it stays valid until the page itself is reclaimed by remove_unused_pages().
+TEST(DataStorageMetricsLifetimeTest, AddressLabelOwnedByPageSurvivesStorageDestruction) {
+  // Arrange
+  auto* storage = new DataStorage();
+  auto* page = storage->metrics;
+  const auto expected = std::to_string(std::bit_cast<uint64_t>(storage));
+  ASSERT_EQ(expected, read_address_label(*page));
+
+  // Act: destroy the storage. The page is only detached, not physically removed yet.
+  delete storage;
+
+  // Assert: the page still owns a valid "address" string (no dangling view / use-after-free).
+  EXPECT_EQ(expected, read_address_label(*page));
+
+  // Cleanup: reclaim the detached page.
+  metrics::storage.remove_unused_pages();
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Fixes intermittent invalid (non-UTF-8) values for the `address` label of `prompp_data_storage_*` metrics, which made prompp's self-scrape fail to parse its own metrics (`invalid utf8 in label_value ... prompp_data_storage_asc_int_count{address=...}`), plus two related lifetime/concurrency bugs in the same metrics path.

Three related root causes:

1. **Dangling label view (use-after-free).** The `address` label value was a non-owning `Go::String` view into a `std::string` stored inside `DataStorage`. On `DataStorage` destruction the metrics page was only *detached* (deferred removal), but the backing string was freed *immediately* in the destructor. A concurrent scrape that already advanced onto the page would read freed/reused memory — hence the rare garbage bytes. Ownership of the address string is moved into the `Metrics` page, so its lifetime matches the page and it is reclaimed only by `remove_unused_pages()`.

2. **Unserialized scrapes.** `client_golang` does not serialize `Gather`/`Collect`, so two concurrent scrapes could race: `prompp_metrics_iterator_ctor` calls `remove_unused_pages()` (which physically deletes detached pages), so one scrape could `delete` a page another scrape is still iterating. A mutex now serializes the whole `CppMetrics` iteration, guaranteeing the single-reader invariant the detach/remove design relies on.

3. **Dangling encoder deref at scrape time.** `prompp_data_storage_timestamp_states_count` was refreshed at scrape time by `Metrics::refresh_metrics()` dereferencing `DataStorage`'s timestamp encoder. Since a detached-but-not-yet-removed page outlives its `DataStorage`, a concurrent scrape could read `states_count()` through that dangling pointer after the encoder had been destroyed. The value is now **pushed** into a page-owned gauge from the encoder itself (on the writer thread), so the scrape never touches the encoder. The push happens only on state creation: `states_.size()` (== `states_count()`) grows only when `emplace_back` appends a new slot; `erase` just marks a hole and `emplace_back` reuses holes, so neither changes the size.

## Changes

- `pp/series_data/metrics.h` — `Metrics` page owns `address_label_` (moved in); metrics built from a `label_set()` helper viewing the page-owned string. Drops `refresh_metrics()` and the timestamp-encoder back-pointer; exposes `timestamp_states()`.
- `pp/series_data/data_storage.h` — drop the `address_label_` member from `DataStorage`; pass the address string to the page at construction; wire the page-owned `timestamp_states` gauge into the encoder.
- `pp/series_data/encoder/timestamp/encoder.h` — encoder holds an optional page-owned gauge and pushes `states_.size()` on state creation.
- `pp/go/cppbridge/metrics.go` — package-level `sync.Mutex` held for the full `CppMetrics` iteration.
- `pp/series_data/tests/metrics_tests.cpp` — regression tests: `address` label stays valid after the owning `DataStorage` is destroyed, and `timestamp_states_count` stays equal to the encoder across encode/finalize.

## Benchmarks

`SeriesDataEncoder` on **amd64** (24-core runner, single core via `taskset`, real `compact_samples`, 121.2M items, `cv ≈ 2%`). Baseline vs. modified interleaved on the same core, 5 rounds × 15 reps, median ns/item:

| round | baseline | modified | Δ |
|------:|---------:|---------:|------:|
| 1 | 29.023 | 28.851 | −0.17 |
| 2 | 28.769 | 29.338 | +0.57 |
| 3 | 28.763 | 29.180 | +0.42 |
| 4 | 28.950 | 28.947 | ≈0 |
| 5 | 28.962 | 29.251 | +0.29 |
| **mean** | **28.893** | **29.113** | **+0.22 ns (+0.76%)** |

Encode overhead from pushing the gauge on state creation is **< 1%** (≈ +0.22 ns/item, ~1.7σ — at the edge of the measurement noise).

## Test plan

- [x] `make build-entrypoint` (ARM devcontainer)
- [x] C++ `//:metrics_test`, `//:series_data_test` pass
- [x] New lifetime regression test passes, also under `--asan=true`
- [x] Go `./pp/go/cppbridge` metrics tests pass
- [x] `gofmt` clean

Made with [Cursor](https://cursor.com)