### PR TITLE
add libclang to docker container

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -44,7 +44,7 @@ RUN set -eux; \
     rm -f /tmp/llvm-snapshot.gpg.key; \
     echo "deb [signed-by=/usr/share/keyrings/apt-llvm-org.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-21 main" > /etc/apt/sources.list.d/llvm.list; \
     apt-get update; \
-    apt-get install -y --no-install-recommends clang-format-21 clang-tidy-21; \
+    apt-get install -y --no-install-recommends clang-format-21 clang-tidy-21 libclang-21-dev; \
     ln -sf /usr/lib/llvm-21/bin/clang-tidy /usr/bin/clang-tidy; \
     ln -sf /usr/lib/llvm-21/bin/clang-format /usr/bin/clang-format; \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100; \


### PR DESCRIPTION
Adding libclang (llvm-21 version for consistency with clang-format and clang-tidy) for future entrypoint tooling 