### PR TITLE
Optimized NewLabelsWithLSS

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -2,17 +2,6 @@ FROM debian:trixie-slim
 
 # Align with Deckhouse module (debian-trixie) and libunwind+lzma static link expectations.
 # LLVM 21 from apt.llvm.org (trixie toolchain).
-# binutils-gold: needed only on linux/arm64 because every currently released Go
-# (1.25.x with x<=9 and 1.26.x with x<=2) unconditionally forces `-fuse-ld=gold`
-# for cgo dynamic/PIE links and aborts with "ARM64 external linker must be gold"
-# otherwise (see https://github.com/golang/go/issues/15696 and
-# https://github.com/golang/go/issues/22040). The underlying GNU bfd bug was
-# fixed in binutils 2.36 (we ship 2.44), but Go itself only learned to detect
-# that and fall back to bfd in CL 740480; the backports landed in
-# release-branch.go1.{25,26} on 2026-04-17, *after* the cut of go1.26.2
-# (2026-04-15), so the fix first shipped in Go 1.25.10 / Go 1.26.3.
-# Once GO_VERSION below is bumped to >=1.25.10 or >=1.26.3, this package can
-# be dropped (see https://github.com/golang/go/issues/78405).
 # gcc-16/g++-16: not yet in Trixie; install from sid with apt pinning (default compiler).
 RUN set -eux; \
     apt-get update; \
@@ -21,7 +10,6 @@ RUN set -eux; \
         curl \
         wget \
         gnupg \
-        binutils \
         libunwind-dev \
         liblzma-dev \
         jq \
@@ -46,6 +34,10 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends clang-format-21 clang-tidy-21 libclang-21-dev; \
     apt-get install -y --no-install-recommends -t sid gcc-16 g++-16 libstdc++-16-dev; \
+    apt-get install -y binutils; \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100; \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100; \
+    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-16 100; \
     ln -sf /usr/lib/llvm-21/bin/clang-tidy /usr/bin/clang-tidy; \
     ln -sf /usr/lib/llvm-21/bin/clang-format /usr/bin/clang-format; \
     rm -rf /var/lib/apt/lists/*
@@ -57,10 +49,6 @@ RUN wget -qO "/usr/local/bin/bazel" https://github.com/bazelbuild/bazel/releases
     chmod +x "/usr/local/bin/bazel"
 
 # Go + go-tools (GOPATH under /opt so FIRST_GOPATH/bin/goyacc is found when /root is volume-mounted)
-# TODO: now that GO_VERSION is >=1.25.10 and >=1.26.3, drop the
-# `binutils-gold` package above — those Go releases no longer require gold on
-# linux/arm64 when GNU ld is 2.36+. See the comment near `binutils-gold` and
-# https://github.com/golang/go/issues/22040 (issue #78405 for the 1.25 backport).
 ARG GO_VERSION=1.26.4
 ARG GO_ARCH
 RUN cd /tmp && curl -LOs https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && tar -C /usr/local -xzf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz
@@ -68,11 +56,6 @@ ENV GOPATH="/opt/go"
 ENV PATH="$PATH:/usr/local/go/bin:/opt/go/bin"
 RUN go install github.com/jstemmer/go-junit-report/v2@latest
 RUN go install github.com/prometheus/promu@latest
-
-# Set gcc-16 as default compiler after installing promu
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-16 100; \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-16 100; \
-    update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-16 100;
 
 # goyacc for generating promql/parser (make test, make build)
 ARG GOYACC_VERSION=v0.6.0

--- a/model/labels/labels_common_dedupelabels.go
+++ b/model/labels/labels_common_dedupelabels.go
@@ -1,9 +1,8 @@
-//go:build !stringlabels && !dedupelabels && !cpplabels
+//go:build dedupelabels
 
 package labels
 
 import (
-	"strings"
 	"sync"
 
 	"github.com/prometheus/prometheus/pp/go/cppbridge"
@@ -27,9 +26,7 @@ func NewLabelsWithLSS(lss *cppbridge.LabelSetSnapshot, id uint32) Labels {
 	builder.Reset()
 
 	_ = lss.RangeLabelSet(id, func(l cppbridge.Label) error {
-		// copy string from cpp memory
-		builder.Add(strings.Clone(l.Name), strings.Clone(l.Value))
-
+		builder.Add(l.Name, l.Value)
 		return nil
 	})
 

--- a/model/labels/labels_common_nonslice_noncpp.go
+++ b/model/labels/labels_common_nonslice_noncpp.go
@@ -1,20 +1,14 @@
-//go:build stringlabels || dedupelabels
+//go:build stringlabels
 
 package labels
 
 import "github.com/prometheus/prometheus/pp/go/cppbridge"
 
 // NewLabelsWithLSS init LabelsCpp with LabelSetSnapshot and ls id.
-func NewLabelsWithLSS(lss *cppbridge.LabelSetSnapshot, id uint32, builder *ScratchBuilder) Labels {
+func NewLabelsWithLSS(lss *cppbridge.LabelSetSnapshot, id uint32) Labels {
 	if lss == nil {
 		return EmptyLabels()
 	}
 
-	_ = lss.RangeLabelSet(id, func(l cppbridge.Label) error {
-		builder.Add(l.Name, l.Value)
-
-		return nil
-	})
-
-	return builder.Labels()
+	return Labels{data: lss.Serialize(id)}
 }

--- a/pp/entrypoint/label_set.cpp
+++ b/pp/entrypoint/label_set.cpp
@@ -2,6 +2,7 @@
 
 #include "bare_bones/algorithm.h"
 #include "bare_bones/iterator.h"
+#include "bare_bones/varint.h"
 #include "entrypoint/head/lss.h"
 #include "primitives/go_model.h"
 #include "primitives/go_slice.h"
@@ -25,7 +26,7 @@ void prompp_label_set_length(void* args, void* res) {
   std::visit([in, res](auto& lss) { new (res) Result{.length = lss[in->series_id].size()}; }, *in->lss);
 }
 
-void prompp_label_set_serialize_from_snapshot(void* args, void* res) {
+extern "C" void prompp_label_set_serialize_from_snapshot(void* args, void* res) {
   using PromPP::Primitives::Go::Label;
   using PromPP::Primitives::Go::String;
 
@@ -47,6 +48,55 @@ void prompp_label_set_serialize_from_snapshot(void* args, void* res) {
         out_label_set.reserve(in_label_set.size());
         std::ranges::transform(in_label_set, std::back_inserter(out_label_set),
                                [](const auto& label) PROMPP_LAMBDA_INLINE { return Label({.name = String{label.first}, .value = String{label.second}}); });
+      },
+      *in->snapshot);
+}
+
+extern "C" void prompp_label_set_serialize_from_snapshot_length(void* args) {
+  using BareBones::Encoding::VarInt;
+
+  struct Arguments {
+    SnapshotLSSVariantPtr snapshot;
+    uint32_t series_id;
+    uint32_t length;
+  };
+
+  auto in = static_cast<Arguments*>(args);
+
+  std::visit(
+      [in](auto& snapshot) {
+        uint32_t length{};
+        for (const auto label_set = snapshot[in->series_id]; auto label : label_set) {
+          length += VarInt::length(label.first.size()) + label.first.size() + VarInt::length(label.second.size()) + label.second.size();
+        }
+        in->length = length;
+      },
+      *in->snapshot);
+}
+
+extern "C" void prompp_label_set_serialize_from_snapshot_to_buffer(void* args) {
+  using BareBones::Encoding::VarInt;
+
+  struct Arguments {
+    SnapshotLSSVariantPtr snapshot;
+    Slice<uint8_t> buffer;
+    uint32_t series_id;
+  };
+
+  auto in = static_cast<Arguments*>(args);
+
+  std::visit(
+      [in](auto& snapshot) {
+        auto buffer = in->buffer.data();
+        for (const auto label_set = snapshot[in->series_id]; auto label : label_set) {
+          buffer += VarInt::write(buffer, static_cast<uint64_t>(label.first.size()));
+          std::memcpy(buffer, label.first.data(), label.first.size());
+          buffer += label.first.size();
+
+          buffer += VarInt::write(buffer, static_cast<uint64_t>(label.second.size()));
+          std::memcpy(buffer, label.second.data(), label.second.size());
+          buffer += label.second.size();
+        }
       },
       *in->snapshot);
 }

--- a/pp/entrypoint/label_set.cpp
+++ b/pp/entrypoint/label_set.cpp
@@ -52,24 +52,28 @@ extern "C" void prompp_label_set_serialize_from_snapshot(void* args, void* res) 
       *in->snapshot);
 }
 
-extern "C" void prompp_label_set_serialize_from_snapshot_length(void* args) {
+extern "C" void prompp_label_set_serialize_from_snapshot_length(void* args, void* res) {
   using BareBones::Encoding::VarInt;
 
   struct Arguments {
     SnapshotLSSVariantPtr snapshot;
     uint32_t series_id;
+  };
+
+  struct Result {
     uint32_t length;
   };
 
   auto in = static_cast<Arguments*>(args);
+  auto out = static_cast<Result*>(res);
 
   std::visit(
-      [in](auto& snapshot) {
+      [in, out](auto& snapshot) {
         uint32_t length = 0;
         for (const auto label_set = snapshot[in->series_id]; auto label : label_set) {
           length += VarInt::length(label.first.size()) + label.first.size() + VarInt::length(label.second.size()) + label.second.size();
         }
-        in->length = length;
+        out->length = length;
       },
       *in->snapshot);
 }

--- a/pp/entrypoint/label_set.cpp
+++ b/pp/entrypoint/label_set.cpp
@@ -65,7 +65,7 @@ extern "C" void prompp_label_set_serialize_from_snapshot_length(void* args) {
 
   std::visit(
       [in](auto& snapshot) {
-        uint32_t length{};
+        uint32_t length = 0;
         for (const auto label_set = snapshot[in->series_id]; auto label : label_set) {
           length += VarInt::length(label.first.size()) + label.first.size() + VarInt::length(label.second.size()) + label.second.size();
         }

--- a/pp/entrypoint/label_set.h
+++ b/pp/entrypoint/label_set.h
@@ -31,6 +31,30 @@ void prompp_label_set_length(void* args, void* res);
 void prompp_label_set_serialize_from_snapshot(void* args, void* res);
 
 /**
+ * @brief get serialized label set buffer length by series id
+ *
+ * @param args {
+ *     snapshot   uintptr                      // pointer to constructed snapshot
+ *     labelSetID uint32                       // series id
+ *     length     uint32                       // serialized buffer length
+ * }
+ *
+ */
+void prompp_label_set_serialize_from_snapshot_length(void* args);
+
+/**
+ * @brief serialize label set into buffer by series id
+ *
+ * @param args {
+ *     snapshot   uintptr                      // pointer to constructed snapshot
+ *     buffer     [] byte                      // allocated buffer
+ *     labelSetID uint32                       // series id
+ * }
+ *
+ */
+void prompp_label_set_serialize_from_snapshot_to_buffer(void* args);
+
+/**
  * @brief free label set returned by prompp_label_set_serialize_from_snapshot
  *
  * @param args {

--- a/pp/entrypoint/label_set.h
+++ b/pp/entrypoint/label_set.h
@@ -36,11 +36,13 @@ void prompp_label_set_serialize_from_snapshot(void* args, void* res);
  * @param args {
  *     snapshot   uintptr                      // pointer to constructed snapshot
  *     labelSetID uint32                       // series id
- *     length     uint32                       // serialized buffer length
  * }
  *
+ * @param res {
+ *     length     uint32                       // serialized buffer length
+ * }
  */
-void prompp_label_set_serialize_from_snapshot_length(void* args);
+void prompp_label_set_serialize_from_snapshot_length(void* args, void* res);
 
 /**
  * @brief serialize label set into buffer by series id

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -3263,6 +3263,37 @@ func labelSetSerializeFromSnapshot(snapshot uintptr, labelSetID uint32) []Label 
 	return res.labelSet
 }
 
+func labelSetSerializeFromSnapshotLength(snapshot uintptr, labelSetID uint32) uint32 {
+	args := struct {
+		snapshot   uintptr
+		labelSetID uint32
+		length     uint32
+	}{snapshot, labelSetID, 0}
+
+	testGC()
+	fastcgo.UnsafeCall1(
+		C.prompp_label_set_serialize_from_snapshot_length,
+		uintptr(unsafe.Pointer(&args)),
+	)
+
+	return args.length
+}
+
+func labelSetSerializeFromSnapshotToBuffer(snapshot uintptr, labelSetID uint32, buffer []byte) {
+	args := struct {
+		snapshot   uintptr
+		buffer     []byte
+		labelSetID uint32
+	}{snapshot, buffer, labelSetID}
+
+	testGC()
+	fastcgo.UnsafeCall1(
+		C.prompp_label_set_serialize_from_snapshot_to_buffer,
+		uintptr(unsafe.Pointer(&args)),
+	)
+	runtime.KeepAlive(buffer)
+}
+
 func labelSetFree(labelSet []Label) {
 	if labelSet == nil {
 		return

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -3267,16 +3267,20 @@ func labelSetSerializeFromSnapshotLength(snapshot uintptr, labelSetID uint32) ui
 	args := struct {
 		snapshot   uintptr
 		labelSetID uint32
-		length     uint32
-	}{snapshot, labelSetID, 0}
+	}{snapshot, labelSetID}
+
+	var res struct {
+		length uint32
+	}
 
 	testGC()
-	fastcgo.UnsafeCall1(
+	fastcgo.UnsafeCall2(
 		C.prompp_label_set_serialize_from_snapshot_length,
 		uintptr(unsafe.Pointer(&args)),
+		uintptr(unsafe.Pointer(&res)),
 	)
 
-	return args.length
+	return res.length
 }
 
 func labelSetSerializeFromSnapshotToBuffer(snapshot uintptr, labelSetID uint32, buffer []byte) {

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -438,6 +438,30 @@ void prompp_label_set_length(void* args, void* res);
 void prompp_label_set_serialize_from_snapshot(void* args, void* res);
 
 /**
+ * @brief get serialized label set buffer length by series id
+ *
+ * @param args {
+ *     snapshot  uintptr                      // pointer to constructed snapshot
+ *     ls_id     uint32                       // series id
+ *     length    uint32                       // serialized buffer length
+ * }
+ *
+ */
+void prompp_label_set_serialize_from_snapshot_length(void* args);
+
+/**
+ * @brief serialize label set into buffer by series id
+ *
+ * @param args {
+ *     snapshot  uintptr                      // pointer to constructed snapshot
+ *     buffer    [] byte                      // allocated buffer
+ *     ls_id     uint32                       // series id
+ * }
+ *
+ */
+void prompp_label_set_serialize_from_snapshot_to_buffer(void* args);
+
+/**
  * @brief free label set returned by prompp_label_set_serialize_from_snapshot
  *
  * @param args {

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -441,21 +441,23 @@ void prompp_label_set_serialize_from_snapshot(void* args, void* res);
  * @brief get serialized label set buffer length by series id
  *
  * @param args {
- *     snapshot  uintptr                      // pointer to constructed snapshot
- *     ls_id     uint32                       // series id
- *     length    uint32                       // serialized buffer length
+ *     snapshot   uintptr                      // pointer to constructed snapshot
+ *     labelSetID uint32                       // series id
  * }
  *
+ * @param res {
+ *     length     uint32                       // serialized buffer length
+ * }
  */
-void prompp_label_set_serialize_from_snapshot_length(void* args);
+void prompp_label_set_serialize_from_snapshot_length(void* args, void* res);
 
 /**
  * @brief serialize label set into buffer by series id
  *
  * @param args {
- *     snapshot  uintptr                      // pointer to constructed snapshot
- *     buffer    [] byte                      // allocated buffer
- *     ls_id     uint32                       // series id
+ *     snapshot   uintptr                      // pointer to constructed snapshot
+ *     buffer     [] byte                      // allocated buffer
+ *     labelSetID uint32                       // series id
  * }
  *
  */

--- a/pp/go/cppbridge/lss_snapshot.go
+++ b/pp/go/cppbridge/lss_snapshot.go
@@ -2,6 +2,7 @@ package cppbridge
 
 import (
 	"runtime"
+	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -68,6 +69,18 @@ func (lss *LabelSetSnapshot) RangeLabelSet(lsID uint32, do func(l Label) error) 
 	labelSetFree(labelSet)
 
 	return nil
+}
+
+func (lss *LabelSetSnapshot) Serialize(lsID uint32) string {
+	length := labelSetSerializeFromSnapshotLength(lss.pointer, lsID)
+	if length == 0 {
+		return ""
+	}
+
+	buf := make([]byte, length)
+	labelSetSerializeFromSnapshotToBuffer(lss.pointer, lsID, buf)
+	runtime.KeepAlive(lss)
+	return unsafe.String(unsafe.SliceData(buf), length)
 }
 
 // Query returns a LSSQueryResult that matches the given selector.

--- a/pp/go/cppbridge/lss_snapshot_serialize_test.go
+++ b/pp/go/cppbridge/lss_snapshot_serialize_test.go
@@ -1,0 +1,94 @@
+//go:build stringlabels
+
+package cppbridge_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/model"
+	"github.com/stretchr/testify/suite"
+)
+
+type LabelSetSnapshotSerializeSuite struct {
+	suite.Suite
+	lss *cppbridge.LabelSetStorage
+}
+
+func TestLabelSetSnapshotSerializeSuite(t *testing.T) {
+	suite.Run(t, new(LabelSetSnapshotSerializeSuite))
+}
+
+func (s *LabelSetSnapshotSerializeSuite) SetupTest() {
+	s.lss = cppbridge.NewQueryableLssStorage()
+}
+
+func labelsFromRangeLabelSet(snapshot *cppbridge.LabelSetSnapshot, lsID uint32) labels.Labels {
+	builder := labels.NewScratchBuilder(10)
+	_ = snapshot.RangeLabelSet(lsID, func(l cppbridge.Label) error {
+		builder.Add(l.Name, l.Value)
+		return nil
+	})
+	return builder.Labels()
+}
+
+func (s *LabelSetSnapshotSerializeSuite) TestMatchesScratchBuilder() {
+	// Arrange
+	lsMap := map[string]string{
+		"__name__": "metric",
+		"job":      "prometheus",
+		"instance": "localhost:9090",
+	}
+
+	lsID := s.lss.FindOrEmplace(model.LabelSetFromMap(lsMap)).LabelSetID
+	snapshot := s.lss.CreateLabelSetSnapshot()
+
+	expected := labelsFromRangeLabelSet(snapshot, lsID)
+
+	// Act
+	serialized := snapshot.Serialize(lsID)
+
+	// Assert
+	s.Equal(expected.Bytes(nil), []byte(serialized))
+}
+
+func (s *LabelSetSnapshotSerializeSuite) TestLongLabelValueUsesMultiByteVarint() {
+	// Arrange
+	longValue := strings.Repeat("x", 200)
+	lsID := s.lss.FindOrEmplace(
+		model.NewLabelSetBuilder().Set("__name__", "metric").Set("key", longValue).Build(),
+	).LabelSetID
+	snapshot := s.lss.CreateLabelSetSnapshot()
+
+	expected := labelsFromRangeLabelSet(snapshot, lsID)
+
+	// Act
+	serialized := snapshot.Serialize(lsID)
+
+	// Assert
+	s.Equal(expected.Bytes(nil), []byte(serialized))
+}
+
+func (s *LabelSetSnapshotSerializeSuite) TestMultipleLabelSets() {
+	// Arrange
+	lsId1 := s.lss.FindOrEmplace(
+		model.NewLabelSetBuilder().Set("__name__", "first").Set("env", "prod").Build(),
+	).LabelSetID
+	lsId2 := s.lss.FindOrEmplace(
+		model.NewLabelSetBuilder().Set("__name__", "second").Set("env", "dev").Build(),
+	).LabelSetID
+	snapshot := s.lss.CreateLabelSetSnapshot()
+
+	expected1 := labelsFromRangeLabelSet(snapshot, lsId1)
+	expected2 := labelsFromRangeLabelSet(snapshot, lsId2)
+
+	// Act
+	serialized1 := snapshot.Serialize(lsId1)
+	serialized2 := snapshot.Serialize(lsId2)
+
+	// Assert
+	s.Equal(expected1.Bytes(nil), []byte(serialized1))
+	s.Equal(expected2.Bytes(nil), []byte(serialized2))
+}

--- a/pp/go/storage/querier/chunk_series.go
+++ b/pp/go/storage/querier/chunk_series.go
@@ -88,13 +88,10 @@ func (css *ChunkSeriesSet) Next() bool {
 		css.index++
 	}
 
-	builder := builderPool.Get().(*labels.ScratchBuilder)
-	builder.Reset()
 	css.chunkSeries = &ChunkSeries{
-		labelSet:      labels.NewLabelsWithLSS(css.labelSetSnapshot, lsID, builder),
+		labelSet:      labels.NewLabelsWithLSS(css.labelSetSnapshot, lsID),
 		recodedChunks: recodedChunks,
 	}
-	builderPool.Put(builder)
 
 	return true
 }

--- a/pp/go/storage/querier/instant_series.go
+++ b/pp/go/storage/querier/instant_series.go
@@ -71,14 +71,7 @@ func (ss *InstantSeriesSet) Next() bool {
 	}
 
 	lsID, _ := ss.lssQueryResult.GetByIndex(ss.nextSeriesIndex)
-	builder := builderPool.Get().(*labels.ScratchBuilder)
-	builder.Reset()
-	ss.instantSeries[ss.nextSeriesIndex].LabelSet = labels.NewLabelsWithLSS(
-		ss.labelSetSnapshot,
-		lsID,
-		builder,
-	)
-	builderPool.Put(builder)
+	ss.instantSeries[ss.nextSeriesIndex].LabelSet = labels.NewLabelsWithLSS(ss.labelSetSnapshot, lsID)
 
 	ss.nextSeriesIndex++
 	return true

--- a/pp/go/storage/querier/series.go
+++ b/pp/go/storage/querier/series.go
@@ -2,7 +2,6 @@ package querier
 
 import (
 	"math"
-	"sync"
 
 	"github.com/prometheus/prometheus/model/histogram"
 	"github.com/prometheus/prometheus/model/labels"
@@ -11,14 +10,6 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/util/annotations"
 )
-
-// builderPool builders pool for reuse in SeriesSet.
-var builderPool = sync.Pool{
-	New: func() any {
-		b := labels.NewScratchBuilder(10)
-		return &b
-	},
-}
 
 // ChunkIterator iterates over the samples of a time series, that can only get the next value with limit.
 type ChunkIterator struct {
@@ -203,16 +194,13 @@ func (s *SeriesSet) Next() bool {
 		return false
 	}
 
-	builder := builderPool.Get().(*labels.ScratchBuilder)
-	builder.Reset()
 	s.series = append(s.series, NewSeries(
 		s.mint,
 		s.maxt,
-		labels.NewLabelsWithLSS(s.labelSetSnapshot, seriesID, builder),
+		labels.NewLabelsWithLSS(s.labelSetSnapshot, seriesID),
 		s.serializedData,
 		chunkRef,
 	))
-	builderPool.Put(builder)
 
 	return true
 }

--- a/pp/go/storage/querier/stalenan_series_set.go
+++ b/pp/go/storage/querier/stalenan_series_set.go
@@ -91,15 +91,8 @@ func (ss *StaleNaNSeriesSet) Next() bool {
 	}
 
 	lsID, _ := ss.lssQueryResult.GetByIndex(ss.nextSeriesIndex)
-	builder := builderPool.Get().(*labels.ScratchBuilder)
-	builder.Reset()
-	ss.series[ss.nextSeriesIndex].labelSet = labels.NewLabelsWithLSS(
-		ss.labelSetSnapshot,
-		lsID,
-		builder,
-	)
+	ss.series[ss.nextSeriesIndex].labelSet = labels.NewLabelsWithLSS(ss.labelSetSnapshot, lsID)
 	ss.nextSeriesIndex++
-	builderPool.Put(builder)
 
 	return true
 }

--- a/pp/third_party/deps.bzl
+++ b/pp/third_party/deps.bzl
@@ -135,6 +135,7 @@ def _third_party_deps_impl(_ctx):
             Label("//third_party/patches/com_google_absl:0002-svacer_fixes.patch"),
             Label("//third_party/patches/com_google_absl:0003-null_dereference_fixes.patch"),
             Label("//third_party/patches/com_google_absl:0004-array_bounds_fixes.patch"),
+            Label("//third_party/patches/com_google_absl:0005-gcc-16_fixes.patch"),
         ],
         sha256 = "f8903111260a18d2cc4618cd5bf35a22bcc28f372ebe4f04024b49e88a2e16c1",
         strip_prefix = "abseil-cpp-20240116.rc1/",

--- a/pp/third_party/patches/com_google_absl/0005-gcc-16_fixes.patch
+++ b/pp/third_party/patches/com_google_absl/0005-gcc-16_fixes.patch
@@ -1,0 +1,10 @@
+--- absl/container/internal/container_memory.h
++++ absl/container/internal/container_memory.h
+@@ -16,6 +16,7 @@
+ #define ABSL_CONTAINER_INTERNAL_CONTAINER_MEMORY_H_
+ 
+ #include <cassert>
++#include <cstdint>
+ #include <cstddef>
+ #include <cstring>
+ #include <memory>


### PR DESCRIPTION
Optimzed `NewLabelsWithLSS` for `stringlabels` build tag by using two c++ bindings: `prompp_label_set_serialize_from_snapshot_length` and `prompp_label_set_serialize_from_snapshot_to_buffer`.
Boost: ~8% on `BenchmarkSeriesSetOpt`