### PR TITLE
Add PROMPP_FEATURES=disable_coredumps feature flag

### DIFF
--- a/cmd/prometheus/main.go
+++ b/cmd/prometheus/main.go
@@ -2357,6 +2357,13 @@ func readPromPPFeatures(logger log.Logger, cfg *flagConfig) {
 				cfg.UseBlockManagerStorage = true
 			}
 			_ = level.Info(logger).Log("msg", "[FEATURE] Block-manager historical storage is enabled.")
+
+		case "disable_coredumps":
+			if err := prom_runtime.DisableCoreDumps(); err != nil {
+				_ = level.Error(logger).Log("msg", "[FEATURE] Failed to disable core dumps.", "err", err)
+				continue
+			}
+			_ = level.Info(logger).Log("msg", "[FEATURE] Core dumps are disabled (RLIMIT_CORE=0).")
 		}
 	}
 }

--- a/util/runtime/limits_default.go
+++ b/util/runtime/limits_default.go
@@ -49,3 +49,11 @@ func getLimits(resource int, unit string) string {
 func FdLimits() string {
 	return getLimits(syscall.RLIMIT_NOFILE, "")
 }
+
+// DisableCoreDumps sets the soft and hard RLIMIT_CORE to 0 for the current
+// process, preventing the kernel from writing core dumps on crash. Lowering a
+// resource limit is always permitted for an unprivileged process, so no extra
+// capabilities (e.g. CAP_SYS_RESOURCE) are required.
+func DisableCoreDumps() error {
+	return syscall.Setrlimit(syscall.RLIMIT_CORE, &syscall.Rlimit{Cur: 0, Max: 0})
+}

--- a/util/runtime/limits_windows.go
+++ b/util/runtime/limits_windows.go
@@ -24,3 +24,8 @@ func FdLimits() string {
 func VMLimits() string {
 	return "N/A"
 }
+
+// DisableCoreDumps is a no-op on Windows, which has no RLIMIT_CORE.
+func DisableCoreDumps() error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- Adds a `PROMPP_FEATURES=disable_coredumps` runtime toggle that sets `RLIMIT_CORE` to `0` at startup, so the kernel no longer writes core dumps into the process working directory on crash.
- Lowering the limit requires no extra privileges (no `CAP_SYS_RESOURCE`), so it works in unprivileged Kubernetes pods without changing `securityContext`.
- Affects the prompp process and its children (including the exception-fork coredump path).

## Changes
- `util/runtime/limits_default.go` — new `DisableCoreDumps()` calling `setrlimit(RLIMIT_CORE, {0,0})`.
- `util/runtime/limits_windows.go` — no-op stub (Windows has no `RLIMIT_CORE`).
- `cmd/prometheus/main.go` — new `disable_coredumps` case in `readPromPPFeatures(...)`, logging via `level.Info`/`level.Error`.

## Test plan
- [ ] Start with `PROMPP_FEATURES=disable_coredumps` and confirm the `[FEATURE] Core dumps are disabled (RLIMIT_CORE=0).` log line.
- [ ] Verify `cat /proc/<pid>/limits` shows `Max core file size = 0`.
- [ ] Trigger a crash and confirm no core file is written to the working directory.

Note: `util/runtime` builds and `go vet`s clean; a full `make build` currently fails on unrelated third-party C++ (`snappy`) due to a gcc-16 / binutils `.aeabi_subsection` toolchain mismatch in the devcontainer, not on any code in this PR.

Made with [Cursor](https://cursor.com)