### PR TITLE
fix(series_data): heap-buffer-overflow in outdated chunk merger + prompptool persist-head

### DIFF
--- a/cmd/prompptool/main.go
+++ b/cmd/prompptool/main.go
@@ -43,6 +43,10 @@ func main() {
 	var walvanillaCmd cmdWALVanillaToBlock
 	registerCmdWALVanillaToBlock(&walvanillaCmd, walvanillaClause)
 
+	persistHeadClause := app.Command("persist-head", "Persist a single prom++ head to tsdb-blocks by its directory path.")
+	var persistHeadCmd cmdPersistHead
+	registerCmdPersistHead(&persistHeadCmd, persistHeadClause)
+
 	cmd := kingpin.MustParse(app.Parse(os.Args[1:]))
 	logger := initLogger(*verbose)
 	logger = log.With(logger, "cmd", cmd)
@@ -57,6 +61,11 @@ func main() {
 	case walvanillaClause.FullCommand():
 		if err := walvanillaCmd.Do(ctx, workingDir, logger); err != nil {
 			level.Error(logger).Log("msg", "fail to convert", "error", err)
+			os.Exit(1)
+		}
+	case persistHeadClause.FullCommand():
+		if err := persistHeadCmd.Do(ctx, logger, nil); err != nil {
+			level.Error(logger).Log("msg", "fail to persist head", "error", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/prompptool/persisthead.go
+++ b/cmd/prompptool/persisthead.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/storage"
+	"github.com/prometheus/prometheus/pp/go/storage/block"
+	"github.com/prometheus/prometheus/pp/go/storage/catalog"
+	"github.com/prometheus/prometheus/pp/go/storage/head/shard"
+)
+
+// shardWalFilePattern matches per-shard wal files (e.g. shard_0.wal) inside a head directory.
+var shardWalFilePattern = regexp.MustCompile(`^shard_(\d+)\.wal$`)
+
+type cmdPersistHead struct {
+	headPath       string
+	outputDir      string
+	blockDuration  model.Duration
+	numberOfShards uint16
+}
+
+func registerCmdPersistHead(cmd *cmdPersistHead, clause *kingpin.CmdClause) {
+	clause.Arg("head-path", "Path to the head directory to persist (the UUID-named directory).").
+		Required().
+		ExistingDirVar(&cmd.headPath)
+
+	clause.Flag("output-dir", "Directory to write TSDB blocks into. Default: parent directory of head-path.").
+		StringVar(&cmd.outputDir)
+
+	clause.Flag("storage.tsdb.min-block-duration", "Minimum duration of a data block before being persisted.").
+		Default("2h").SetValue(&cmd.blockDuration)
+
+	clause.Flag("number-of-shards", "Number of shards in the head. 0 means autodetect by shard_*.wal files.").
+		Default("0").Uint16Var(&cmd.numberOfShards)
+}
+
+// Do loads a single head directly by path (without consulting head.log) and writes TSDB blocks.
+func (cmd *cmdPersistHead) Do(
+	ctx context.Context,
+	logger log.Logger,
+	registerer prometheus.Registerer,
+) error {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	headPath, err := filepath.Abs(cmd.headPath)
+	if err != nil {
+		return err
+	}
+
+	dataDir := filepath.Dir(headPath)
+	headID := filepath.Base(headPath)
+
+	// The loader resolves the head directory as filepath.Join(dataDir, record.ID()),
+	// so the directory name must be a valid head UUID.
+	id, err := uuid.Parse(headID)
+	if err != nil {
+		return fmt.Errorf("head directory name %q is not a valid head UUID: %w", headID, err)
+	}
+
+	numberOfShards := cmd.numberOfShards
+	if numberOfShards == 0 {
+		if numberOfShards, err = detectNumberOfShards(headPath); err != nil {
+			return err
+		}
+	}
+	if numberOfShards == 0 {
+		return fmt.Errorf("no shard_*.wal files found in %s; pass --number-of-shards explicitly", headPath)
+	}
+
+	outputDir := cmd.outputDir
+	if outputDir == "" {
+		outputDir = dataDir
+	}
+	if err = os.MkdirAll(outputDir, 0o755); err != nil { //nolint:gosec,mnd // standard data dir permissions
+		return fmt.Errorf("failed to create output dir %s: %w", outputDir, err)
+	}
+
+	level.Info(logger).Log(
+		"msg", "persisting head",
+		"id", id.String(),
+		"head_path", headPath,
+		"output_dir", outputDir,
+		"shards", numberOfShards,
+	)
+
+	now := time.Now().UnixMilli()
+	record := catalog.NewRecordWithData(
+		id,
+		numberOfShards,
+		now, // createdAt
+		now, // updatedAt
+		0,   // deletedAt
+		false,
+		0, // referenceCount
+		catalog.StatusRotated,
+		nil, // lastAppendedSegmentID
+	)
+
+	// LoadReadOnly always returns a head, even on error; a non-fatal error means the
+	// head is (partially) corrupted but we can still persist whatever decoded.
+	loader := storage.NewLoader(dataDir, 0, registerer, time.Duration(0))
+	h, err := loader.LoadReadOnly(record, 0)
+	if err != nil && !errors.Is(err, cppbridge.ErrInvalidEncoderVersion) {
+		level.Warn(logger).Log("msg", "head is corrupted, persisting decoded data only", "id", id.String(), "err", err)
+	}
+	defer func() {
+		if closeErr := h.Close(); closeErr != nil {
+			level.Error(logger).Log("msg", "failed to close head", "id", id.String(), "err", closeErr)
+		}
+	}()
+
+	bw := block.NewWriter[*shard.Shard](
+		outputDir,
+		block.DefaultChunkSegmentSize,
+		time.Duration(cmd.blockDuration),
+		registerer,
+	)
+
+	total := 0
+	for sd := range h.RangeShards() {
+		if err = ctx.Err(); err != nil {
+			return err
+		}
+
+		writtenBlocks, writeErr := bw.Write(sd)
+		if writeErr != nil {
+			return fmt.Errorf("failed to write tsdb block [id: %s, dir: %s]: %w", id.String(), headID, writeErr)
+		}
+
+		for i := range writtenBlocks {
+			total++
+			level.Info(logger).Log(
+				"msg", "block written",
+				"ulid", writtenBlocks[i].Meta.ULID.String(),
+				"dir", writtenBlocks[i].Dir,
+				"min_time", writtenBlocks[i].Meta.MinTime,
+				"max_time", writtenBlocks[i].Meta.MaxTime,
+				"series", writtenBlocks[i].Meta.Stats.NumSeries,
+				"samples", writtenBlocks[i].Meta.Stats.NumSamples,
+			)
+		}
+	}
+
+	level.Info(logger).Log("msg", "head persisted", "id", id.String(), "blocks", total)
+
+	return nil
+}
+
+// detectNumberOfShards counts contiguous shard_<n>.wal files in the head directory.
+func detectNumberOfShards(headPath string) (uint16, error) {
+	entries, err := os.ReadDir(headPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read head dir %s: %w", headPath, err)
+	}
+
+	maxShardID := -1
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		m := shardWalFilePattern.FindStringSubmatch(entry.Name())
+		if m == nil {
+			continue
+		}
+		shardID, convErr := strconv.Atoi(m[1])
+		if convErr != nil {
+			continue
+		}
+		if shardID > maxShardID {
+			maxShardID = shardID
+		}
+	}
+
+	if maxShardID < 0 {
+		return 0, nil
+	}
+
+	return uint16(maxShardID + 1), nil //nolint:gosec // shard count fits uint16
+}

--- a/pp/series_data/outdated_chunk_merger.h
+++ b/pp/series_data/outdated_chunk_merger.h
@@ -133,6 +133,10 @@ class OutdatedChunkMerger {
 
   void merge_outdated_samples_in_finalized_chunks(uint32_t ls_id, const chunk::FinalizedChunkList& finalized_chunks, SamplesSpan& samples) {
     for (auto it = finalized_chunks.begin(), next_it = std::next(it); it != finalized_chunks.end(); ++next_it) {
+      if (samples.empty()) {
+        return;
+      }
+
       if (next_it == finalized_chunks.end()) {
         if (auto open_chunk_timestamp = Decoder::get_chunk_first_timestamp<ChunkType::kOpen>(encoder_.storage(), encoder_.storage().open_chunks[ls_id]);
             open_chunk_timestamp > samples.front().timestamp) {

--- a/pp/series_data/tests/outdated_chunk_merger_tests.cpp
+++ b/pp/series_data/tests/outdated_chunk_merger_tests.cpp
@@ -779,4 +779,65 @@ INSTANTIATE_TEST_SUITE_P(Uint32ConstantChunk, OutdatedChunkMergerInOpenConstantC
 INSTANTIATE_TEST_SUITE_P(DoubleConstantChunk, OutdatedChunkMergerInOpenConstantChunkWithDuplicatedStalenanFixture, testing::Values(1.1));
 INSTANTIATE_TEST_SUITE_P(Float32ConstantChunk, OutdatedChunkMergerInOpenConstantChunkWithDuplicatedStalenanFixture, testing::Values(-1.0));
 
+class OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture : public OutdatedChunkMergerTrait<4>, public testing::Test {
+ protected:
+  [[nodiscard]] SampleList decode_series(uint32_t ls_id) {
+    SampleList result;
+    Decoder::decode_series(storage_, ls_id, [&result](const Sample& sample) { result.emplace_back(sample); });
+    return result;
+  }
+};
+
+// Regression: all outdated samples belong to an early finalized chunk, so the samples span
+// becomes empty after merging into it while there are still finalized chunks left to iterate.
+// merge_outdated_samples_in_finalized_chunks must stop instead of dereferencing samples.front()
+// on the empty span (heap-buffer-overflow reported by ASan in production heads).
+TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesNotReadPastEndOfSamples) {
+  // Arrange
+  // 13 in-order samples produce 3 finalized chunks ({2,4,6,8}, {10,12,14,16}, {18,20,22,24})
+  // plus an open chunk ({26}); kSamplesPerChunk == 4.
+  encode({
+      {.ls_id = 0, .sample = {.timestamp = 2, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 4, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 6, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 8, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 10, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 12, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 14, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 16, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 18, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 20, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 22, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 24, .value = 1.0}},
+      {.ls_id = 0, .sample = {.timestamp = 26, .value = 1.0}},
+  });
+  // A single outdated sample that lands only in the first finalized chunk (timestamp < 10).
+  encode_outdated({
+      {.ls_id = 0, .sample = {.timestamp = 3, .value = 1.0}},
+  });
+
+  // Act
+  merger_.merge();
+
+  // Assert
+  EXPECT_TRUE(std::ranges::equal(
+      ExpectedSampleList{
+          {.timestamp = 2, .value = 1.0},
+          {.timestamp = 3, .value = 1.0},
+          {.timestamp = 4, .value = 1.0},
+          {.timestamp = 6, .value = 1.0},
+          {.timestamp = 8, .value = 1.0},
+          {.timestamp = 10, .value = 1.0},
+          {.timestamp = 12, .value = 1.0},
+          {.timestamp = 14, .value = 1.0},
+          {.timestamp = 16, .value = 1.0},
+          {.timestamp = 18, .value = 1.0},
+          {.timestamp = 20, .value = 1.0},
+          {.timestamp = 22, .value = 1.0},
+          {.timestamp = 24, .value = 1.0},
+          {.timestamp = 26, .value = 1.0},
+      },
+      decode_series(0)));
+}
+
 }  // namespace

--- a/pp/series_data/tests/outdated_chunk_merger_tests.cpp
+++ b/pp/series_data/tests/outdated_chunk_merger_tests.cpp
@@ -794,8 +794,8 @@ class OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture : publi
 // on the empty span (heap-buffer-overflow reported by ASan in production heads).
 TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesNotReadPastEndOfSamples) {
   // Arrange
-  // 13 in-order samples produce 3 finalized chunks ({2,4,6,8}, {10,12,14,16}, {18,20,22,24})
-  // plus an open chunk ({26}); kSamplesPerChunk == 4.
+  // 9 in-order samples produce 2 finalized chunks ({2,4,6,8}, {10,12,14,16})
+  // plus an open chunk ({18}); kSamplesPerChunk == 4.
   encode({
       {.ls_id = 0, .sample = {.timestamp = 2, .value = 1.0}},
       {.ls_id = 0, .sample = {.timestamp = 4, .value = 1.0}},
@@ -806,10 +806,6 @@ TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesN
       {.ls_id = 0, .sample = {.timestamp = 14, .value = 1.0}},
       {.ls_id = 0, .sample = {.timestamp = 16, .value = 1.0}},
       {.ls_id = 0, .sample = {.timestamp = 18, .value = 1.0}},
-      {.ls_id = 0, .sample = {.timestamp = 20, .value = 1.0}},
-      {.ls_id = 0, .sample = {.timestamp = 22, .value = 1.0}},
-      {.ls_id = 0, .sample = {.timestamp = 24, .value = 1.0}},
-      {.ls_id = 0, .sample = {.timestamp = 26, .value = 1.0}},
   });
   // A single outdated sample that lands only in the first finalized chunk (timestamp < 10).
   encode_outdated({
@@ -832,10 +828,6 @@ TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesN
           {.timestamp = 14, .value = 1.0},
           {.timestamp = 16, .value = 1.0},
           {.timestamp = 18, .value = 1.0},
-          {.timestamp = 20, .value = 1.0},
-          {.timestamp = 22, .value = 1.0},
-          {.timestamp = 24, .value = 1.0},
-          {.timestamp = 26, .value = 1.0},
       },
       decode_series(0)));
 }


### PR DESCRIPTION
## Summary

- **fix(series_data):** Fix a heap-buffer-overflow in `OutdatedChunkMerger::merge_outdated_samples_in_finalized_chunks`. The loop over finalized chunks dereferenced `samples.front()` after the samples span had already been fully consumed into an earlier chunk, reading one `Sample` past the end of the buffer decoded in `Decoder::decode_outdated_chunk`. In production this surfaced as a non-deterministic `SIGSEGV` in the Persistener background service (head → block serialization) and a crash loop. Fixed by bailing out of the loop as soon as the samples span is empty (`if (samples.empty()) return;`), mirroring the existing `!samples.empty()` guard at the call site.
- **feat(prompptool):** Add a `persist-head` command that persists a single prom++ head to TSDB blocks directly by its directory path, without consulting `head.log`. It autodetects the shard count from `shard_*.wal` files and loads the head read-only (continuing on partial corruption). Useful for recovering/persisting an individual orphaned or corrupted head, and for reproducing head-specific crashes in isolation.

## Root cause

`merge_outdated_samples<>()` advances `begin` and resets the span (`samples = {begin, samples.end()}`) on each merge. Once all outdated samples have been merged into earlier finalized chunks, `samples` becomes empty, but the loop kept iterating the remaining finalized chunks and called `samples.front()` on the empty `std::span` (out-of-bounds read at `outdated_chunk_merger.h:146`). Without a sanitizer the stray read usually hits adjacent live heap and silently returns garbage; when the region sits at the end of a page it reads unmapped memory → `SIGSEGV`.

## Test plan

- [x] `bazel test -c dbg --asan //:series_data_test` — 31 merger tests pass, including the new regression test `OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture.DoesNotReadPastEndOfSamples`.
- [x] New test fails pre-fix (libstdc++ hardened `std::span::front()` assertion / ASan heap-buffer-overflow), passes post-fix.
- [x] `prompptool-asan persist-head` on the real problematic head `bd23374c-…`: crashed pre-fix, now completes with `EXIT=0`, writes 4 blocks, no other ASan errors.

Made with [Cursor](https://cursor.com)