### PR TITLE
fix(cppbridge): copy C++ metric pages into Go memory to avoid use-after-free

### DIFF
--- a/pp/entrypoint/go_constants.h
+++ b/pp/entrypoint/go_constants.h
@@ -7,7 +7,7 @@
 
 #define Sizeof_SerializedDataIterator 152
 
-#define Sizeof_MetricsIterator 24
+#define Sizeof_MetricsIterator 32
 
 #define Sizeof_SegmentSamplesStorage 80
 #define Sizeof_RemoteWriteMessageEncoder 32

--- a/pp/entrypoint/metrics.cpp
+++ b/pp/entrypoint/metrics.cpp
@@ -19,9 +19,13 @@ extern "C" void prompp_metrics_register() {
 }
 
 extern "C" void prompp_metrics_iterator_ctor(void* args) {
-  metrics::storage.remove_unused_pages();
-
   std::construct_at(static_cast<metrics::Storage::Iterator*>(args), metrics::storage.begin());
+}
+
+// Reclaims pages detached before this scrape. Called after the iteration completes (not in the ctor) so that begin() never
+// frees an address that could be reused and re-observed within the same scrape snapshot.
+extern "C" void prompp_metrics_remove_unused_pages(void* args) {
+  metrics::storage.remove_unused_pages(static_cast<metrics::Storage::Iterator*>(args)->generation());
 }
 
 extern "C" void prompp_metrics_iterator_next(void* args, void* res) {
@@ -76,5 +80,5 @@ extern "C" void prompp_metrics_page_for_test_detach(void* args) {
     MetricsPageForTest* page;
   };
 
-  static_cast<Arguments*>(args)->page->detach();
+  static_cast<Arguments*>(args)->page->detach(metrics::storage.current_generation());
 }

--- a/pp/entrypoint/metrics.h
+++ b/pp/entrypoint/metrics.h
@@ -15,6 +15,13 @@ void prompp_metrics_register();
 void prompp_metrics_iterator_ctor(void* args);
 
 /**
+ * @brief Reclaim pages detached before this scrape. Must be called after the iteration finishes.
+ *
+ * @param args *MetricIterator
+ */
+void prompp_metrics_remove_unused_pages(void* args);
+
+/**
  * @brief Serialize metric into protobuf and advance iterator to next metric
  *
  * @param args {

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -3747,6 +3747,18 @@ func prometheusMetricsIteratorCtor() CppMetricsIterator {
 	return iterator
 }
 
+func prometheusMetricsRemoveUnusedPages(iterator *CppMetricsIterator) {
+	testGC()
+	fastcgo.UnsafeCall1(
+		C.prompp_metrics_remove_unused_pages,
+		uintptr(unsafe.Pointer(iterator)),
+	)
+	// This is the last use of the iterator: after the uintptr conversion above the compiler would treat its backing storage
+	// as dead, so a GC (e.g. the one testGC forces) could poison/reclaim it while C is still reading the embedded generation.
+	// KeepAlive extends its lifetime past the C read.
+	runtime.KeepAlive(iterator)
+}
+
 func prometheusMetricsIteratorNext(iterator *CppMetricsIterator) *CppMetric {
 	args := struct {
 		iterator uintptr

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -42,7 +42,7 @@ void prompp_dump_memory_profile(void* args, void* res);
 
 #define Sizeof_SerializedDataIterator 152
 
-#define Sizeof_MetricsIterator 24
+#define Sizeof_MetricsIterator 32
 
 #define Sizeof_SegmentSamplesStorage 80
 #define Sizeof_RemoteWriteMessageEncoder 32
@@ -548,6 +548,13 @@ void prompp_metrics_register();
  * @param args *MetricIterator
  */
 void prompp_metrics_iterator_ctor(void* args);
+
+/**
+ * @brief Reclaim pages detached before this scrape. Must be called after the iteration finishes.
+ *
+ * @param args *MetricIterator
+ */
+void prompp_metrics_remove_unused_pages(void* args);
 
 /**
  * @brief Serialize metric into protobuf and advance iterator to next metric

--- a/pp/go/cppbridge/metrics.go
+++ b/pp/go/cppbridge/metrics.go
@@ -11,8 +11,8 @@ import (
 
 // CppMetric is the raw view returned by the C++ metrics iterator. Its descriptor/metric pointers and every string and
 // value they reference live inside a C++ metrics page that may be physically freed after the scrape (see
-// prompp_metrics_remove_unused_pages, called at the end of CppMetrics). It must never be handed to Go consumers
-// directly; it is only used, under cppMetricsMu, to build a fully Go-owned CppMetricCopy.
+// prompp_metrics_remove_unused_pages, called at the end of collectCppMetricCopies). It must never be handed to Go
+// consumers directly; it is only used, under cppMetricsMu, to build a fully Go-owned CppMetricCopy.
 type CppMetric struct {
 	descriptor *prometheus.Desc
 	metric     *dto.Metric
@@ -56,16 +56,21 @@ type CppMetricMeta struct {
 
 // CppMetricCopy is a per-scrape, fully Go-owned snapshot of a single metric. It implements prometheus.Metric and is
 // therefore safe to buffer in the collect channel and read after cppMetricsMu has been released.
+//
+// Methods use a pointer receiver on purpose: CppMetricsCollector.Collect hands every metric to a chan<- prometheus.Metric.
+// A *CppMetricCopy converts to the interface without a heap allocation (the interface just wraps the existing pointer into
+// the backing slice), whereas a value receiver would box every metric into the interface — one allocation per metric per
+// scrape. See collectCppMetricCopies for the single-allocation backing slice.
 type CppMetricCopy struct {
 	meta  *CppMetricMeta
 	value float64
 }
 
-func (m CppMetricCopy) Desc() *prometheus.Desc {
+func (m *CppMetricCopy) Desc() *prometheus.Desc {
 	return m.meta.desc
 }
 
-func (m CppMetricCopy) Write(out *dto.Metric) error {
+func (m *CppMetricCopy) Write(out *dto.Metric) error {
 	out.Label = m.meta.labelPairs
 	switch m.meta.kind {
 	case cppMetricCounter:
@@ -92,14 +97,31 @@ var (
 	metaCacheGen uint64
 )
 
-// CppMetrics iterates the C++ metric pages under cppMetricsMu, builds a fully Go-owned CppMetricCopy for every metric
-// and passes it by value to f. Iteration stops early if f returns false.
+// CppMetrics builds a fully Go-owned copy of every C++ metric and passes a *CppMetricCopy for each to f. Iteration stops
+// early if f returns false. The pointers handed to f are stable for the whole call (they point into a single backing
+// slice, see collectCppMetricCopies), so f may forward them straight to a chan<- prometheus.Metric without boxing.
+func CppMetrics(f func(metric *CppMetricCopy) bool) {
+	copies := collectCppMetricCopies()
+	for i := range copies {
+		if !f(&copies[i]) {
+			return
+		}
+	}
+}
+
+// collectCppMetricCopies iterates the C++ metric pages under cppMetricsMu, builds fully Go-owned copies, reclaims freed
+// pages, evicts stale cache entries and returns the copies. The lock is held only while C++ memory is touched; once this
+// returns every referenced byte is Go-owned, so the copies can be read safely after the lock is released (e.g. lazily
+// drained from a buffered channel by prometheus.Registry.Gather).
 //
-// The lock is held for the entire call, f included: the C++ storage is not safe for concurrent readers (see
-// cppMetricsMu), so the whole iteration must run as a single reader. Each CppMetricCopy is fully Go-owned, so f may
-// retain it and read it after CppMetrics returns (e.g. buffer it in prometheus' collect channel and drain it later).
-// Passing the copy by value lets callers forward it straight to a consumer without allocating a per-scrape slice.
-func CppMetrics(f func(metric CppMetricCopy) bool) {
+// The lock spans the whole C++ iteration: the storage is not safe for concurrent readers (see cppMetricsMu), so the whole
+// scrape must run as a single reader.
+//
+// Copies are returned in a single backing slice so the whole scrape costs one allocation for the values instead of one
+// per metric. A fresh slice is allocated per scrape on purpose: the elements are handed to the collect channel and read
+// asynchronously (and possibly by concurrent Gather calls), so a shared/pooled buffer could be overwritten while still
+// in flight.
+func collectCppMetricCopies() []CppMetricCopy {
 	cppMetricsMu.Lock()
 	defer cppMetricsMu.Unlock()
 
@@ -108,6 +130,7 @@ func CppMetrics(f func(metric CppMetricCopy) bool) {
 
 	iterator := prometheusMetricsIteratorCtor()
 
+	copies := make([]CppMetricCopy, 0, len(metaCache))
 	for {
 		metric := prometheusMetricsIteratorNext(&iterator)
 		if metric == nil {
@@ -125,11 +148,7 @@ func CppMetrics(f func(metric CppMetricCopy) bool) {
 		}
 		meta.lastSeenGen = gen
 
-		if !f(CppMetricCopy{meta: meta, value: value}) {
-			// Early stop: not every page was visited, so skip both the page reclamation and the mark-and-sweep below.
-			// Nothing is freed and nothing is evicted, so no cache entry can dangle; the next full scrape cleans up.
-			return
-		}
+		copies = append(copies, CppMetricCopy{meta: meta, value: value})
 	}
 
 	// Reclaim pages detached before this scrape (their deletion was deferred one generation on the C++ side). Freeing an
@@ -143,6 +162,8 @@ func CppMetrics(f func(metric CppMetricCopy) bool) {
 			delete(metaCache, key)
 		}
 	}
+
+	return copies
 }
 
 // buildMeta deep-copies the descriptor and label pairs from the C++ page into Go-owned memory. Every string is cloned

--- a/pp/go/cppbridge/metrics.go
+++ b/pp/go/cppbridge/metrics.go
@@ -103,8 +103,9 @@ var (
 )
 
 func CppMetrics(f func(metric *CppMetricCopy) bool) {
-	for _, metric := range collectCppMetricCopies() {
-		if !f(metric) {
+	copies := collectCppMetricCopies()
+	for i := range copies {
+		if !f(&copies[i]) {
 			break
 		}
 	}
@@ -114,7 +115,12 @@ func CppMetrics(f func(metric *CppMetricCopy) bool) {
 // cache entries and returns the copies. The lock is held only while C++ memory is touched; once this returns every
 // referenced byte is Go-owned, so the copies can be read safely after the lock is released (e.g. lazily drained from a
 // buffered channel by prometheus.Registry.Gather).
-func collectCppMetricCopies() []*CppMetricCopy {
+//
+// Copies are returned in a single backing slice so the whole scrape costs one allocation for the values instead of one
+// per metric. A fresh slice is allocated per scrape on purpose: the elements are handed to the collect channel and read
+// asynchronously (and possibly by concurrent Gather calls), so a shared/pooled buffer could be overwritten while still
+// in flight.
+func collectCppMetricCopies() []CppMetricCopy {
 	cppMetricsMu.Lock()
 	defer cppMetricsMu.Unlock()
 
@@ -123,7 +129,7 @@ func collectCppMetricCopies() []*CppMetricCopy {
 
 	iterator := prometheusMetricsIteratorCtor()
 
-	copies := make([]*CppMetricCopy, 0, len(metaCache))
+	copies := make([]CppMetricCopy, 0, len(metaCache))
 	for {
 		metric := prometheusMetricsIteratorNext(&iterator)
 		if metric == nil {
@@ -141,7 +147,7 @@ func collectCppMetricCopies() []*CppMetricCopy {
 		}
 		meta.lastSeenGen = gen
 
-		copies = append(copies, &CppMetricCopy{meta: meta, value: value})
+		copies = append(copies, CppMetricCopy{meta: meta, value: value})
 	}
 
 	// Mark-and-sweep: drop metadata for descriptors that disappeared (e.g. their page was freed). Entries seen in this

--- a/pp/go/cppbridge/metrics.go
+++ b/pp/go/cppbridge/metrics.go
@@ -1,55 +1,176 @@
 package cppbridge
 
 import (
+	"strings"
 	"sync"
+	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )
 
+// CppMetric is the raw view returned by the C++ metrics iterator. Its descriptor/metric pointers and every string and
+// value they reference live inside a C++ metrics page that may be physically freed on the next scrape (see
+// prompp_metrics_iterator_ctor -> remove_unused_pages). It must never be handed to Go consumers directly; it is only
+// used, under cppMetricsMu, to build a fully Go-owned CppMetricCopy.
 type CppMetric struct {
 	descriptor *prometheus.Desc
 	metric     *dto.Metric
 }
 
-func (m *CppMetric) Desc() *prometheus.Desc {
-	return m.descriptor
+// cppMetricDescriptor mirrors the memory layout of PromPP::Primitives::Go::dto::MetricDescriptor
+// (pp/primitives/go_metric.h). It is used as a read-only view over the C++ descriptor to cheaply read fields that
+// prometheus.Desc keeps unexported (fqName/help for rebuilding the Desc, id/dimHash for the cache key).
+// Keep the field order and sizes in sync with the C++ struct.
+type cppMetricDescriptor struct {
+	fqName          string           // C++ String{data, len}
+	help            string           // C++ String{data, len}
+	constLabelPairs []*dto.LabelPair // C++ Slice<const LabelPair*>{data, len, cap}
+	variableLabels  unsafe.Pointer   // C++ const CompiledLabels*
+	id              uint64
+	dimHash         uint64
+	// C++ trailing field `Error error` is intentionally omitted: it is never read here.
 }
 
-func (m *CppMetric) Write(out *dto.Metric) error {
-	out.Label = m.metric.Label
-	out.Counter = m.metric.Counter
-	out.Gauge = m.metric.Gauge
-	out.Untyped = m.metric.Untyped
+type cppMetricKind uint8
+
+const (
+	cppMetricCounter cppMetricKind = iota
+	cppMetricGauge
+)
+
+// kindAndValue reads the metric kind and its current numeric value from the C++-owned dto.Metric. The value pointer
+// dereferenced here points into the C++ page, so this must be called while cppMetricsMu is held; the returned float64
+// is a plain Go copy.
+func (m *CppMetric) kindAndValue() (cppMetricKind, float64) {
+	if c := m.metric.Counter; c != nil {
+		return cppMetricCounter, c.GetValue()
+	}
+	return cppMetricGauge, m.metric.Gauge.GetValue()
+}
+
+// CppMetricMeta is the immutable, fully Go-owned part of a metric: the descriptor, the emitted label pairs and the
+// metric kind. It is cached across scrapes keyed by the descriptor identity ({id, dimHash}) because only the numeric
+// value changes between scrapes, so the (relatively expensive) string copies are reused.
+type CppMetricMeta struct {
+	desc        *prometheus.Desc
+	labelPairs  []*dto.LabelPair
+	kind        cppMetricKind
+	lastSeenGen uint64
+}
+
+// CppMetricCopy is a per-scrape, fully Go-owned snapshot of a single metric. It implements prometheus.Metric and is
+// therefore safe to buffer in the collect channel and read after cppMetricsMu has been released.
+type CppMetricCopy struct {
+	meta  *CppMetricMeta
+	value float64
+}
+
+func (m *CppMetricCopy) Desc() *prometheus.Desc {
+	return m.meta.desc
+}
+
+func (m *CppMetricCopy) Write(out *dto.Metric) error {
+	out.Label = m.meta.labelPairs
+	switch m.meta.kind {
+	case cppMetricCounter:
+		out.Counter = &dto.Counter{Value: &m.value}
+	case cppMetricGauge:
+		out.Gauge = &dto.Gauge{Value: &m.value}
+	}
 	return nil
 }
 
-func (m *CppMetric) Labels() Labels {
-	labels := make(Labels, 0, len(m.metric.Label))
-	for _, l := range m.metric.Label {
-		labels = append(labels, Label{Name: *l.Name, Value: *l.Value})
-	}
-	return labels
+// descKey identifies a descriptor for caching. id/dimHash come from the C++ descriptor and together cover
+// fqName/help/label names/label values. kind is part of the key because the same descriptor identity can be emitted as
+// both a counter and a gauge (e.g. the test page), and their metadata differs.
+type descKey struct {
+	id      uint64
+	dimHash uint64
+	kind    cppMetricKind
 }
 
-// cppMetricsMu serializes the whole metrics-page iteration. The underlying C++ storage is not safe for concurrent
-// readers: prompp_metrics_iterator_ctor first calls remove_unused_pages(), which physically deletes pages detached from
-// the list. If two scrapes run concurrently (client_golang does not serialize Gather/Collect), one scrape could delete a
-// page that another scrape is still iterating, causing a use-after-free. Holding this mutex for the full iteration
-// guarantees a single reader at a time, which is the invariant the detach/remove_unused_pages design relies on.
-var cppMetricsMu sync.Mutex
+// cppMetricsMu serializes the whole metrics-page iteration and guards metaCache. The underlying C++ storage is not safe
+// for concurrent readers: prompp_metrics_iterator_ctor first calls remove_unused_pages(), which physically deletes
+// pages detached from the list. If two scrapes ran concurrently (client_golang does not serialize Gather/Collect), one
+// scrape could delete a page that another is still iterating, causing a use-after-free. Holding this mutex for the whole
+// build phase guarantees a single reader at a time, which is the invariant the detach/remove_unused_pages design relies
+// on. Because CppMetrics returns Go-owned copies, consumers may safely read them after the lock is released.
+var (
+	cppMetricsMu sync.Mutex
+	metaCache    = make(map[descKey]*CppMetricMeta)
+	metaCacheGen uint64
+)
 
-func CppMetrics(f func(metric *CppMetric) bool) {
+func CppMetrics(f func(metric *CppMetricCopy) bool) {
+	for _, metric := range collectCppMetricCopies() {
+		if !f(metric) {
+			break
+		}
+	}
+}
+
+// collectCppMetricCopies iterates the C++ metric pages under cppMetricsMu, builds fully Go-owned copies, evicts stale
+// cache entries and returns the copies. The lock is held only while C++ memory is touched; once this returns every
+// referenced byte is Go-owned, so the copies can be read safely after the lock is released (e.g. lazily drained from a
+// buffered channel by prometheus.Registry.Gather).
+func collectCppMetricCopies() []*CppMetricCopy {
 	cppMetricsMu.Lock()
 	defer cppMetricsMu.Unlock()
 
+	metaCacheGen++
+	gen := metaCacheGen
+
 	iterator := prometheusMetricsIteratorCtor()
 
+	copies := make([]*CppMetricCopy, 0, len(metaCache))
 	for {
 		metric := prometheusMetricsIteratorNext(&iterator)
-		if metric == nil || !f(metric) {
+		if metric == nil {
 			break
 		}
+
+		desc := (*cppMetricDescriptor)(unsafe.Pointer(metric.descriptor))
+		kind, value := metric.kindAndValue()
+
+		key := descKey{id: desc.id, dimHash: desc.dimHash, kind: kind}
+		meta := metaCache[key]
+		if meta == nil {
+			meta = buildMeta(metric, desc, kind)
+			metaCache[key] = meta
+		}
+		meta.lastSeenGen = gen
+
+		copies = append(copies, &CppMetricCopy{meta: meta, value: value})
+	}
+
+	// Mark-and-sweep: drop metadata for descriptors that disappeared (e.g. their page was freed). Entries seen in this
+	// iteration carry the current generation; everything else is stale.
+	for key, meta := range metaCache {
+		if meta.lastSeenGen != gen {
+			delete(metaCache, key)
+		}
+	}
+
+	return copies
+}
+
+// buildMeta deep-copies the descriptor and label pairs from the C++ page into Go-owned memory. Every string is cloned
+// so the resulting CppMetricMeta holds no pointers into C++ memory.
+func buildMeta(metric *CppMetric, desc *cppMetricDescriptor, kind cppMetricKind) *CppMetricMeta {
+	constLabels := make(prometheus.Labels, len(metric.metric.Label))
+	labelPairs := make([]*dto.LabelPair, 0, len(metric.metric.Label))
+	for _, l := range metric.metric.Label {
+		name := strings.Clone(l.GetName())
+		value := strings.Clone(l.GetValue())
+		constLabels[name] = value
+		labelPairs = append(labelPairs, &dto.LabelPair{Name: &name, Value: &value})
+	}
+
+	return &CppMetricMeta{
+		desc:       prometheus.NewDesc(strings.Clone(desc.fqName), strings.Clone(desc.help), nil, constLabels),
+		labelPairs: labelPairs,
+		kind:       kind,
 	}
 }
 

--- a/pp/go/cppbridge/metrics.go
+++ b/pp/go/cppbridge/metrics.go
@@ -10,26 +10,21 @@ import (
 )
 
 // CppMetric is the raw view returned by the C++ metrics iterator. Its descriptor/metric pointers and every string and
-// value they reference live inside a C++ metrics page that may be physically freed on the next scrape (see
-// prompp_metrics_iterator_ctor -> remove_unused_pages). It must never be handed to Go consumers directly; it is only
-// used, under cppMetricsMu, to build a fully Go-owned CppMetricCopy.
+// value they reference live inside a C++ metrics page that may be physically freed after the scrape (see
+// prompp_metrics_remove_unused_pages, called at the end of CppMetrics). It must never be handed to Go consumers
+// directly; it is only used, under cppMetricsMu, to build a fully Go-owned CppMetricCopy.
 type CppMetric struct {
 	descriptor *prometheus.Desc
 	metric     *dto.Metric
 }
 
-// cppMetricDescriptor mirrors the memory layout of PromPP::Primitives::Go::dto::MetricDescriptor
-// (pp/primitives/go_metric.h). It is used as a read-only view over the C++ descriptor to cheaply read fields that
-// prometheus.Desc keeps unexported (fqName/help for rebuilding the Desc, id/dimHash for the cache key).
-// Keep the field order and sizes in sync with the C++ struct.
+// cppMetricDescriptor mirrors the leading fields of PromPP::Primitives::Go::dto::MetricDescriptor
+// (pp/primitives/go_metric.h). It is used as a read-only view over the C++ descriptor to cheaply read fqName/help,
+// which prometheus.Desc keeps unexported, when (re)building a Desc. Only the leading fields are mirrored; the trailing
+// fields are never read here. Keep the field order and sizes of the mirrored prefix in sync with the C++ struct.
 type cppMetricDescriptor struct {
-	fqName          string           // C++ String{data, len}
-	help            string           // C++ String{data, len}
-	constLabelPairs []*dto.LabelPair // C++ Slice<const LabelPair*>{data, len, cap}
-	variableLabels  unsafe.Pointer   // C++ const CompiledLabels*
-	id              uint64
-	dimHash         uint64
-	// C++ trailing field `Error error` is intentionally omitted: it is never read here.
+	fqName string // C++ String{data, len}
+	help   string // C++ String{data, len}
 }
 
 type cppMetricKind uint8
@@ -50,8 +45,8 @@ func (m *CppMetric) kindAndValue() (cppMetricKind, float64) {
 }
 
 // CppMetricMeta is the immutable, fully Go-owned part of a metric: the descriptor, the emitted label pairs and the
-// metric kind. It is cached across scrapes keyed by the descriptor identity ({id, dimHash}) because only the numeric
-// value changes between scrapes, so the (relatively expensive) string copies are reused.
+// metric kind. It is cached across scrapes keyed by the C++ descriptor address because only the numeric value changes
+// between scrapes, so the (relatively expensive) string copies are reused.
 type CppMetricMeta struct {
 	desc        *prometheus.Desc
 	labelPairs  []*dto.LabelPair
@@ -66,11 +61,11 @@ type CppMetricCopy struct {
 	value float64
 }
 
-func (m *CppMetricCopy) Desc() *prometheus.Desc {
+func (m CppMetricCopy) Desc() *prometheus.Desc {
 	return m.meta.desc
 }
 
-func (m *CppMetricCopy) Write(out *dto.Metric) error {
+func (m CppMetricCopy) Write(out *dto.Metric) error {
 	out.Label = m.meta.labelPairs
 	switch m.meta.kind {
 	case cppMetricCounter:
@@ -81,46 +76,30 @@ func (m *CppMetricCopy) Write(out *dto.Metric) error {
 	return nil
 }
 
-// descKey identifies a descriptor for caching. id/dimHash come from the C++ descriptor and together cover
-// fqName/help/label names/label values. kind is part of the key because the same descriptor identity can be emitted as
-// both a counter and a gauge (e.g. the test page), and their metadata differs.
-type descKey struct {
-	id      uint64
-	dimHash uint64
-	kind    cppMetricKind
-}
-
 // cppMetricsMu serializes the whole metrics-page iteration and guards metaCache. The underlying C++ storage is not safe
-// for concurrent readers: prompp_metrics_iterator_ctor first calls remove_unused_pages(), which physically deletes
+// for concurrent readers: prompp_metrics_remove_unused_pages() (called at the end of the scrape) physically deletes
 // pages detached from the list. If two scrapes ran concurrently (client_golang does not serialize Gather/Collect), one
 // scrape could delete a page that another is still iterating, causing a use-after-free. Holding this mutex for the whole
 // build phase guarantees a single reader at a time, which is the invariant the detach/remove_unused_pages design relies
 // on. Because CppMetrics returns Go-owned copies, consumers may safely read them after the lock is released.
+//
+// The cache is keyed by the C++ descriptor address. This is safe against address reuse (ABA) because page deletion is
+// deferred by one generation on the C++ side: a page detached during a scrape is only freed by the next scrape, which
+// no longer observes it, so the mark-and-sweep below evicts its cache entry in the very scrape that frees its address.
 var (
 	cppMetricsMu sync.Mutex
-	metaCache    = make(map[descKey]*CppMetricMeta)
+	metaCache    = make(map[unsafe.Pointer]*CppMetricMeta)
 	metaCacheGen uint64
 )
 
-func CppMetrics(f func(metric *CppMetricCopy) bool) {
-	copies := collectCppMetricCopies()
-	for i := range copies {
-		if !f(&copies[i]) {
-			break
-		}
-	}
-}
-
-// collectCppMetricCopies iterates the C++ metric pages under cppMetricsMu, builds fully Go-owned copies, evicts stale
-// cache entries and returns the copies. The lock is held only while C++ memory is touched; once this returns every
-// referenced byte is Go-owned, so the copies can be read safely after the lock is released (e.g. lazily drained from a
-// buffered channel by prometheus.Registry.Gather).
+// CppMetrics iterates the C++ metric pages under cppMetricsMu, builds a fully Go-owned CppMetricCopy for every metric
+// and passes it by value to f. Iteration stops early if f returns false.
 //
-// Copies are returned in a single backing slice so the whole scrape costs one allocation for the values instead of one
-// per metric. A fresh slice is allocated per scrape on purpose: the elements are handed to the collect channel and read
-// asynchronously (and possibly by concurrent Gather calls), so a shared/pooled buffer could be overwritten while still
-// in flight.
-func collectCppMetricCopies() []CppMetricCopy {
+// The lock is held for the entire call, f included: the C++ storage is not safe for concurrent readers (see
+// cppMetricsMu), so the whole iteration must run as a single reader. Each CppMetricCopy is fully Go-owned, so f may
+// retain it and read it after CppMetrics returns (e.g. buffer it in prometheus' collect channel and drain it later).
+// Passing the copy by value lets callers forward it straight to a consumer without allocating a per-scrape slice.
+func CppMetrics(f func(metric CppMetricCopy) bool) {
 	cppMetricsMu.Lock()
 	defer cppMetricsMu.Unlock()
 
@@ -129,36 +108,41 @@ func collectCppMetricCopies() []CppMetricCopy {
 
 	iterator := prometheusMetricsIteratorCtor()
 
-	copies := make([]CppMetricCopy, 0, len(metaCache))
 	for {
 		metric := prometheusMetricsIteratorNext(&iterator)
 		if metric == nil {
 			break
 		}
 
-		desc := (*cppMetricDescriptor)(unsafe.Pointer(metric.descriptor))
 		kind, value := metric.kindAndValue()
 
-		key := descKey{id: desc.id, dimHash: desc.dimHash, kind: kind}
+		key := unsafe.Pointer(metric.descriptor)
 		meta := metaCache[key]
 		if meta == nil {
+			desc := (*cppMetricDescriptor)(unsafe.Pointer(metric.descriptor))
 			meta = buildMeta(metric, desc, kind)
 			metaCache[key] = meta
 		}
 		meta.lastSeenGen = gen
 
-		copies = append(copies, CppMetricCopy{meta: meta, value: value})
+		if !f(CppMetricCopy{meta: meta, value: value}) {
+			// Early stop: not every page was visited, so skip both the page reclamation and the mark-and-sweep below.
+			// Nothing is freed and nothing is evicted, so no cache entry can dangle; the next full scrape cleans up.
+			return
+		}
 	}
 
-	// Mark-and-sweep: drop metadata for descriptors that disappeared (e.g. their page was freed). Entries seen in this
+	// Reclaim pages detached before this scrape (their deletion was deferred one generation on the C++ side). Freeing an
+	// address here and evicting its stale cache entry in the sweep below happen in the same scrape, so no key can dangle.
+	prometheusMetricsRemoveUnusedPages(&iterator)
+
+	// Mark-and-sweep: drop metadata for descriptors that disappeared (their page was freed above). Entries seen in this
 	// iteration carry the current generation; everything else is stale.
 	for key, meta := range metaCache {
 		if meta.lastSeenGen != gen {
 			delete(metaCache, key)
 		}
 	}
-
-	return copies
 }
 
 // buildMeta deep-copies the descriptor and label pairs from the C++ page into Go-owned memory. Every string is cloned

--- a/pp/go/cppbridge/metrics_test.go
+++ b/pp/go/cppbridge/metrics_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/suite"
 )
@@ -30,7 +31,7 @@ func (s *CppMetricsSuite) getMetrics() []CppMetricCopy {
 		if strings.HasPrefix(metric.meta.desc.String(), jemallocMetricDescPrefix) {
 			continue
 		}
-		metrics = append(metrics, metric)
+		metrics = append(metrics, *metric)
 	}
 
 	return metrics
@@ -176,9 +177,12 @@ func (s *CppMetricsSuite) TestCacheEvictsDisappearedMetric() {
 }
 
 // BenchmarkCppMetrics measures reading all metrics from C++ into Go through CppMetrics for a varying number of metric
-// pages. Each page yields a counter and a gauge (2 metrics). The "warm" variant reflects the steady-state scrape path
-// where the per-descriptor meta is already cached and only numeric values are copied; the "cold" variant clears the
-// meta cache before every iteration to measure the full deep-copy (descriptor + labels) build cost.
+// pages. Each page yields a counter and a gauge (2 metrics). Variants:
+//   - "warm"    — steady-state scrape: meta is cached, only the numeric values are copied (build cost only);
+//   - "collect" — steady-state scrape plus the real CppMetricsCollector.Collect hand-off, where every metric is converted
+//     to the prometheus.Metric interface (exactly what `ch <- metric` does). This is the number that matters in
+//     production; with a *CppMetricCopy the interface conversion does not allocate, so it stays close to "warm";
+//   - "cold"    — meta cache cleared before every iteration: full deep-copy (descriptor + labels) build cost.
 func BenchmarkCppMetrics(b *testing.B) {
 	for _, pageCount := range []int{1, 10, 100, 1000} {
 		pages := make([]uintptr, 0, pageCount)
@@ -191,7 +195,12 @@ func BenchmarkCppMetrics(b *testing.B) {
 		}
 
 		var consumed int
-		consume := func(CppMetricCopy) bool { consumed++; return true }
+		consume := func(*CppMetricCopy) bool { consumed++; return true }
+
+		// sink mirrors CppMetricsCollector.Collect handing each metric to a chan<- prometheus.Metric: the *CppMetricCopy is
+		// converted to the prometheus.Metric interface here, exactly as `ch <- metric` would.
+		var sink []prometheus.Metric
+		collect := func(m *CppMetricCopy) bool { sink = append(sink, m); return true }
 
 		b.Run(fmt.Sprintf("warm/pages=%d", pageCount), func(b *testing.B) {
 			CppMetrics(consume) // warm the meta cache
@@ -203,6 +212,19 @@ func BenchmarkCppMetrics(b *testing.B) {
 			}
 			b.StopTimer()
 			runtime.KeepAlive(consumed)
+		})
+
+		b.Run(fmt.Sprintf("collect/pages=%d", pageCount), func(b *testing.B) {
+			CppMetrics(consume) // warm the meta cache
+			sink = make([]prometheus.Metric, 0, pageCount*2)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				sink = sink[:0]
+				CppMetrics(collect)
+			}
+			b.StopTimer()
+			runtime.KeepAlive(sink)
 		})
 
 		b.Run(fmt.Sprintf("cold/pages=%d", pageCount), func(b *testing.B) {

--- a/pp/go/cppbridge/metrics_test.go
+++ b/pp/go/cppbridge/metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,16 +21,29 @@ func TestCppMetricsSuite(t *testing.T) {
 // per-test metric pages and are filtered out of the suite's view of CppMetrics.
 const jemallocMetricDescPrefix = `Desc{fqName: "prompp_common_jemalloc_`
 
-func (s *CppMetricsSuite) getMetrics() []*CppMetric {
-	metrics := []*CppMetric(nil)
+func (s *CppMetricsSuite) getMetrics() []*CppMetricCopy {
+	metrics := []*CppMetricCopy(nil)
 	for metric := range CppMetrics {
-		if strings.HasPrefix(metric.descriptor.String(), jemallocMetricDescPrefix) {
+		if strings.HasPrefix(metric.meta.desc.String(), jemallocMetricDescPrefix) {
 			continue
 		}
 		metrics = append(metrics, metric)
 	}
 
 	return metrics
+}
+
+func cacheContainsMeta(meta *CppMetricMeta) bool {
+	cppMetricsMu.Lock()
+	defer cppMetricsMu.Unlock()
+
+	for _, m := range metaCache {
+		if m == meta {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *CppMetricsSuite) TestNoMetricPages() {
@@ -54,11 +68,13 @@ func (s *CppMetricsSuite) TestOneMetricsPage() {
 
 	// Assert
 	s.Require().Len(metrics, 2)
-	s.Equal(`Desc{fqName: "counter", help: "", constLabels: {metrics_page="for_test"}, variableLabels: {}}`, metrics[0].descriptor.String())
-	s.Equal(metrics[0].metric.Counter.GetValue(), float64(counterValue))
+	s.Equal(`Desc{fqName: "counter", help: "", constLabels: {metrics_page="for_test"}, variableLabels: {}}`, metrics[0].meta.desc.String())
+	s.Equal(cppMetricCounter, metrics[0].meta.kind)
+	s.Equal(float64(counterValue), metrics[0].value)
 
-	s.Equal(`Desc{fqName: "counter", help: "", constLabels: {metrics_page="for_test"}, variableLabels: {}}`, metrics[0].descriptor.String())
-	s.Equal(metrics[1].metric.Gauge.GetValue(), float64(counterValue))
+	s.Equal(`Desc{fqName: "counter", help: "", constLabels: {metrics_page="for_test"}, variableLabels: {}}`, metrics[1].meta.desc.String())
+	s.Equal(cppMetricGauge, metrics[1].meta.kind)
+	s.Equal(float64(counterValue), metrics[1].value)
 }
 
 func (s *CppMetricsSuite) TestTwoMetricPages() {
@@ -79,15 +95,79 @@ func (s *CppMetricsSuite) TestTwoMetricPages() {
 	// Assert
 	s.Require().Len(metrics, 4)
 
-	s.Equal(`Desc{fqName: "counter2", help: "", constLabels: {metrics_page2="for_test"}, variableLabels: {}}`, metrics[0].descriptor.String())
-	s.Equal(metrics[0].metric.Counter.GetValue(), float64(counterValue2))
+	s.Equal(`Desc{fqName: "counter2", help: "", constLabels: {metrics_page2="for_test"}, variableLabels: {}}`, metrics[0].meta.desc.String())
+	s.Equal(float64(counterValue2), metrics[0].value)
 
-	s.Equal(`Desc{fqName: "counter2", help: "", constLabels: {metrics_page2="for_test"}, variableLabels: {}}`, metrics[1].descriptor.String())
-	s.Equal(metrics[1].metric.Gauge.GetValue(), float64(counterValue2))
+	s.Equal(`Desc{fqName: "counter2", help: "", constLabels: {metrics_page2="for_test"}, variableLabels: {}}`, metrics[1].meta.desc.String())
+	s.Equal(float64(counterValue2), metrics[1].value)
 
-	s.Equal(`Desc{fqName: "counter1", help: "", constLabels: {metrics_page1="for_test"}, variableLabels: {}}`, metrics[2].descriptor.String())
-	s.Equal(metrics[2].metric.Counter.GetValue(), float64(counterValue1))
+	s.Equal(`Desc{fqName: "counter1", help: "", constLabels: {metrics_page1="for_test"}, variableLabels: {}}`, metrics[2].meta.desc.String())
+	s.Equal(float64(counterValue1), metrics[2].value)
 
-	s.Equal(`Desc{fqName: "counter1", help: "", constLabels: {metrics_page1="for_test"}, variableLabels: {}}`, metrics[3].descriptor.String())
-	s.Equal(metrics[3].metric.Gauge.GetValue(), float64(counterValue1))
+	s.Equal(`Desc{fqName: "counter1", help: "", constLabels: {metrics_page1="for_test"}, variableLabels: {}}`, metrics[3].meta.desc.String())
+	s.Equal(float64(counterValue1), metrics[3].value)
+}
+
+// TestCopyOutlivesFreedPage is the use-after-free regression: copies returned by CppMetrics must remain fully readable
+// even after the underlying C++ metrics page has been detached and physically freed by remove_unused_pages().
+func (s *CppMetricsSuite) TestCopyOutlivesFreedPage() {
+	// Arrange
+	const counterValue = 777
+
+	page := prometheusMetricsPageForTestCtor(Labels{Label{Name: "metrics_page", Value: "for_test"}}, "counter", counterValue)
+
+	metrics := s.getMetrics()
+	s.Require().Len(metrics, 2)
+
+	// Act: detach the page and trigger the next iterator ctor, which runs remove_unused_pages() -> delete page.
+	prometheusMetricsPageForTestDetach(page)
+	s.getMetrics()
+
+	// Assert: the earlier copies are Go-owned and still valid.
+	s.Equal(`Desc{fqName: "counter", help: "", constLabels: {metrics_page="for_test"}, variableLabels: {}}`, metrics[0].meta.desc.String())
+	s.Equal(float64(counterValue), metrics[0].value)
+	s.Equal(float64(counterValue), metrics[1].value)
+
+	out := &dto.Metric{}
+	s.Require().NoError(metrics[0].Write(out))
+	s.Require().Len(out.Label, 1)
+	s.Equal("metrics_page", out.Label[0].GetName())
+	s.Equal("for_test", out.Label[0].GetValue())
+	s.Require().NotNil(out.Counter)
+	s.Equal(float64(counterValue), out.Counter.GetValue())
+}
+
+// TestCacheReusesMetaAcrossScrapes verifies that the immutable meta (descriptor + labels) is cached and reused across
+// scrapes for the same descriptor identity, while the value is copied fresh each time.
+func (s *CppMetricsSuite) TestCacheReusesMetaAcrossScrapes() {
+	// Arrange
+	page := prometheusMetricsPageForTestCtor(Labels{Label{Name: "metrics_page", Value: "reuse"}}, "counter_reuse", 1)
+	defer func() { prometheusMetricsPageForTestDetach(page) }()
+
+	// Act
+	first := s.getMetrics()
+	second := s.getMetrics()
+
+	// Assert
+	s.Require().Len(first, 2)
+	s.Require().Len(second, 2)
+	s.Same(first[0].meta, second[0].meta)
+	s.Same(first[1].meta, second[1].meta)
+}
+
+// TestCacheEvictsDisappearedMetric verifies that cached meta for a metric whose page was freed is swept out.
+func (s *CppMetricsSuite) TestCacheEvictsDisappearedMetric() {
+	// Arrange
+	page := prometheusMetricsPageForTestCtor(Labels{Label{Name: "metrics_page", Value: "evict"}}, "counter_evict", 1)
+
+	first := s.getMetrics()
+	s.Require().Len(first, 2)
+	s.True(cacheContainsMeta(first[0].meta))
+
+	// Act
+	prometheusMetricsPageForTestDetach(page)
+	s.getMetrics()
+
+	// Assert
+	s.False(cacheContainsMeta(first[0].meta))
 }

--- a/pp/go/cppbridge/metrics_test.go
+++ b/pp/go/cppbridge/metrics_test.go
@@ -24,8 +24,8 @@ func TestCppMetricsSuite(t *testing.T) {
 // per-test metric pages and are filtered out of the suite's view of CppMetrics.
 const jemallocMetricDescPrefix = `Desc{fqName: "prompp_common_jemalloc_`
 
-func (s *CppMetricsSuite) getMetrics() []*CppMetricCopy {
-	metrics := []*CppMetricCopy(nil)
+func (s *CppMetricsSuite) getMetrics() []CppMetricCopy {
+	metrics := []CppMetricCopy(nil)
 	for metric := range CppMetrics {
 		if strings.HasPrefix(metric.meta.desc.String(), jemallocMetricDescPrefix) {
 			continue
@@ -122,7 +122,7 @@ func (s *CppMetricsSuite) TestCopyOutlivesFreedPage() {
 	metrics := s.getMetrics()
 	s.Require().Len(metrics, 2)
 
-	// Act: detach the page and trigger the next iterator ctor, which runs remove_unused_pages() -> delete page.
+	// Act: detach the page and run the next scrape, which reclaims it via remove_unused_pages() -> delete page.
 	prometheusMetricsPageForTestDetach(page)
 	s.getMetrics()
 
@@ -191,7 +191,7 @@ func BenchmarkCppMetrics(b *testing.B) {
 		}
 
 		var consumed int
-		consume := func(*CppMetricCopy) bool { consumed++; return true }
+		consume := func(CppMetricCopy) bool { consumed++; return true }
 
 		b.Run(fmt.Sprintf("warm/pages=%d", pageCount), func(b *testing.B) {
 			CppMetrics(consume) // warm the meta cache

--- a/pp/go/cppbridge/metrics_test.go
+++ b/pp/go/cppbridge/metrics_test.go
@@ -1,6 +1,9 @@
 package cppbridge
 
 import (
+	"fmt"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -170,4 +173,57 @@ func (s *CppMetricsSuite) TestCacheEvictsDisappearedMetric() {
 
 	// Assert
 	s.False(cacheContainsMeta(first[0].meta))
+}
+
+// BenchmarkCppMetrics measures reading all metrics from C++ into Go through CppMetrics for a varying number of metric
+// pages. Each page yields a counter and a gauge (2 metrics). The "warm" variant reflects the steady-state scrape path
+// where the per-descriptor meta is already cached and only numeric values are copied; the "cold" variant clears the
+// meta cache before every iteration to measure the full deep-copy (descriptor + labels) build cost.
+func BenchmarkCppMetrics(b *testing.B) {
+	for _, pageCount := range []int{1, 10, 100, 1000} {
+		pages := make([]uintptr, 0, pageCount)
+		for i := 0; i < pageCount; i++ {
+			pages = append(pages, prometheusMetricsPageForTestCtor(
+				Labels{Label{Name: "metrics_page", Value: strconv.Itoa(i)}},
+				"benchmark_counter",
+				uint64(i),
+			))
+		}
+
+		var consumed int
+		consume := func(*CppMetricCopy) bool { consumed++; return true }
+
+		b.Run(fmt.Sprintf("warm/pages=%d", pageCount), func(b *testing.B) {
+			CppMetrics(consume) // warm the meta cache
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				consumed = 0
+				CppMetrics(consume)
+			}
+			b.StopTimer()
+			runtime.KeepAlive(consumed)
+		})
+
+		b.Run(fmt.Sprintf("cold/pages=%d", pageCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				cppMetricsMu.Lock()
+				clear(metaCache)
+				cppMetricsMu.Unlock()
+				b.StartTimer()
+
+				consumed = 0
+				CppMetrics(consume)
+			}
+			b.StopTimer()
+			runtime.KeepAlive(consumed)
+		})
+
+		for _, page := range pages {
+			prometheusMetricsPageForTestDetach(page)
+		}
+	}
 }

--- a/pp/metrics/metrics_page.h
+++ b/pp/metrics/metrics_page.h
@@ -64,7 +64,15 @@ class MetricsPageControlBlock {
   [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t page_object_size() const noexcept { return page_object_size_; }
   [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t metric_offset() const noexcept { return metric_offset_; }
   [[nodiscard]] PROMPP_ALWAYS_INLINE bool is_unused() const noexcept { return ref_count_ == 0; }
-  PROMPP_ALWAYS_INLINE void detach() noexcept { ref_count_ = 0; }
+  [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t detach_generation() const noexcept { return detach_generation_; }
+
+  // Detach records the storage generation at the moment the owning DataStorage is destroyed. remove_unused_pages() defers the
+  // physical deletion until a strictly newer generation, so a page detached during a scrape stays alive (its address is not
+  // reused) until the next scrape, which no longer observes it — keeping pointer-based scrape caches free of ABA aliasing.
+  PROMPP_ALWAYS_INLINE void detach(uint32_t generation) noexcept {
+    detach_generation_ = generation;
+    ref_count_ = 0;
+  }
 
   [[nodiscard]] PROMPP_ALWAYS_INLINE Iterator begin() const noexcept { return Iterator(this); }
   [[nodiscard]] PROMPP_ALWAYS_INLINE IteratorSentinel static end() noexcept { return {}; }
@@ -72,6 +80,7 @@ class MetricsPageControlBlock {
  private:
   MetricsPageControlBlock* next_metrics_page_{};
   uint32_t ref_count_{1};
+  uint32_t detach_generation_{};
   const uint32_t page_object_size_;
   const uint32_t metric_offset_{sizeof(MetricsPageControlBlock)};
 };

--- a/pp/metrics/metrics_page_list.h
+++ b/pp/metrics/metrics_page_list.h
@@ -64,15 +64,18 @@ class MetricsPageList {
     } while (!next_metrics_page_.compare_exchange_weak(current_next_page, page));
   }
 
-  void remove_unused_pages() {
+  // Deletes unused pages that were detached in a generation strictly older than the given (scrape iterator) generation. A page
+  // detached during the current generation is kept alive for one more scrape, so its address cannot be reused before the next
+  // scrape stops observing it — this is what makes descriptor-pointer scrape caches safe from ABA aliasing.
+  void remove_unused_pages(uint32_t generation) {
     MetricsPageControlBlock* page = next_metrics_page_;
     if (page == nullptr) [[unlikely]] {
       return;
     }
 
-    remove_unused_pages(page, page->next_metrics_page());
+    remove_unused_pages(page, page->next_metrics_page(), generation);
 
-    if (page->is_unused()) {
+    if (is_deletable(page, generation)) {
       // If page is first page in list then we delete it. Otherwise, we will delete it at another remove_unused_pages call
       if (next_metrics_page_.compare_exchange_weak(page, page->next_metrics_page())) [[likely]] {
         delete page;
@@ -86,11 +89,17 @@ class MetricsPageList {
  private:
   std::atomic<MetricsPageControlBlock*> next_metrics_page_{};
 
-  static void remove_unused_pages(MetricsPageControlBlock* prev_page, MetricsPageControlBlock* page) {
+  // A page can be physically deleted only when it is unused and was detached in a generation strictly older than the current
+  // one. Unsigned wraparound of the generation counter is handled by comparing the difference as a signed value.
+  static PROMPP_ALWAYS_INLINE bool is_deletable(const MetricsPageControlBlock* page, uint32_t generation) noexcept {
+    return page->is_unused() && static_cast<int32_t>(page->detach_generation() - generation) < 0;
+  }
+
+  static void remove_unused_pages(MetricsPageControlBlock* prev_page, MetricsPageControlBlock* page, uint32_t generation) {
     while (page != nullptr) [[likely]] {
       const auto next_page = page->next_metrics_page();
 
-      if (page->is_unused()) {
+      if (is_deletable(page, generation)) {
         prev_page->set_next_metrics_page(next_page);
         delete page;
       } else {

--- a/pp/metrics/metrics_page_list_tests.cpp
+++ b/pp/metrics/metrics_page_list_tests.cpp
@@ -62,9 +62,9 @@ TEST_F(MetricsPageListFixture, TestIteratorWithUsedPages) {
 TEST_F(MetricsPageListFixture, TestIteratorWithUnusedPages) {
   // Arrange
   const MetricsPagesVector metrics_pages{new Metrics(), new Metrics(), new Metrics(), new Metrics()};
-  metrics_pages[0]->detach();
-  metrics_pages[1]->detach();
-  metrics_pages[3]->detach();
+  metrics_pages[0]->detach(0);
+  metrics_pages[1]->detach(0);
+  metrics_pages[3]->detach(0);
 
   add_metrics_pages(metrics_pages);
 
@@ -117,7 +117,7 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveInEmptyList) {
   // Arrange
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
 }
@@ -130,7 +130,7 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveWithoutUnusedPages) {
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -143,12 +143,12 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveFirstMetricsPageInOneP
   // Arrange
   const auto metric = new Metrics();
   metrics_page_list_.add(metric);
-  metric->detach();
+  metric->detach(0);
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -158,12 +158,12 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveFirstMetricsPageInOneP
 TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveAllMetricsPages) {
   // Arrange
   auto metrics_pages = fill_4_metric_pages();
-  std::ranges::for_each(metrics_pages, [&](auto metric) { metric->detach(); });
+  std::ranges::for_each(metrics_pages, [&](auto metric) { metric->detach(0); });
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -173,13 +173,13 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveAllMetricsPages) {
 TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveFirstMetric) {
   // Arrange
   auto metrics_pages = fill_4_metric_pages();
-  metrics_pages[0]->detach();
+  metrics_pages[0]->detach(0);
   metrics_pages.erase(metrics_pages.begin());
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -191,13 +191,13 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveFirstMetric) {
 TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveSecondMetric) {
   // Arrange
   auto metrics_pages = fill_4_metric_pages();
-  metrics_pages[1]->detach();
+  metrics_pages[1]->detach(0);
   metrics_pages.erase(metrics_pages.begin() + 1);
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -209,13 +209,13 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveSecondMetric) {
 TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveThirdMetric) {
   // Arrange
   auto metrics_pages = fill_4_metric_pages();
-  metrics_pages[2]->detach();
+  metrics_pages[2]->detach(0);
   metrics_pages.erase(metrics_pages.begin() + 2);
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));
@@ -227,14 +227,14 @@ TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveThirdMetric) {
 TEST_F(MetricsPageListRemoveUnusedPagesFixture, TestRemoveSecondAndThirdMetric) {
   // Arrange
   auto metrics_pages = fill_4_metric_pages();
-  metrics_pages[1]->detach();
-  metrics_pages[2]->detach();
+  metrics_pages[1]->detach(0);
+  metrics_pages[2]->detach(0);
   metrics_pages.erase(metrics_pages.begin() + 1, metrics_pages.begin() + 3);
 
   MetricsPagesVector actual;
 
   // Act
-  metrics_page_list_.remove_unused_pages();
+  metrics_page_list_.remove_unused_pages(1);
 
   // Assert
   std::ranges::copy(metrics_page_list_, std::back_inserter(actual));

--- a/pp/metrics/storage.h
+++ b/pp/metrics/storage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+
 #include "metrics_page_list.h"
 
 namespace metrics {
@@ -16,7 +18,10 @@ class Storage {
     using pointer = value_type;
     using reference = value_type;
 
-    explicit Iterator(const MetricsPageList& storage) : page_iterator_(storage.begin()), metric_iterator_(*page_iterator_) {}
+    explicit Iterator(const MetricsPageList& storage, uint32_t generation)
+        : page_iterator_(storage.begin()), metric_iterator_(*page_iterator_), generation_(generation) {}
+
+    [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t generation() const noexcept { return generation_; }
 
     [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator*() const noexcept { return metric_iterator_.operator*(); }
     [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator->() const noexcept { return metric_iterator_.operator->(); }
@@ -40,15 +45,21 @@ class Storage {
    private:
     MetricsPageList::Iterator page_iterator_;
     MetricsPageControlBlock::Iterator metric_iterator_;
+    uint32_t generation_;
   };
 
   PROMPP_ALWAYS_INLINE void add(MetricsPageControlBlock* page) { page_list_.add(page); }
-  PROMPP_ALWAYS_INLINE void remove_unused_pages() { page_list_.remove_unused_pages(); }
+  PROMPP_ALWAYS_INLINE void remove_unused_pages(uint32_t generation) { page_list_.remove_unused_pages(generation); }
 
-  [[nodiscard]] PROMPP_ALWAYS_INLINE Iterator begin() const noexcept { return Iterator(page_list_); }
+  [[nodiscard]] PROMPP_ALWAYS_INLINE uint32_t current_generation() const noexcept { return generation_.load(std::memory_order_relaxed); }
+
+  // begin() opens a new scrape: it bumps the storage generation and stamps the iterator with it. Detached pages recorded in
+  // earlier generations become eligible for deletion via remove_unused_pages(iterator.generation()) after the scrape.
+  [[nodiscard]] PROMPP_ALWAYS_INLINE Iterator begin() noexcept { return Iterator(page_list_, generation_.fetch_add(1, std::memory_order_relaxed) + 1); }
   [[nodiscard]] PROMPP_ALWAYS_INLINE IteratorSentinel static end() noexcept { return {}; }
 
  private:
+  std::atomic<uint32_t> generation_{0};
   MetricsPageList page_list_;
 };
 

--- a/pp/primitives/go_metric.h
+++ b/pp/primitives/go_metric.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 #include "bare_bones/xxhash.h"
 #include "go_model.h"
 #include "label_set.h"
@@ -127,6 +129,16 @@ struct MetricDescriptor {
     return hash.digest();
   }
 };
+
+// The Go side reinterprets MetricDescriptor both as prometheus.Desc and, in cppbridge.cppMetricDescriptor
+// (pp/go/cppbridge/metrics.go), as a read-only view to extract fq_name/help and id/dim_hash. These asserts pin the
+// field offsets so any layout change breaks the C++ build and forces the Go mirror to be updated in lockstep.
+static_assert(offsetof(MetricDescriptor, fq_name) == 0);
+static_assert(offsetof(MetricDescriptor, help) == 16);
+static_assert(offsetof(MetricDescriptor, const_label_pairs) == 32);
+static_assert(offsetof(MetricDescriptor, variable_labels) == 56);
+static_assert(offsetof(MetricDescriptor, id) == 64);
+static_assert(offsetof(MetricDescriptor, dim_hash) == 72);
 
 }  // namespace dto
 

--- a/pp/series_data/data_storage.h
+++ b/pp/series_data/data_storage.h
@@ -433,7 +433,7 @@ struct DataStorage {
 
   template <BareBones::ReallocatorInterface Reallocator>
   PROMPP_ALWAYS_INLINE void destructor_impl() noexcept {
-    metrics->detach();
+    metrics->detach(metrics::storage.current_generation());
 
     if constexpr (BareBones::ArenaAllocatorInterface<Reallocator>) {
       Reallocator::release_arena(arena_index);

--- a/pp/series_data/tests/metrics_tests.cpp
+++ b/pp/series_data/tests/metrics_tests.cpp
@@ -297,8 +297,9 @@ TEST(DataStorageMetricsLifetimeTest, AddressLabelOwnedByPageSurvivesStorageDestr
   // Assert: the page still owns a valid "address" string (no dangling view / use-after-free).
   EXPECT_EQ(expected, read_address_label(*page));
 
-  // Cleanup: reclaim the detached page.
-  metrics::storage.remove_unused_pages();
+  // Cleanup: reclaim the detached page. The page was detached at the current generation, so a strictly newer generation makes
+  // it eligible for deletion.
+  metrics::storage.remove_unused_pages(metrics::storage.current_generation() + 1);
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

`CppMetrics` handed Prometheus `*dto.Metric` / `*prometheus.Desc` whose strings and values point **inside C++ metrics-page memory**. `cppMetricsMu` was held only while writing to the (buffered) collect channel; `Registry.Gather` reads those metrics *after* the lock is released. By then the next scrape can free the page (`remove_unused_pages()` → `delete page`), so the registry reads through dangling pointers (use-after-free).

## Fix

- Build fully **Go-owned** copies of each metric under the lock, and emit them to the channel only **after** releasing it (also removes lock contention on a slow consumer).
- New models: `CppMetricMeta` (immutable: `Desc` + label pairs + kind) and `CppMetricCopy` (meta + copied value). `CppMetricCopy` implements `prometheus.Metric` with **pointer receivers**: `Collect` feeds each metric into a `chan<- prometheus.Metric`, and a `*CppMetricCopy` pointing into the backing slice converts to the interface for free, whereas a value receiver would box every metric (one heap alloc per metric per scrape).
- Copies are returned in a **single per-scrape backing slice** (`[]CppMetricCopy`, handing out `&copies[i]`) so the whole warm scrape costs one allocation for the values instead of one per metric. A fresh slice per scrape is used on purpose: elements are consumed asynchronously via the buffered channel (and possibly by concurrent `Gather` calls), so a shared/pooled buffer could be overwritten while still in flight.
- Cache the immutable meta across scrapes (only the numeric value is copied each scrape); stale entries are evicted via mark-and-sweep.

## Cache key: C++ descriptor pointer + generation-gated deletion

The meta cache is keyed **directly by the C++ descriptor address** (`unsafe.Pointer(metric.descriptor)`) instead of a composite `{id, dimHash, kind}` key. This removes the composite-key hashing/mirroring and makes the warm path allocation-free per metric.

A raw address key is normally unsafe (ABA: a freed page's address is reused by a new page, causing a stale cache hit). We make it safe by **deferring page deletion by one generation** on the C++ side:

- Each scrape opens an iterator that bumps and captures a `generation` (`Storage::begin()`).
- When a page is detached it records the current generation (`MetricsPageControlBlock::detach(generation)`).
- `remove_unused_pages(generation)` only deletes pages detached in a **strictly older** generation (unsigned wraparound handled by signed diff comparison).

So a page detached during scrape *N* is only physically freed by scrape *N+1*, which no longer observes it — its address cannot be reused while any scrape still holds it, and the mark-and-sweep evicts its cache entry in the very scrape that frees the address.

`remove_unused_pages` was also **moved out of the iterator ctor into its own entrypoint**, called *after* the iteration loop (passing the iterator's generation). This means reclamation never runs at `begin()` (so no address can be freed and re-observed within the same snapshot), and an early exit from the iterator simply skips reclamation instead of leaving the cache inconsistent. `runtime.KeepAlive(iterator)` guards the Go-allocated iterator buffer (whose embedded generation C++ reads) from being GC-poisoned under ASAN after the `uintptr` conversion.

`cppMetricDescriptor` is a read-only Go mirror of the leading fields of the C++ `MetricDescriptor` (`pp/primitives/go_metric.h`), used only to cheaply read `fqName`/`help` when building a `Desc`.

## Benchmarks

`BenchmarkCppMetrics`, arm64 devcontainer, `pages` metric pages (each page = 1 counter + 1 gauge = 2 metrics), `-benchmem`, benchtime=1s.

- `warm` — steady-state scrape, meta cached (build cost only).
- `collect` — steady-state scrape **plus the real `Collect` hand-off**, converting every metric to `prometheus.Metric` (what `ch <- metric` does). This is the number that matters in production.
- `cold` — meta cache cleared each iteration (full descriptor + label deep copy).

**Real Collect path — value receiver (boxes each metric) vs. `*CppMetricCopy` (this PR):**

| pages / metrics | value receiver | `*CppMetricCopy` |
|---|---|---|
| 1 / 2 | 5 allocs, 195 ns | **1 alloc, 136 ns** |
| 10 / 20 | 23 allocs, 882 ns | **1 alloc, 601 ns** |
| 100 / 200 | 203 allocs, 7.99 µs | **1 alloc, 4.40 µs** |
| 1000 / 2000 | 2003 allocs, 105 µs | **1 alloc, 74 µs** |

The value receiver's Collect path allocated linearly (`≈2×pages+3` boxing allocs). With `*CppMetricCopy` the interface conversion is free, so `warm` and `collect` coincide and the whole scrape stays at **1 allocation** regardless of metric count.

**Full results (this PR):**

| pages / metrics | warm | collect | cold |
|---|---|---|---|
| 1 / 2 | 140 ns, 80 B, 1 alloc | 136 ns, 80 B, 1 alloc | 5.33 µs, 1.9 KB, 49 allocs |
| 10 / 20 | 567 ns, 384 B, 1 alloc | 601 ns, 384 B, 1 alloc | 14.7 µs, 10.7 KB, 321 allocs |
| 100 / 200 | 4.39 µs, 3.5 KB, 1 alloc | 4.40 µs, 3.5 KB, 1 alloc | 103 µs, 99.7 KB, 3024 allocs |
| 1000 / 2000 | 66.8 µs, 32 KB, 1 alloc | 74.1 µs, 32 KB, 1 alloc | 1.17 ms, 998 KB, 30028 allocs |

The meta cache keeps the hot path ~16x faster / ~30x lighter than a full rebuild.

## Test plan

- [x] `go test ./pp/go/cppbridge/` — green
- [x] `go test -race ./pp/go/cppbridge/ -run TestCppMetricsSuite` — green (concurrent scrapes stay isolated)
- [x] ASAN + double GC: `go test -asan -tags=asan ./pp/go/cppbridge/` — green, no UAF / use-after-poison (benchmark also run under ASAN)
- [x] C++ unit tests for generation-gated `remove_unused_pages` — green
- [x] C++ rebuilt — `static_assert`s on iterator size / descriptor layout compile
- Regression tests: `TestCopyOutlivesFreedPage`, `TestCacheReusesMetaAcrossScrapes`, `TestCacheEvictsDisappearedMetric`
