### PR TITLE
fix(block): clean up leftover tmp block dirs on startup

### DIFF
--- a/pp/go/storage/block/manager.go
+++ b/pp/go/storage/block/manager.go
@@ -99,6 +99,13 @@ func NewManager(
 	}
 	m.metrics = newMetrics(m, r)
 
+	// Best-effort cleanup of leftover tmp block dirs (e.g. *.tmp-for-creation) that
+	// may remain after a crash during compaction or persist. Unlike tsdb.DB.Open, the
+	// block Manager never loads these dirs, so without this they would leak on disk.
+	if err := tsdb.RemoveBestEffortTmpDirs(logger, dir); err != nil {
+		level.Warn(logger).Log("msg", "failed to remove leftover tmp block dirs", "dir", dir, "err", err)
+	}
+
 	if err := m.reloadBlocks(); err != nil {
 		return nil, fmt.Errorf("initial reload blocks: %w", err)
 	}

--- a/pp/go/storage/block/manager_test.go
+++ b/pp/go/storage/block/manager_test.go
@@ -104,6 +104,31 @@ func TestManagerExportsLoadedBlocksMetrics(t *testing.T) {
 	}
 }
 
+func TestManagerRemovesLeftoverTmpDirsOnStartup(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	createTestBlock(t, dir, 1000, "metric_a")
+
+	// Simulate leftovers from a crash during compaction/persist.
+	const validULID = "01ARZ3NDEKTSV4RRFFQ69G5FAV"
+	tmpCreation := filepath.Join(dir, validULID+tmpForCreationBlockDirSuffix)
+	tmpDeletion := filepath.Join(dir, validULID+tmpForDeletionBlockDirSuffix)
+	require.NoError(t, os.Mkdir(tmpCreation, 0o777))
+	require.NoError(t, os.Mkdir(tmpDeletion, 0o777))
+
+	m, err := NewManager(dir, nil, nil, log.NewNopLogger(), nil)
+	require.NoError(t, err)
+	t.Cleanup(m.Close)
+
+	require.Len(t, m.Blocks(), 1)
+
+	_, err = os.Stat(tmpCreation)
+	require.True(t, os.IsNotExist(err), "expected leftover tmp-for-creation dir to be removed")
+	_, err = os.Stat(tmpDeletion)
+	require.True(t, os.IsNotExist(err), "expected leftover tmp-for-deletion dir to be removed")
+}
+
 func createTestBlock(t *testing.T, dir string, startTS int, metric string) {
 	t.Helper()
 

--- a/tsdb/external.go
+++ b/tsdb/external.go
@@ -11,3 +11,10 @@ import (
 func OpenBlocks(l log.Logger, dir string, loaded []*Block, chunkPool chunkenc.Pool) ([]*Block, map[ulid.ULID]error, error) {
 	return openBlocks(l, dir, loaded, chunkPool)
 }
+
+// RemoveBestEffortTmpDirs deletes leftover temporary block dirs (e.g. *.tmp-for-creation,
+// *.tmp-for-deletion) that may remain after a crash during compaction or persist
+// (usage: pp/go/storage/block).
+func RemoveBestEffortTmpDirs(l log.Logger, dir string) error {
+	return removeBestEffortTmpDirs(l, dir)
+}


### PR DESCRIPTION
## Description

The block `Manager` never loads `*.tmp-for-creation` / `*.tmp-for-deletion` dirs, so leftovers from a crash during compaction or persist leak on disk forever. Unlike `tsdb.DB.Open`, `Manager` has no equivalent of `removeBestEffortTmpDirs`.

This adds startup cleanup:
- Expose `tsdb.RemoveBestEffortTmpDirs` (thin wrapper over the existing, tested `removeBestEffortTmpDirs`).
- Call it in `NewManager` before the initial `reloadBlocks` (best-effort; errors are logged via `level.Warn`, not fatal).

Split out from the discussion on #403 (the local-storage observer would otherwise report these leaked tmp dirs as "unknown" indefinitely).

## Test plan
- [x] `TestManagerRemovesLeftoverTmpDirsOnStartup` — leftover tmp dirs are removed on startup, valid block still loads.
- [x] `go test -tags stringlabels ./pp/go/storage/block/...` passes (ARM devcontainer, gcc-16).
- [x] `go vet` / `gofmt` clean; `tsdb` + `cmd/prometheus` build.

Made with [Cursor](https://cursor.com)