### PR TITLE
fix(entrypoint): call __builtin_cpu_init before CPU feature detection

### DIFF
--- a/pp/entrypoint/entrypoint.cpp.template
+++ b/pp/entrypoint/entrypoint.cpp.template
@@ -23,6 +23,12 @@
 enum class arch_flavor : uint8_t { generic, nehalem, haswell };
 
 arch_flavor determine_arch_flavor() {
+  // initialize() may run before libgcc's CPU-detection constructor (it is also
+  // triggered by the malloc interposer), so __cpu_model can be uninitialized.
+  // Force detection explicitly, otherwise every __builtin_cpu_supports() returns
+  // 0 and we always fall back to the k8 bindings.
+  __builtin_cpu_init();
+
   if (!__builtin_cpu_supports("sse4.2"))
     return arch_flavor::generic;
 


### PR DESCRIPTION
## Problem

Profiles showed calls into the `amd64_k8_*` (baseline) symbols even on modern CPUs. `determine_arch_flavor()` calls `__builtin_cpu_supports()` without first calling `__builtin_cpu_init()`.

The entrypoint `initialize()` can run before libgcc's high-priority CPU-detection constructor (it is also triggered via the malloc interposer), leaving `__cpu_model` uninitialized. As a result every `__builtin_cpu_supports()` returned 0 and the k8/generic bindings were always selected.

## Fix

Call `__builtin_cpu_init()` explicitly at the start of `determine_arch_flavor()` before the feature checks.

## Test

Built and deployed to stage; `GetFlavor()` now reports the real flavor instead of `k8`.

Made with [Cursor](https://cursor.com)