### PR TITLE
refactor: snapshot metrics

### DIFF
--- a/pp/go/cppbridge/lss_snapshot.go
+++ b/pp/go/cppbridge/lss_snapshot.go
@@ -5,21 +5,69 @@ import (
 	"unsafe"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/prometheus/pp/go/util"
 )
 
 var (
-	snapshotCreate = promauto.NewCounter(
+	// Working snapshot.
+	snapshotCreateWorking = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
 		prometheus.CounterOpts{
-			Name: "prompp_cppbridge_snapshot_create_count",
-			Help: "Current number of created snapshots.",
+			Name:        "prompp_cppbridge_snapshot_create_count",
+			Help:        "Current number of created snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "working"},
+		},
+	)
+	snapshotFinalizeWorking = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_finalize_count",
+			Help:        "Current number of finalized snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "working"},
 		},
 	)
 
-	snapshotFinalize = promauto.NewCounter(
+	// Transition snapshot.
+	snapshotCreateTransition = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
 		prometheus.CounterOpts{
-			Name: "prompp_cppbridge_snapshot_finalize_count",
-			Help: "Current number of finalized snapshots.",
+			Name:        "prompp_cppbridge_snapshot_create_count",
+			Help:        "Current number of created snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "transition"},
+		},
+	)
+	snapshotFinalizeTransition = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_finalize_count",
+			Help:        "Current number of finalized snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "transition"},
+		},
+	)
+	// Remote write snapshot.
+	snapshotCreateRemoteWrite = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_create_count",
+			Help:        "Current number of created snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "remote_write"},
+		},
+	)
+	snapshotFinalizeRemoteWrite = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_finalize_count",
+			Help:        "Current number of finalized snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "remote_write"},
+		},
+	)
+	// Rotation snapshot.
+	snapshotCreateRotation = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_create_count",
+			Help:        "Current number of created snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "rotation"},
+		},
+	)
+	snapshotFinalizeRotation = util.NewUnconflictRegisterer(prometheus.DefaultRegisterer).NewCounter(
+		prometheus.CounterOpts{
+			Name:        "prompp_cppbridge_snapshot_finalize_count",
+			Help:        "Current number of finalized snapshots.",
+			ConstLabels: prometheus.Labels{"snapshot_type": "rotation"},
 		},
 	)
 )
@@ -28,25 +76,71 @@ var (
 var gcDestroyDetector uint64
 
 //
+// SnapshotType
+//
+
+// SnapshotType is the type of snapshot.
+type SnapshotType uint64
+
+// IncCreate increment the create counter for the snapshot type.
+func (t SnapshotType) IncCreate() {
+	switch t {
+	case SnapshotTypeWorking:
+		snapshotCreateWorking.Inc()
+	case SnapshotTypeTransition:
+		snapshotCreateTransition.Inc()
+	case SnapshotTypeRemoteWrite:
+		snapshotCreateRemoteWrite.Inc()
+	case SnapshotTypeRotation:
+		snapshotCreateRotation.Inc()
+	}
+}
+
+// IncFinalize increment the finalize counter for the snapshot type.
+func (t SnapshotType) IncFinalize() {
+	switch t {
+	case SnapshotTypeWorking:
+		snapshotFinalizeWorking.Inc()
+	case SnapshotTypeTransition:
+		snapshotFinalizeTransition.Inc()
+	case SnapshotTypeRemoteWrite:
+		snapshotFinalizeRemoteWrite.Inc()
+	case SnapshotTypeRotation:
+		snapshotFinalizeRotation.Inc()
+	}
+}
+
+const (
+	// SnapshotTypeWorking is the snapshot type for working state.
+	SnapshotTypeWorking SnapshotType = iota
+	// SnapshotTypeTransition is the snapshot type for transition state.
+	SnapshotTypeTransition
+	// SnapshotTypeRemoteWrite is the snapshot type for remote write state.
+	SnapshotTypeRemoteWrite
+	// SnapshotTypeRotation is the snapshot type for rotation state.
+	SnapshotTypeRotation
+)
+
+//
 // LabelSetSnapshot
 //
 
 // LabelSetSnapshot go container for snapshot from LabelSetStorage.
 type LabelSetSnapshot struct {
-	pointer           uintptr
-	gcDestroyDetector *uint64 // field for the GC to destroy the structure.
+	pointer      uintptr
+	snapshotType SnapshotType
 }
 
 // newLabelSetSnapshot init new LabelSetSnapshot.
-func newLabelSetSnapshot(snapshotPtr uintptr) *LabelSetSnapshot {
-	lsst := &LabelSetSnapshot{pointer: snapshotPtr, gcDestroyDetector: &gcDestroyDetector}
+func newLabelSetSnapshot(snapshotPtr uintptr, snapshotType SnapshotType) *LabelSetSnapshot {
+	lsst := &LabelSetSnapshot{pointer: snapshotPtr, snapshotType: snapshotType}
 	runtime.SetFinalizer(lsst, func(l *LabelSetSnapshot) {
 		primitivesSnapshotDtor(l.pointer)
 
-		snapshotFinalize.Inc()
+		l.snapshotType.IncFinalize()
 	})
 
-	snapshotCreate.Inc()
+	snapshotType.IncCreate()
 
 	return lsst
 }

--- a/pp/go/cppbridge/primitives_lss.go
+++ b/pp/go/cppbridge/primitives_lss.go
@@ -160,7 +160,14 @@ func (lss *LabelSetStorage) Pointer() uintptr {
 
 // CreateLabelSetSnapshot create LabelSetSnapshot from lss.
 func (lss *LabelSetStorage) CreateLabelSetSnapshot() *LabelSetSnapshot {
-	res := newLabelSetSnapshot(primitivesLSSCreateSnapshotLSS(lss.pointer))
+	res := newLabelSetSnapshot(primitivesLSSCreateSnapshotLSS(lss.pointer), SnapshotTypeWorking)
+	runtime.KeepAlive(lss)
+	return res
+}
+
+// CreateLabelSetSnapshotWithType create LabelSetSnapshot from lss with snapshot type.
+func (lss *LabelSetStorage) CreateLabelSetSnapshotWithType(snapshotType SnapshotType) *LabelSetSnapshot {
+	res := newLabelSetSnapshot(primitivesLSSCreateSnapshotLSS(lss.pointer), snapshotType)
 	runtime.KeepAlive(lss)
 	return res
 }

--- a/pp/go/storage/builder.go
+++ b/pp/go/storage/builder.go
@@ -107,7 +107,7 @@ func (b *Builder) Build(generation uint64, numberOfShards uint16) (*Head, error)
 // with [shard.Shard] with [wal.NoopWal] which is written to disk.
 func (b *Builder) BuildTransactionHead() *TransactionHead {
 	sd := shard.NewShard(
-		shard.NewLSS(),
+		shard.NewTransitionLSS(),
 		shard.NewDataStorage(false),
 		nil,
 		nil,
@@ -166,8 +166,8 @@ func (b *Builder) createShardOnDisk(
 		shardID,
 		shardFile,
 		writer.WriteSegment[*cppbridge.HeadEncodedSegment], // V2: writer.WriteSegmentV2
-		swn,                                                // V2: NoopSegmentWriteNotifier{}
-		writer.NoopSegmentMarkup{},                         // V2: headRecord
+		swn,                        // V2: NoopSegmentWriteNotifier{}
+		writer.NoopSegmentMarkup{}, // V2: headRecord
 		// writer.WriteSegmentV2[*cppbridge.HeadEncodedSegment],
 		// NoopSegmentWriteNotifier{},
 		// headRecord,

--- a/pp/go/storage/head/shard/lss.go
+++ b/pp/go/storage/head/shard/lss.go
@@ -20,6 +20,7 @@ type LSS struct {
 	mappedSnapshot       *cppbridge.LabelSetSnapshot
 	locker               sync.RWMutex
 	once                 sync.Once
+	snapshotType         cppbridge.SnapshotType
 }
 
 // NewLSS init new [LSS].
@@ -27,6 +28,15 @@ func NewLSS() *LSS {
 	return &LSS{
 		input:  cppbridge.NewLssStorage(),
 		target: cppbridge.NewQueryableLssStorage(),
+	}
+}
+
+// NewTransitionLSS init new [LSS] with transition snapshot type.
+func NewTransitionLSS() *LSS {
+	return &LSS{
+		input:        cppbridge.NewLssStorage(),
+		target:       cppbridge.NewQueryableLssStorage(),
+		snapshotType: cppbridge.SnapshotTypeTransition,
 	}
 }
 
@@ -77,7 +87,7 @@ func (l *LSS) FreezeAndCopyAddedSeries(destination *LSS, shrinkBoundary uint32) 
 	// [LSS.FinalizeCopyAndShrink] and [Shard.DstSrcLsIdsMapping] from the
 	// post-rotation path).
 	destination.dstSrcLsIdsMapping = snapshot.CopyAddedSeries(bitsetSeries, destination.target)
-	l.mappedSnapshot = destination.target.CreateLabelSetSnapshot()
+	l.mappedSnapshot = destination.target.CreateLabelSetSnapshotWithType(cppbridge.SnapshotTypeRotation)
 	l.newToOldLsIdsMapping = destination.dstSrcLsIdsMapping
 }
 
@@ -203,7 +213,7 @@ func (l *LSS) WithRLock(fn func(target, input *cppbridge.LabelSetStorage) error)
 // getSnapshot return the actual snapshot.
 func (l *LSS) getSnapshot() *cppbridge.LabelSetSnapshot {
 	l.once.Do(func() {
-		l.snapshot = l.target.CreateLabelSetSnapshot()
+		l.snapshot = l.target.CreateLabelSetSnapshotWithType(l.snapshotType)
 	})
 
 	return l.snapshot

--- a/pp/go/storage/remotewriter/shard.go
+++ b/pp/go/storage/remotewriter/shard.go
@@ -140,7 +140,7 @@ func newCorruptedShard(
 		headID:            headID,
 		shardID:           shardID,
 		corrupted:         true,
-		corruptedSnapshot: cppbridge.NewLssStorage().CreateLabelSetSnapshot(),
+		corruptedSnapshot: cppbridge.NewLssStorage().CreateLabelSetSnapshotWithType(cppbridge.SnapshotTypeRemoteWrite),
 		segmentSize:       segmentSize,
 	}
 }
@@ -248,7 +248,7 @@ func (s *shard) LSSSnapshot() *cppbridge.LabelSetSnapshot {
 		return s.corruptedSnapshot
 	}
 
-	return s.decoder.lss.CreateLabelSetSnapshot()
+	return s.decoder.lss.CreateLabelSetSnapshotWithType(cppbridge.SnapshotTypeRemoteWrite)
 }
 
 // Read [Segment] from WAL and decode to [DecodedSegment].
@@ -417,7 +417,7 @@ func newCorruptedShardRotated(
 		headID:            headID,
 		shardID:           shardID,
 		corrupted:         true,
-		corruptedSnapshot: cppbridge.NewLssStorage().CreateLabelSetSnapshot(),
+		corruptedSnapshot: cppbridge.NewLssStorage().CreateLabelSetSnapshotWithType(cppbridge.SnapshotTypeRemoteWrite),
 		segmentSize:       segmentSize,
 	}
 }
@@ -526,7 +526,7 @@ func (s *shardRotated) LSSSnapshot() *cppbridge.LabelSetSnapshot {
 		return s.corruptedSnapshot
 	}
 
-	return s.decoder.lss.CreateLabelSetSnapshot()
+	return s.decoder.lss.CreateLabelSetSnapshotWithType(cppbridge.SnapshotTypeRemoteWrite)
 }
 
 // ReadSegment reads [DecodedSegment] from wal.


### PR DESCRIPTION
## Description
Refactor snapshot metrics in cppbridge:

- Introduced distinct snapshot types: Working, Transition, Remote Write, and Rotation.
- Updated snapshot creation and finalization counters to reflect the new types.
- Enhanced `LabelSetSnapshot` to accept snapshot types during initialization.
- Modified `CreateLabelSetSnapshot` methods to support type-specific snapshots.