### PR TITLE
tsdb/fileutil: advise MADV_RANDOM for block mmaps

### DIFF
--- a/tsdb/fileutil/mmap_unix.go
+++ b/tsdb/fileutil/mmap_unix.go
@@ -22,7 +22,18 @@ import (
 )
 
 func mmap(f *os.File, length int) ([]byte, error) {
-	return unix.Mmap(int(f.Fd()), 0, length, unix.PROT_READ, unix.MAP_SHARED)
+	b, err := unix.Mmap(int(f.Fd()), 0, length, unix.PROT_READ, unix.MAP_SHARED)
+	if err != nil {
+		return nil, err
+	}
+
+	// Disable kernel readahead for this mapping. Block index/chunk files are
+	// accessed randomly, so the default sequential prefetch only pulls large
+	// chunks of the file into the (active) page cache on first touch, inflating
+	// the container working set for a long time after a restart.
+	_ = unix.Madvise(b, unix.MADV_RANDOM)
+
+	return b, nil
 }
 
 func munmap(b []byte) (err error) {


### PR DESCRIPTION
## Motivation
After a restart, the process memory (page cache working set) balloons and only shrinks much later. `fileutil.OpenMmapFile` maps block files with the kernel's default sequential readahead, so the first touch of a block pulls large neighbouring regions of the index/chunk files into the **active** page cache. Under a query workload that touches many blocks, this over-fetched, actively-referenced cache keeps the container working set inflated for a long time.

This change advises `MADV_RANDOM` on those mmaps to disable readahead, so only the pages actually accessed are faulted in.

In prompp this helper covers **block index** (`tsdb/index/index.go`) and **block chunk segments** (`tsdb/chunks/chunks.go`). The `tsdb` head chunk path (`tsdb/chunks/head_chunks.go`) is **not** exercised here, since WAL is written into prompp's own heads rather than the upstream `tsdb.head`.

## Validation on Mimir
This mirrors a known fix on the Mimir ingester, which exhibited exactly this behaviour: memory ballooned right after start and released ~half of it only after ~8h. Advising `MADV_RANDOM` on the block mmaps removed that hump. In the Mimir ingester the blocks are read **only by queries** — the compactor does not run there.

## Hypothesis
Block access is predominantly random (index lookups + scattered per-series chunk reads), so readahead brings little benefit while significantly inflating the active page cache. Disabling it via `MADV_RANDOM` should:
- cut the post-restart working-set hump (validated on Mimir), and
- keep query performance effectively unchanged for typical (random) block access.

## Risks
Unlike the Mimir ingester, prompp runs a compactor (`tcompactor`) over these same blocks, and compaction reads chunk segments **sequentially** — the one path that genuinely benefits from readahead and that Mimir never validated with this advice.

Watch on stage:
- compaction duration / throughput: `prometheus_tsdb_compaction_duration_seconds`, `prometheus_tcompact_group_compaction_runs_*`;
- disk read IO / iowait during compaction;
- block accumulation (`prometheus_tsdb_blocks_loaded`) in case compaction starts lagging;
- heavy range/`rate()` queries over long intervals (sequential-ish scans);
- and, as the goal, the pod working set (`container_memory_working_set_bytes` / RSS) after restart vs. baseline.

## Possible fixes if a regression shows up
Scoping the advice to index-only is **not** an option here: chunk segments are likely the main contributor to the query-side page-cache hump, so removing the advice from them would bring the balloon back.

The targeted mitigation is to keep `MADV_RANDOM` as the global default but let the **compactor** temporarily hint `MADV_SEQUENTIAL` / `MADV_WILLNEED` on the specific chunk files it is actively reading. That preserves the working-set win while giving compaction readahead exactly where it reads sequentially. This is a localized change inside the forked `lcompactor` / `block` read path, not a change to the shared `mmap` helper, and would be done as a follow-up only if stage shows a compaction regression.

## Test plan
- [ ] Deploy to stage; confirm the post-restart working-set hump is reduced vs. baseline.
- [ ] Verify compaction duration / throughput and disk read IO show no regression.
- [ ] Check block count does not grow (compaction keeps up).
- [ ] Spot-check latency of heavy range queries.