### PR TITLE
ci: optimize CI and make checks required-safe

### DIFF
--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -3,43 +3,9 @@ name: Linter
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    paths:
-      - 'pp/**'
-      - '**/*.bazel'
-      - '**/*.bzl'
-      - '**/BUILD'
-      - '**/WORKSPACE'
-      - '.bazelrc'
-      - '.bazelversion'
-      - 'MODULE.bazel'
-      # The lint toolchain (clang-format/clang-tidy) lives in the CI image
-      # built from Dockerfile.ci, so re-lint when it changes.
-      - 'Dockerfile.ci'
-      # pp/go is the Go bindings; the only C++ header there
-      # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
-      # in any bazel target, and is not linted. Keep it last so it overrides
-      # the includes above.
-      - '!pp/go/**'
   push:
     branches:
       - pp
-    paths:
-      - 'pp/**'
-      - '**/*.bazel'
-      - '**/*.bzl'
-      - '**/BUILD'
-      - '**/WORKSPACE'
-      - '.bazelrc'
-      - '.bazelversion'
-      - 'MODULE.bazel'
-      # The lint toolchain (clang-format/clang-tidy) lives in the CI image
-      # built from Dockerfile.ci, so re-lint when it changes.
-      - 'Dockerfile.ci'
-      # pp/go is the Go bindings; the only C++ header there
-      # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
-      # in any bazel target, and is not linted. Keep it last so it overrides
-      # the includes above.
-      - '!pp/go/**'
   workflow_dispatch:
     inputs:
       release_branch:
@@ -58,8 +24,48 @@ jobs:
       pr_base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
     secrets: inherit
 
+  changes:
+    runs-on: fsn-dev-gitlab-runner
+    outputs:
+      cpp: ${{ steps.filter.outputs.cpp }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # On PRs, decide whether C++, bazel, or the lint toolchain changed. The Go
+      # bindings under pp/go are excluded first: the only C++ header there
+      # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not in
+      # any bazel target, and is not linted. Dockerfile.ci is included because the
+      # clang-format/clang-tidy toolchain lives in the CI image built from it. On
+      # push/workflow_dispatch this step is skipped and the linter runs
+      # unconditionally. Gating is done at job level (not workflow-level paths) so
+      # the `clang-lint` context is still reported (as skipped) and stays safe to
+      # use as a required status check.
+      - name: Detect C++/bazel changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"; echo "$changed"
+          if echo "$changed" \
+            | grep -vE '^pp/go/' \
+            | grep -qE '^pp/|\.bazel$|\.bzl$|(^|/)BUILD$|(^|/)WORKSPACE$|(^|/)MODULE\.bazel$|^\.bazelrc$|^\.bazelversion$|^Dockerfile\.ci$'; then
+            echo "cpp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cpp=false" >> "$GITHUB_OUTPUT"
+          fi
+
   clang-lint:
-    needs: build-ci-image
+    needs: [build-ci-image, changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cpp == 'true'
     runs-on: fsn-dev-gitlab-runner
     steps:
       - name: Clean workspace

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -5,11 +5,35 @@ on:
     types: [opened, reopened, labeled, synchronize]
     paths:
       - 'pp/**'
+      - '**/*.bazel'
+      - '**/*.bzl'
+      - '**/BUILD'
+      - '**/WORKSPACE'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'MODULE.bazel'
+      # pp/go is the Go bindings; the only C++ header there
+      # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
+      # in any bazel target, and is not linted. Keep it last so it overrides
+      # the includes above.
+      - '!pp/go/**'
   push:
     branches:
       - pp
     paths:
       - 'pp/**'
+      - '**/*.bazel'
+      - '**/*.bzl'
+      - '**/BUILD'
+      - '**/WORKSPACE'
+      - '.bazelrc'
+      - '.bazelversion'
+      - 'MODULE.bazel'
+      # pp/go is the Go bindings; the only C++ header there
+      # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
+      # in any bazel target, and is not linted. Keep it last so it overrides
+      # the includes above.
+      - '!pp/go/**'
   workflow_dispatch:
     inputs:
       release_branch:

--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -12,6 +12,9 @@ on:
       - '.bazelrc'
       - '.bazelversion'
       - 'MODULE.bazel'
+      # The lint toolchain (clang-format/clang-tidy) lives in the CI image
+      # built from Dockerfile.ci, so re-lint when it changes.
+      - 'Dockerfile.ci'
       # pp/go is the Go bindings; the only C++ header there
       # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
       # in any bazel target, and is not linted. Keep it last so it overrides
@@ -29,6 +32,9 @@ on:
       - '.bazelrc'
       - '.bazelversion'
       - 'MODULE.bazel'
+      # The lint toolchain (clang-format/clang-tidy) lives in the CI image
+      # built from Dockerfile.ci, so re-lint when it changes.
+      - 'Dockerfile.ci'
       # pp/go is the Go bindings; the only C++ header there
       # (pp/go/cppbridge/entrypoint.h) is generated from pp/entrypoint, is not
       # in any bazel target, and is not linted. Keep it last so it overrides

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -3,24 +3,9 @@ name: Linter
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    paths:
-      - '**/*.go'
-      - '**/go.mod'
-      - '**/go.sum'
-      - '**/.golangci.yml'
-      - 'scripts/golangci-lint.yml'
-      # Go toolchain lives in the CI image built from Dockerfile.ci.
-      - 'Dockerfile.ci'
   push:
     branches:
       - pp
-    paths:
-      - '**/*.go'
-      - '**/go.mod'
-      - '**/go.sum'
-      - '**/.golangci.yml'
-      - 'scripts/golangci-lint.yml'
-      - 'Dockerfile.ci'
   workflow_dispatch:
     inputs:
       release_branch:
@@ -39,8 +24,44 @@ jobs:
       pr_base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
     secrets: inherit
 
+  changes:
+    runs-on: fsn-dev-gitlab-runner
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # On PRs, decide whether Go sources, module files, the golangci config, or
+      # the Go toolchain (CI image / Dockerfile.ci) changed. On
+      # push/workflow_dispatch this step is skipped and the linter runs
+      # unconditionally. Gating is done at job level (not workflow-level paths)
+      # so the `golangci` context is still reported (as skipped) and stays safe
+      # to use as a required status check.
+      - name: Detect Go changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"; echo "$changed"
+          if echo "$changed" \
+            | grep -qE '\.go$|(^|/)go\.mod$|(^|/)go\.sum$|(^|/)\.golangci\.yml$|^scripts/golangci-lint\.yml$|^Dockerfile\.ci$'; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          fi
+
   golangci:
-    needs: build-ci-image
+    needs: [build-ci-image, changes]
+    if: github.event_name != 'pull_request' || needs.changes.outputs.go == 'true'
     runs-on: fsn-dev-gitlab-runner
     steps:
       - name: Clean workspace

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -3,17 +3,24 @@ name: Linter
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-    # paths:
-    #   - '**/*.go'
-    #   - '**/*.mod'
-    #   - '**/*.sum'
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '**/.golangci.yml'
+      - 'scripts/golangci-lint.yml'
+      # Go toolchain lives in the CI image built from Dockerfile.ci.
+      - 'Dockerfile.ci'
   push:
     branches:
       - pp
-    # paths:
-    #   - '**/*.go'
-    #   - '**/*.mod'
-    #   - '**/*.sum'
+    paths:
+      - '**/*.go'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '**/.golangci.yml'
+      - 'scripts/golangci-lint.yml'
+      - 'Dockerfile.ci'
   workflow_dispatch:
     inputs:
       release_branch:

--- a/.github/workflows/pr-milestone.yaml
+++ b/.github/workflows/pr-milestone.yaml
@@ -1,0 +1,25 @@
+name: PR Milestone Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, milestoned, demilestoned]
+    branches:
+      - pp
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  require-milestone:
+    runs-on: fsn-dev-gitlab-runner
+    steps:
+      - name: Require milestone on PR into pp
+        env:
+          MILESTONE: ${{ github.event.pull_request.milestone.title }}
+        run: |
+          if [ -z "$MILESTONE" ]; then
+            echo "::error::PR into 'pp' must be assigned a milestone. Assign one (see release flow in .wiki/howto/release.md) and the check will re-run."
+            exit 1
+          fi
+          echo "Milestone: $MILESTONE"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -402,3 +402,25 @@ jobs:
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dev-image')
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit
+
+  tests-gate:
+    # Single required status check that aggregates the mandatory test pipeline.
+    # `if: always()` guarantees the context is always reported, so conditional
+    # matrix jobs (whose context names vary) don't have to be required directly.
+    # A `skipped` dependency is fine (e.g. cpp-tests when C++ is unchanged); the
+    # gate fails only when a required job failed or was cancelled.
+    # The optional label-gated jobs (go-test-pp asan, build_dev) are intentionally
+    # excluded, so they never block merge.
+    needs: [build-ci-image, changes, cpp-tests, build-go-bindings, go-test-all]
+    if: always()
+    runs-on: fsn-dev-gitlab-runner
+    steps:
+      - name: Check required test jobs
+        run: |
+          results="${{ join(needs.*.result, ',') }}"
+          echo "needs results: $results"
+          if [[ "$results" == *failure* || "$results" == *cancelled* ]]; then
+            echo "::error::A required test job failed or was cancelled"
+            exit 1
+          fi
+          echo "All required test jobs passed or were safely skipped."

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -272,11 +272,8 @@ jobs:
               set -eo pipefail
 
               git config --global --add safe.directory /workspace
-              # go tools
+              # go test-report/coverage tools are baked into the CI image
               mkdir -p .cache
-              go install github.com/jstemmer/go-junit-report/v2@latest
-              go install github.com/afunix/gocov/gocov@latest
-              go install github.com/AlekSi/gocov-xml@latest
 
               # Tests for our packages (Makefile default pkgs = ./pp/go/... ./pp-pkg/...).
               FLAGS=\$(./pp/scripts/ci_get_go_test_flags.sh)
@@ -364,11 +361,8 @@ jobs:
               set -eo pipefail
 
               git config --global --add safe.directory /workspace
-              # go tools
+              # go test-report/coverage tools are baked into the CI image
               mkdir -p .cache
-              go install github.com/jstemmer/go-junit-report/v2@latest
-              go install github.com/afunix/gocov/gocov@latest
-              go install github.com/AlekSi/gocov-xml@latest
 
               # All-packages run; pkgs override = filtered list from scripts/list-test-packages.sh.
               # -timeout 20m: per-package timeout (default 10m) — heavy upstream tsdb suite needs more under -race+coverage.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -143,8 +143,9 @@ jobs:
     if: ${{ always() && needs.build-ci-image.result == 'success' && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
     strategy:
       max-parallel: 4
+      # Only opt builds are consumed downstream: go-tests uses opt+asan,
+      # go-tests-all-pkgs uses opt+jemalloc. ASAN toggles the two variants.
       matrix:
-        COMPILATION_MODE: [dbg, opt]
         ASAN: [false, true]
         runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
         include:
@@ -174,7 +175,7 @@ jobs:
           docker run --rm \
             -v $PWD:/workspace \
             -w /workspace \
-            -e COMPILATION_MODE=${{ matrix.COMPILATION_MODE }} \
+            -e COMPILATION_MODE=opt \
             -e ASAN=${{ matrix.ASAN }} \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }}${{ needs.build-ci-image.outputs.tag_suffix }} \
             bash -c "
@@ -182,7 +183,7 @@ jobs:
 
               git config --global --add safe.directory /workspace && cd pp
               echo \"build --remote_cache=http://172.17.0.1/cache/ --experimental_guard_against_concurrent_changes\" >> .bazelrc
-              make compilation_mode=${{ matrix.COMPILATION_MODE }} asan=${{ matrix.ASAN }} build-entrypoint
+              make compilation_mode=opt asan=${{ matrix.ASAN }} build-entrypoint
             "
 
       - name: Fix build artifact ownership
@@ -194,7 +195,7 @@ jobs:
       - name: Upload Specific Static Libraries
         uses: actions/upload-artifact@v4
         with:
-          name: go-cppbridge-${{ matrix.arch }}-${{ matrix.COMPILATION_MODE }}-${{ matrix.ASAN }}
+          name: go-cppbridge-${{ matrix.arch }}-opt-${{ matrix.ASAN }}
           path: pp/go/cppbridge/${{ matrix.arch }}_*
           retention-days: 7
 
@@ -202,27 +203,18 @@ jobs:
         run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
 
   go-tests:
+    # Our packages (Makefile default pkgs = ./pp/go/... ./pp-pkg/...).
+    # Single combination: opt + asan, on amd64 and arm64. The opt + jemalloc
+    # variant is covered by `go-tests-all-pkgs` (full repository).
     needs: [build-ci-image, build-go-bindings]
     strategy:
-      max-parallel: 4
+      max-parallel: 2
       matrix:
-        runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
         include:
-          - SANITIZERS: no_sanitizers
-            ASAN: false
-            STATIC: static
-          - SANITIZERS: with_sanitizers
-            ASAN: true
-        # Run only the two meaningful combinations: dbg+jemalloc and opt+asan.
-        # The remaining opt+jemalloc variant is covered by `go-tests-all-pkgs`,
-        # which exercises the full repository (root module ./...).
-        exclude:
-          - SANITIZERS: with_sanitizers
-            OPT: dbg
-          - SANITIZERS: no_sanitizers
-            OPT: opt
+          - runner_name: fsn-dev-perftest-runner
+            arch: amd64
+          - runner_name: fsn-dev-arm-runner
+            arch: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:
       - name: Clean workspace
@@ -240,18 +232,10 @@ jobs:
           registry_password: ${{ secrets.DEV_REGISTRY_PASSWORD }}
           channel: ${{ secrets.WERF_UPDATE_CHANNEL }}
 
-      - name: Set architecture variable
-        run: |
-          if [[ "${{ matrix.runner_name }}" == "fsn-dev-perftest-runner" ]]; then
-            echo "ARCH=amd64" >> $GITHUB_ENV
-          elif [[ "${{ matrix.runner_name }}" == "fsn-dev-arm-runner" ]]; then
-            echo "ARCH=arm64" >> $GITHUB_ENV
-          fi
-
       - name: Download Static Library
         uses: actions/download-artifact@v4
         with:
-          name: go-cppbridge-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.ASAN }}
+          name: go-cppbridge-${{ matrix.arch }}-opt-true
           path: pp/go/cppbridge/
 
       - name: Run Go Tests and Process Reports
@@ -260,14 +244,14 @@ jobs:
             -v $PWD:/workspace \
             -w /workspace \
             -e CI=true \
-            -e OPT=${{ matrix.OPT }} \
-            -e SANITIZERS=${{ matrix.SANITIZERS }} \
+            -e OPT=opt \
+            -e SANITIZERS=with_sanitizers \
             -e CGO_CFLAGS="-Wno-error -I/usr/include" \
             -e CGO_LDFLAGS="-L/usr/lib/" \
             -e CGO_ENABLED="1" \
             -e GOPATH="${{ github.workspace }}/.cache" \
             -e GOBIN="/usr/local/go/bin" \
-            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ env.ARCH }}${{ needs.build-ci-image.outputs.tag_suffix }} \
+            ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }}${{ needs.build-ci-image.outputs.tag_suffix }} \
             bash -c "
               set -eo pipefail
 
@@ -298,14 +282,14 @@ jobs:
       - name: Upload Go Test Reports
         uses: actions/upload-artifact@v4
         with:
-          name: go-unit-tests-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+          name: go-unit-tests-${{ matrix.arch }}-opt-with_sanitizers
           path: report.xml
           retention-days: 7
 
       - name: Upload Coverage Report
         uses: actions/upload-artifact@v4
         with:
-          name: go-coverage-report-${{ env.ARCH }}-${{ matrix.OPT }}-${{ matrix.SANITIZERS }}
+          name: go-coverage-report-${{ matrix.arch }}-opt-with_sanitizers
           path: coverage.xml
           retention-days: 7
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,10 +37,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      # On PRs, decide whether C++ or bazel files changed. The Go bindings
-      # under pp/go are excluded first (those are Go changes, covered by the
-      # Go test jobs). On push/workflow_dispatch this step is skipped and
-      # consumers run the C++ suite unconditionally.
+      # On PRs, decide whether C++, bazel, or the CI toolchain changed. The Go
+      # bindings under pp/go are excluded first (those are Go changes, covered
+      # by the Go test jobs). Dockerfile.ci is included because the C++
+      # toolchain lives in the CI image built from it. On push/workflow_dispatch
+      # this step is skipped and consumers run the C++ suite unconditionally.
       - name: Detect C++/bazel changes
         id: filter
         if: github.event_name == 'pull_request'
@@ -52,7 +53,7 @@ jobs:
           echo "Changed files:"; echo "$changed"
           if echo "$changed" \
             | grep -vE '^pp/go/' \
-            | grep -qE '^pp/|\.bazel$|\.bzl$|(^|/)BUILD$|(^|/)WORKSPACE$|(^|/)MODULE\.bazel$|^\.bazelrc$|^\.bazelversion$'; then
+            | grep -qE '^pp/|\.bazel$|\.bzl$|(^|/)BUILD$|(^|/)WORKSPACE$|(^|/)MODULE\.bazel$|^\.bazelrc$|^\.bazelversion$|^Dockerfile\.ci$'; then
             echo "cpp=true" >> "$GITHUB_OUTPUT"
           else
             echo "cpp=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -191,8 +191,6 @@ jobs:
           docker run --rm \
             -v $PWD:/workspace \
             -w /workspace \
-            -e COMPILATION_MODE=opt \
-            -e ASAN=${{ matrix.ASAN }} \
             ${{ secrets.DEV_REGISTRY }}/prompp/ci-gcc-image:gcc-tools-${{ matrix.arch }}${{ needs.build-ci-image.outputs.tag_suffix }} \
             bash -c "
               set -eo pipefail

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -144,9 +144,12 @@ jobs:
     strategy:
       max-parallel: 4
       # Only opt builds are consumed downstream: go-test-pp uses opt+asan,
-      # go-test-all uses opt+jemalloc. ASAN toggles the two variants.
+      # go-test-all uses opt+jemalloc.
       matrix:
-        ASAN: [false, true]
+        # Jemalloc (ASAN off) always builds — go-test-all needs it. The ASAN
+        # variant is heavy and only feeds the optional go-test-pp job, so build
+        # it only when the PR carries the `go-test-asan` label.
+        ASAN: ${{ contains(github.event.pull_request.labels.*.name, 'go-test-asan') && fromJSON('[false, true]') || fromJSON('[false]') }}
         runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
         include:
           - runner_name: fsn-dev-perftest-runner

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -65,14 +65,26 @@ jobs:
     if: github.event_name != 'pull_request' || needs.changes.outputs.cpp == 'true'
     strategy:
       max-parallel: 2
+      # Two meaningful combinations, on amd64 and arm64:
+      #   dbg + asan       — catch memory bugs with debug symbols
+      #   opt + jemalloc   — release-like build
       matrix:
-        OPT: [dbg, opt]
-        SANITIZERS: [no_sanitizers, with_sanitizers]
-        runner_name: [fsn-dev-gitlab-runner, fsn-dev-arm-runner]
         include:
-          - runner_name: fsn-dev-gitlab-runner
+          - OPT: dbg
+            SANITIZERS: with_sanitizers
+            runner_name: fsn-dev-gitlab-runner
             arch: amd64
-          - runner_name: fsn-dev-arm-runner
+          - OPT: dbg
+            SANITIZERS: with_sanitizers
+            runner_name: fsn-dev-arm-runner
+            arch: arm64
+          - OPT: opt
+            SANITIZERS: no_sanitizers
+            runner_name: fsn-dev-gitlab-runner
+            arch: amd64
+          - OPT: opt
+            SANITIZERS: no_sanitizers
+            runner_name: fsn-dev-arm-runner
             arch: arm64
     runs-on: ${{ matrix.runner_name }}
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -364,6 +364,6 @@ jobs:
 
   build_dev:
     needs: [go-tests, go-tests-all-pkgs]
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dev-image')
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,8 +24,45 @@ jobs:
       pr_base_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref || '' }}
     secrets: inherit
 
+  changes:
+    runs-on: fsn-dev-gitlab-runner
+    outputs:
+      cpp: ${{ steps.filter.outputs.cpp }}
+    steps:
+      - name: Clean workspace
+        uses: freenet-actions/action-clean@v1
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # On PRs, decide whether C++ or bazel files changed. The Go bindings
+      # under pp/go are excluded first (those are Go changes, covered by the
+      # Go test jobs). On push/workflow_dispatch this step is skipped and
+      # consumers run the C++ suite unconditionally.
+      - name: Detect C++/bazel changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -eo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"; echo "$changed"
+          if echo "$changed" \
+            | grep -vE '^pp/go/' \
+            | grep -qE '^pp/|\.bazel$|\.bzl$|(^|/)BUILD$|(^|/)WORKSPACE$|(^|/)MODULE\.bazel$|^\.bazelrc$|^\.bazelversion$'; then
+            echo "cpp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cpp=false" >> "$GITHUB_OUTPUT"
+          fi
+
   cpp-tests:
-    needs: build-ci-image
+    needs: [build-ci-image, changes]
+    # C++ unit tests run only when C++/bazel files changed (on PRs); always on
+    # push to pp and manual dispatch.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cpp == 'true'
     strategy:
       max-parallel: 2
       matrix:
@@ -100,6 +137,10 @@ jobs:
 
   build-go-bindings:
     needs: [build-ci-image, cpp-tests]
+    # Go tests link against the freshly built cppbridge libs, so this must run
+    # every time — including when cpp-tests was skipped (C++ unchanged). Only
+    # block it if the CI image failed or the C++ tests actually failed.
+    if: ${{ always() && needs.build-ci-image.result == 'success' && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
     strategy:
       max-parallel: 4
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -143,8 +143,8 @@ jobs:
     if: ${{ always() && needs.build-ci-image.result == 'success' && (needs.cpp-tests.result == 'success' || needs.cpp-tests.result == 'skipped') }}
     strategy:
       max-parallel: 4
-      # Only opt builds are consumed downstream: go-tests uses opt+asan,
-      # go-tests-all-pkgs uses opt+jemalloc. ASAN toggles the two variants.
+      # Only opt builds are consumed downstream: go-test-pp uses opt+asan,
+      # go-test-all uses opt+jemalloc. ASAN toggles the two variants.
       matrix:
         ASAN: [false, true]
         runner_name: [fsn-dev-perftest-runner, fsn-dev-arm-runner]
@@ -202,11 +202,13 @@ jobs:
       - name: Clear workspace
         run: rm -rf pp/go/cppbridge/${{ matrix.arch }}_*
 
-  go-tests:
+  go-test-pp:
     # Our packages (Makefile default pkgs = ./pp/go/... ./pp-pkg/...).
     # Single combination: opt + asan, on amd64 and arm64. The opt + jemalloc
-    # variant is covered by `go-tests-all-pkgs` (full repository).
+    # variant is covered by `go-test-all` (full repository).
+    # Optional: runs only when the PR carries the `go-test-asan` label.
     needs: [build-ci-image, build-go-bindings]
+    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'go-test-asan')
     strategy:
       max-parallel: 2
       matrix:
@@ -293,7 +295,7 @@ jobs:
           path: coverage.xml
           retention-days: 7
 
-  go-tests-all-pkgs:
+  go-test-all:
     # Runs the entire repository (root module ./..., minus packages that we
     # replace with pp-pkg counterparts or do not ship in cmd/prometheus).
     # Single combination: opt + jemalloc (no sanitizers), on amd64 and arm64.
@@ -388,7 +390,7 @@ jobs:
           retention-days: 7
 
   build_dev:
-    needs: [go-tests, go-tests-all-pkgs]
+    needs: [go-test-all]
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dev-image')
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -60,6 +60,9 @@ ENV GOPATH="/opt/go"
 ENV PATH="$PATH:/usr/local/go/bin:/opt/go/bin"
 RUN go install github.com/jstemmer/go-junit-report/v2@latest
 RUN go install github.com/prometheus/promu@latest
+# Go test-report/coverage tools (used by the Go test jobs in CI).
+RUN go install github.com/afunix/gocov/gocov@latest
+RUN go install github.com/AlekSi/gocov-xml@latest
 
 # goyacc for generating promql/parser (make test, make build)
 ARG GOYACC_VERSION=v0.6.0


### PR DESCRIPTION
## Summary

Optimize the PR pipeline and restructure it so status checks can be made **required** on `pp` without deadlocking merges.

### Milestone gate
- Add `pr-milestone` workflow: PRs into `pp` must have a milestone assigned.

### Cost cuts
- C++ lint & tests run only when C++/bazel/`Dockerfile.ci` changed (excluding `pp/go`).
- `golangci` runs only on Go/toolchain changes.
- Trim `cpp-tests` matrix to `dbg+asan` and `opt+jemalloc` (2 arch → 4 jobs).
- Simplify Go test matrices; drop `dbg`/no-sanitizer combos.
- `go-test-pp` (Go tests + ASAN) opt-in via `go-test-asan` label; ASAN cppbridge build gated by the same label.
- Dev image build/push (`build_dev`) opt-in via `build-dev-image` label.
- Drop redundant `COMPILATION_MODE`/`ASAN` env in `build-go-bindings`.
- Bake `gocov`/`gocov-xml` into the CI image; drop per-run `go install`.

### Required-safe design
GitHub keeps a required check permanently *pending* when the whole workflow is skipped by a workflow-level `paths:` filter. So gating moved to **job-level `if:`** (a skipped job reports `skipped`, which branch protection treats as passing):
- `golang_lint` / `clang_lint`: always trigger; gate the lint job via a `changes` detector.
- `tests.yaml`: add a `tests-gate` aggregator (`needs` the mandatory jobs, `if: always()`, fails only on failure/cancelled) — a single required check covering the conditional matrix jobs. Optional jobs (`go-test-pp` asan, `build_dev`) excluded.

Intended required checks on `pp`: `require-milestone`, `golangci`, `clang-lint`, `tests-gate`.

## Test plan
- [ ] Green pipeline on this PR (Go-only change → C++ jobs skipped, `tests-gate` passes).
- [ ] Verify a docs-only PR skips heavy jobs while `tests-gate` still reports.
- [ ] After merge: enable required status checks via branch protection API.

Made with [Cursor](https://cursor.com)