### PR TITLE
chore(renovate): enable platform automerge and auto-assign reviewer

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,14 @@
   "minimumReleaseAge": "90 days",
   "internalChecksFilter": "strict",
 
+  "reviewers": ["vporoshok"],
+  "assignees": ["vporoshok"],
+
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+
   "vulnerabilityAlerts": {
     "enabled": true,
     "minimumReleaseAge": "0 days",


### PR DESCRIPTION
## Summary
- Enable native GitHub auto-merge (`platformAutomerge: true`) with squash strategy for Renovate PRs, so they merge automatically once branch protection is satisfied (1 approval + required checks).
- Always add `vporoshok` as reviewer and assignee on all Renovate PRs.

## Details
- `automerge: true`, `automergeType: "pr"`, `platformAutomerge: true`, `automergeStrategy: "squash"`.
- `reviewers` / `assignees` set to `vporoshok`.
- Existing cool-down (`minimumReleaseAge`) rules are unchanged: automerge only fires after an update matures (14 days for trusted vendors / 90 days default).

## Note
Branch protection on `pp` currently has no required status checks (only 1 required approval). Native auto-merge waits only for *required* checks, so to guarantee "merge only on green CI" the key CI contexts should be added to `pp` required status checks.

Made with [Cursor](https://cursor.com)