### PR TITLE
ci: use distinct concurrency groups for clang and go linters

### DIFF
--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -13,7 +13,7 @@ on:
         required: false
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: clang-lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -13,7 +13,7 @@ on:
         required: false
 
 concurrency: 
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: golangci-lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Both `clang_lint.yaml` and `golang_lint.yaml` share `name: Linter` and the concurrency group `${{ github.workflow }}-${{ github.ref }}`. Since `github.workflow` is the workflow *name*, both files resolved to the same group (`Linter-<ref>`).
- With `cancel-in-progress: true`, the two linters ended up in one concurrency group and cancelled each other — the clang lint job was killed with `Canceling since a higher priority waiting request for Linter-... exists` whenever the Go linter started on the same ref (and vice versa).
- Give each workflow its own literal group so they run independently per ref:
  - clang: `clang-lint-${{ github.ref }}`
  - golangci: `golangci-lint-${{ github.ref }}`

`cancel-in-progress: true` is kept, so a new push to the same PR still supersedes the previous in-progress run of that same linter.

## Test plan

- [ ] Open/push a PR touching `pp/**` and Go files; confirm both `clang-lint` and `golangci` run to completion without cancelling each other.

Made with [Cursor](https://cursor.com)