### PR TITLE
ci: gate Renovate PRs behind ready-for-ci label; drop push CI on pp

### DIFF
--- a/.github/workflows/clang_lint.yaml
+++ b/.github/workflows/clang_lint.yaml
@@ -3,9 +3,6 @@ name: Linter
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-  push:
-    branches:
-      - pp
   workflow_dispatch:
     inputs:
       release_branch:
@@ -18,6 +15,12 @@ concurrency:
 
 jobs:
   build-ci-image:
+    # Skip linting for Renovate PRs until a human adds the `ready-for-ci` label.
+    # Merge stays blocked in the meantime via the tests-gate check (tests.yaml).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'deckhouse-BOaTswain' ||
+      contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
     uses: ./.github/workflows/build-ci-image.yaml
     with:
       pr_number: ${{ github.event_name == 'pull_request' && format('{0}', github.event.number) || '' }}

--- a/.github/workflows/golang_lint.yaml
+++ b/.github/workflows/golang_lint.yaml
@@ -3,9 +3,6 @@ name: Linter
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-  push:
-    branches:
-      - pp
   workflow_dispatch:
     inputs:
       release_branch:
@@ -18,6 +15,12 @@ concurrency:
 
 jobs:
   build-ci-image:
+    # Skip linting for Renovate PRs until a human adds the `ready-for-ci` label.
+    # Merge stays blocked in the meantime via the tests-gate check (tests.yaml).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'deckhouse-BOaTswain' ||
+      contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
     uses: ./.github/workflows/build-ci-image.yaml
     with:
       pr_number: ${{ github.event_name == 'pull_request' && format('{0}', github.event.number) || '' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,9 +3,6 @@ name: Run Tests
 on:
   pull_request:
     types: [opened, reopened, labeled, synchronize]
-  push:
-    branches:
-      - pp
   workflow_dispatch:
     inputs:
       release_branch:
@@ -18,6 +15,13 @@ concurrency:
 
 jobs:
   build-ci-image:
+    # Skip the whole heavy pipeline for Renovate PRs until a human adds the
+    # `ready-for-ci` label. Non-PR events and non-Renovate PRs are unaffected.
+    # The merge is still blocked in the meantime by the tests-gate job below.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.user.login != 'deckhouse-BOaTswain' ||
+      contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
     uses: ./.github/workflows/build-ci-image.yaml
     with:
       pr_number: ${{ github.event_name == 'pull_request' && format('{0}', github.event.number) || '' }}
@@ -415,6 +419,18 @@ jobs:
     if: always()
     runs-on: fsn-dev-gitlab-runner
     steps:
+      # Block merge (and native automerge) for Renovate PRs that have not yet
+      # received the `ready-for-ci` label. This is the required check that keeps
+      # such PRs un-mergeable while the heavy CI jobs are intentionally skipped.
+      - name: Require ready-for-ci label on Renovate PRs
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login == 'deckhouse-BOaTswain' &&
+          !contains(github.event.pull_request.labels.*.name, 'ready-for-ci')
+        run: |
+          echo "::error::Renovate PR is awaiting the 'ready-for-ci' label. CI runs and merge unlock once the label is added."
+          exit 1
+
       - name: Check required test jobs
         run: |
           results="${{ join(needs.*.result, ',') }}"


### PR DESCRIPTION
## Summary
- Gate the heavy CI/lint pipeline for Renovate PRs (`deckhouse-BOaTswain`) behind a `ready-for-ci` label. Until the label is added, `build-ci-image` (and everything downstream) is skipped, and the required `tests-gate` check fails — so the PR and native automerge stay blocked without spending runners.
- Adding the `ready-for-ci` label re-triggers the workflows (they already listen on `labeled`) and runs the full pipeline as usual.
- Remove the `push: branches: [pp]` trigger from `tests.yaml`, `golang_lint.yaml`, `clang_lint.yaml` (kept `workflow_dispatch` for manual runs). Post-merge CI on `pp` is redundant given required PR checks.

## Scope / not touched
- Only Renovate-authored PRs are gated; human PRs and `workflow_dispatch` are unaffected.
- CI image rebuild on `Dockerfile.ci` push to `pp` and dockerhub publish on `v*` tags are unchanged.

## Notes
- The `ready-for-ci` label needs to exist in the repo (author will add it).
- Effective for Renovate PRs created/rebased after this merges to `pp`.
- Trade-off: with `strict: false` branch protection, disabling post-merge `pp` CI removes the safety net for two independently-green PRs whose combination breaks.

Made with [Cursor](https://cursor.com)