### PR TITLE
make stringlabels default

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@ run:
   timeout: 15m
   build-tags:
     - static
-    - stringlabels
 
 output:
   sort-results: true

--- a/.promu.yml
+++ b/.promu.yml
@@ -18,10 +18,8 @@ build:
             - netgo
             - builtinassets
             - osusergo
-            - stringlabels
         windows:
             - builtinassets
-            - stringlabels
     ldflags: |
         -X github.com/prometheus/common/version.Version={{.Version}}
         -X github.com/prometheus/common/version.Revision={{.Revision}}

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ TSDB_BENCHMARK_OUTPUT_DIR ?= ./benchout
 
 GOLANGCI_LINT_OPTS ?= --timeout 4m
 GOYACC_VERSION ?= v0.6.0
-GOOPTS ?= -tags stringlabels
 
 include Makefile.common
 

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !stringlabels && !dedupelabels
+//go:build slicelabels && !dedupelabels
 
 package labels
 
@@ -460,7 +460,7 @@ func (b *ScratchBuilder) Add(name, value string) {
 }
 
 // UnsafeAddBytes adds a name/value pair, using []byte instead of string.
-// The '-tags stringlabels' version of this function is unsafe, hence the name.
+// The default string-labels version of this function is unsafe, hence the name.
 // This version is safe - it copies the strings immediately - but we keep the same name so everything compiles.
 func (b *ScratchBuilder) UnsafeAddBytes(name, value []byte) {
 	b.add = append(b.add, Label{Name: string(name), Value: string(value)})

--- a/model/labels/labels_common_noncpp.go
+++ b/model/labels/labels_common_noncpp.go
@@ -1,4 +1,4 @@
-//go:build !stringlabels && !dedupelabels && !cpplabels
+//go:build slicelabels && !dedupelabels && !cpplabels
 
 package labels
 

--- a/model/labels/labels_common_nonslice_noncpp.go
+++ b/model/labels/labels_common_nonslice_noncpp.go
@@ -1,4 +1,4 @@
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package labels
 

--- a/model/labels/labels_stringlabels.go
+++ b/model/labels/labels_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package labels
 

--- a/model/labels/labels_struct_size.go
+++ b/model/labels/labels_struct_size.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !stringlabels && !dedupelabels
+//go:build slicelabels && !dedupelabels
 
 package labels
 

--- a/model/labels/labels_struct_size_stringlabels.go
+++ b/model/labels/labels_struct_size_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package labels
 

--- a/model/labels/sharding.go
+++ b/model/labels/sharding.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !stringlabels && !dedupelabels
+//go:build slicelabels && !dedupelabels
 
 package labels
 

--- a/model/labels/sharding_stringlabels.go
+++ b/model/labels/sharding_stringlabels.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package labels
 

--- a/pp/.golangci.yml
+++ b/pp/.golangci.yml
@@ -15,7 +15,6 @@ run:
 
   build-tags:
     - static
-    - stringlabels
 
 # output configuration options
 output:

--- a/pp/go/cppbridge/lss_snapshot_serialize_test.go
+++ b/pp/go/cppbridge/lss_snapshot_serialize_test.go
@@ -1,4 +1,4 @@
-//go:build stringlabels
+//go:build !slicelabels && !dedupelabels
 
 package cppbridge_test
 

--- a/pp/go/storage/remotewriter/iterator_test.go
+++ b/pp/go/storage/remotewriter/iterator_test.go
@@ -274,7 +274,7 @@ func (*IteratorSuite) decodeToWriteRequest(wr *prompb.WriteRequest, data []byte)
 // Benchmark
 //
 
-// go test -test.fullpath=true -benchmem -run=^$ -tags stringlabels -bench ^BenchmarkIteratorV1$ github.com/prometheus/prometheus/pp/go/storage/remotewriter -v -count=1 -benchtime=1000x.
+// go test -test.fullpath=true -benchmem -run=^$ -bench ^BenchmarkIteratorV1$ github.com/prometheus/prometheus/pp/go/storage/remotewriter -v -count=1 -benchtime=1000x.
 func BenchmarkIteratorV1(b *testing.B) {
 	if b.N != 100 && b.N != 1000 {
 		return
@@ -359,7 +359,7 @@ func BenchmarkIteratorV1(b *testing.B) {
 	}
 }
 
-// go test -test.fullpath=true -benchmem -run=^$ -tags stringlabels -bench ^BenchmarkIteratorV2$ github.com/prometheus/prometheus/pp/go/storage/remotewriter -v -count=1 -benchtime=1000x.
+// go test -test.fullpath=true -benchmem -run=^$ -bench ^BenchmarkIteratorV2$ github.com/prometheus/prometheus/pp/go/storage/remotewriter -v -count=1 -benchtime=1000x.
 func BenchmarkIteratorV2(b *testing.B) {
 	if b.N != 100 && b.N != 1000 {
 		return

--- a/pp/scripts/ci_get_go_test_flags.sh
+++ b/pp/scripts/ci_get_go_test_flags.sh
@@ -3,7 +3,7 @@
 # Supported OPT env var values: dbg, opt
 # Supported SANITIZERS env var values: with_sanitizers, no_sanitizers
 # Supported FASTCGO env var values: with_fastcgo, without_fastcgo
-tags="stringlabels"
+tags=""
 
 function append_tag_if_equal() {
 	if [ "$1" = "$2" ]; then

--- a/tsdb/agent/series_test.go
+++ b/tsdb/agent/series_test.go
@@ -81,7 +81,7 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
 	if ls1.Hash() != ls2.Hash() {
-		// These ones are the same when using -tags stringlabels
+		// These ones are the same with the default string-labels representation.
 		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
 		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
 	}

--- a/tsdb/head_test.go
+++ b/tsdb/head_test.go
@@ -5944,7 +5944,7 @@ func labelsWithHashCollision() (labels.Labels, labels.Labels) {
 	ls2 := labels.FromStrings("__name__", "metric", "lbl1", "value", "lbl2", "v7uDlF")
 
 	if ls1.Hash() != ls2.Hash() {
-		// These ones are the same when using -tags stringlabels
+		// These ones are the same with the default string-labels representation.
 		ls1 = labels.FromStrings("__name__", "metric", "lbl", "HFnEaGl")
 		ls2 = labels.FromStrings("__name__", "metric", "lbl", "RqcXatm")
 	}


### PR DESCRIPTION
Inverted `stringlabels` tag, now it's default behaviour. Introduced `slicelabels` tag, which restores previous behaviour.