### PR TITLE
Physical dependencies cleanup

### DIFF
--- a/pp/BUILD
+++ b/pp/BUILD
@@ -19,12 +19,10 @@ cc_library(
     name = "bare_bones_headers",
     hdrs = glob(["bare_bones/*.h"]),
     deps = [
-        "//third_party",
         "@lz4",
         "@parallel_hashmap",
         "@scope_exit",
         "@xxHash",
-        "@roaring",
     ],
 )
 
@@ -68,6 +66,9 @@ cc_library(
     hdrs = glob(["primitives/**/*.h"]),
     deps = [
         ":bare_bones",
+        "//third_party:protozero",
+        "@parallel_hashmap",
+        "@scope_exit",
     ],
 )
 
@@ -93,9 +94,12 @@ cc_library(
     deps = [
         ":bare_bones",
         ":primitives",
+        "//third_party:protozero",
         "@com_google_absl//absl/crc:crc32c",
+        "@parallel_hashmap",
         "@quasis_crypto",
         "@re2",
+        "@roaring",
         "@simdutf",
     ],
 )
@@ -118,8 +122,11 @@ cc_library(
         ":primitives",
         ":prometheus",
         ":series_data",
+        "//third_party:protozero",
+        "//third_party:uuid",
         "//third_party/fastfloat",
         "@roaring",
+        "@scope_exit",
         "@simdutf",
         "@snappy",
     ],
@@ -149,6 +156,9 @@ cc_library(
     hdrs = glob(["head/**/*.h"]),
     linkstatic = True,
     deps = [
+        ":bare_bones",
+        ":primitives",
+        ":prometheus",
         ":series_data",
         ":series_index",
     ],
@@ -168,6 +178,7 @@ cc_library(
     hdrs = glob(["metrics/**/*.h"]),
     linkstatic = True,
     deps = [
+        ":bare_bones",
         ":prometheus",
         ":primitives",
     ],
@@ -190,8 +201,8 @@ cc_library(
     linkstatic = True,
     deps = [
         ":bare_bones",
-        ":head",
         ":primitives",
+        ":prometheus",
         ":series_data",
         ":series_index",
         ":wal",
@@ -229,6 +240,9 @@ cc_library(
         ":head",
         ":metrics",
         ":primitives",
+        ":prometheus",
+        ":series_data",
+        ":series_index",
         ":wal",
     ] + select({
         "//bazel/toolchain:with_asan": [],
@@ -264,13 +278,10 @@ cc_library(
     name = "performance_tests_headers",
     hdrs = glob(["performance_tests/**/*.h"]),
     deps = [
-        ":head",
+        ":bare_bones",
         ":primitives",
-        ":prometheus",
-        ":series_data",
-        ":series_index",
         ":wal",
-        "//third_party",
+        "@parallel_hashmap",
     ],
 )
 
@@ -280,7 +291,15 @@ cc_binary(
     malloc = "@jemalloc",
     deps = [
         ":performance_tests_headers",
-        "@gtest//:gtest_main",
+        ":bare_bones",
+        ":primitives",
+        ":prometheus",
+        ":series_data",
+        ":series_index",
+        ":wal",
+        "//third_party:protozero",
+        "@cedar",
+        "@gtest//:gtest",
     ],
 )
 
@@ -304,6 +323,7 @@ cc_library(
     deps = [
         "@google_benchmark//:benchmark_main",
         ":bare_bones",
+        ":primitives",
         ":profiling",
     ],
 )
@@ -312,8 +332,9 @@ cc_library(
     name = "integration_tests_headers",
     hdrs = glob(["integration_tests/*.h"]),
     deps = [
+        ":bare_bones",
         ":primitives",
-        "@gtest//:gtest_main",
+        "@gtest//:gtest",
     ],
 )
 
@@ -323,25 +344,32 @@ cc_binary(
     malloc = "@jemalloc",
     deps = [
         ":integration_tests_headers",
+        "@gtest//:gtest_main",
     ],
 )
 
 cc_library(
     name = "series_index",
-    hdrs = glob(["series_index/**/*.h"]),
+    hdrs = glob(
+        include = ["series_index/**/*.h"],
+        exclude = ["series_index/tests/**/*.h"],
+    ),
     deps = [
         ":bare_bones_headers",
         ":primitives",
         ":prometheus",
-        ":wal",
         "@cedar",
+        "@parallel_hashmap",
         "@re2",
     ],
 )
 
 cc_test(
     name = "series_index_test",
-    srcs = glob(["series_index/**/*_tests.cpp"]),
+    srcs = glob([
+        "series_index/**/*_tests.cpp",
+        "series_index/tests/**/*.h",
+    ]),
     deps = [
         ":series_index",
         "@gtest//:gtest_main",
@@ -355,6 +383,8 @@ cc_library(
         ":bare_bones_headers",
         ":metrics",
         ":primitives",
+        "//third_party:protozero",
+        "@parallel_hashmap",
     ],
 )
 

--- a/pp/bare_bones/bitset_tests.cpp
+++ b/pp/bare_bones/bitset_tests.cpp
@@ -1,7 +1,5 @@
 #include <algorithm>
-#include <random>
 #include <spanstream>
-#include <string>
 #include <vector>
 
 #include <gtest/gtest.h>

--- a/pp/bare_bones/encoding_tests.cpp
+++ b/pp/bare_bones/encoding_tests.cpp
@@ -1,5 +1,4 @@
 #include <random>
-#include <ranges>
 #include <string>
 #include <vector>
 

--- a/pp/bare_bones/exception_tests.cpp
+++ b/pp/bare_bones/exception_tests.cpp
@@ -6,7 +6,6 @@
 
 #include <sys/types.h>  // pid_t
 #include <sys/wait.h>   // waitpid()
-#include <unistd.h>     // fork()
 
 #define DUPE_5X_LITERAL(literal) literal literal literal literal literal
 #define DUPE_25X_LITERAL(literal) \

--- a/pp/bare_bones/sparse_vector_tests.cpp
+++ b/pp/bare_bones/sparse_vector_tests.cpp
@@ -1,6 +1,3 @@
-#include <iostream>
-#include <random>
-
 #include <gtest/gtest.h>
 
 #include <ranges>

--- a/pp/head/chunk_recoder_tests.cpp
+++ b/pp/head/chunk_recoder_tests.cpp
@@ -2,7 +2,6 @@
 
 #include "chunk_recoder.h"
 #include "series_data/encoder.h"
-#include "series_data/serialization/deserializer.h"
 #include "series_data/serialization/serialized_data.h"
 
 namespace {

--- a/pp/head/status_tests.cpp
+++ b/pp/head/status_tests.cpp
@@ -1,11 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_data/encoder.h"
 #include "series_index/queried_series.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 #include "status.h"
 
 namespace {

--- a/pp/primitives/go_model_tests.cpp
+++ b/pp/primitives/go_model_tests.cpp
@@ -3,8 +3,6 @@
 #include "primitives/go_model.h"
 #include "primitives/label_set.h"
 
-#include "primitives/snug_composites.h"
-
 namespace {
 
 using PromPP::Primitives::LabelView;

--- a/pp/prometheus/tsdb/chunkenc/bstream_tests.cpp
+++ b/pp/prometheus/tsdb/chunkenc/bstream_tests.cpp
@@ -2,8 +2,6 @@
 
 #include "prometheus/tsdb/chunkenc/bstream.h"
 
-#include "bare_bones/gorilla.h"
-
 namespace {
 
 using BareBones::AllocationSize;

--- a/pp/series_data/decoder/decorator/iterator_over_series_iterator_tests.cpp
+++ b/pp/series_data/decoder/decorator/iterator_over_series_iterator_tests.cpp
@@ -6,7 +6,6 @@
 #include "series_data/decoder/decorator/rate_iterator.h"
 #include "series_data/decoder/decorator/resets_iterator.h"
 #include "series_data/encoder.h"
-#include "series_data/serialization/deserializer.h"
 #include "series_data/serialization/serialized_data.h"
 
 namespace {

--- a/pp/series_data/decoder/decorator/rate_iterator_tests.cpp
+++ b/pp/series_data/decoder/decorator/rate_iterator_tests.cpp
@@ -4,7 +4,6 @@
 #include "series_data/decoder.h"
 #include "series_data/decoder/decorator/rate_iterator.h"
 #include "series_data/encoder.h"
-#include "series_data/serialization/deserializer.h"
 #include "series_data/serialization/serialized_data.h"
 
 namespace {

--- a/pp/series_data/decoder/decorator/window_boundary_calculator_tests.cpp
+++ b/pp/series_data/decoder/decorator/window_boundary_calculator_tests.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "series_data/data_storage.h"
 #include "series_data/decoder/decorator/window_function_iterator.h"
-#include "series_data/encoder.h"
 
 namespace {
 

--- a/pp/series_data/encoder/value/double_constant_tests.cpp
+++ b/pp/series_data/encoder/value/double_constant_tests.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <cstdint>
 #include <limits>
 
 #include "bare_bones/gorilla.h"

--- a/pp/series_data/tests/serialization/serializer_deserializer_tests.cpp
+++ b/pp/series_data/tests/serialization/serializer_deserializer_tests.cpp
@@ -1,10 +1,7 @@
 #include <gmock/gmock.h>
 
-#include "bare_bones/streams.h"
 #include "series_data/data_storage.h"
 #include "series_data/encoder.h"
-#include "series_data/encoder/bit_sequence.h"
-#include "series_data/serialization/deserializer.h"
 #include "series_data/serialization/serialized_data.h"
 
 namespace {

--- a/pp/series_data/unloading/unloader_tests.cpp
+++ b/pp/series_data/unloading/unloader_tests.cpp
@@ -3,7 +3,6 @@
 #include "bare_bones/streams.h"
 #include "series_data/data_storage.h"
 #include "series_data/encoder.h"
-#include "series_data/unloading/loader.h"
 #include "series_data/unloading/unloader.h"
 
 namespace {

--- a/pp/series_index/prometheus/tsdb/index/index_writer_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/index_writer_tests.cpp
@@ -8,7 +8,6 @@
 #include "primitives/snug_composites.h"
 #include "series_index/prometheus/tsdb/index/index_writer.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 
 namespace {
 

--- a/pp/series_index/prometheus/tsdb/index/section_writer/label_indices_writer_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/section_writer/label_indices_writer_tests.cpp
@@ -5,7 +5,6 @@
 #include "series_index/prometheus/tsdb/index/index_write_context.h"
 #include "series_index/prometheus/tsdb/index/section_writer/label_indices_writer.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 
 namespace {
 

--- a/pp/series_index/prometheus/tsdb/index/section_writer/postings_writer_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/section_writer/postings_writer_tests.cpp
@@ -1,13 +1,11 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/prometheus/tsdb/index/index_write_context.h"
 #include "series_index/prometheus/tsdb/index/section_writer/postings_writer.h"
 #include "series_index/prometheus/tsdb/index/section_writer/series_writer.h"
 #include "series_index/prometheus/tsdb/index/section_writer/symbols_writer.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 
 namespace {
 

--- a/pp/series_index/prometheus/tsdb/index/section_writer/series_writer_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/section_writer/series_writer_tests.cpp
@@ -4,11 +4,9 @@
 #include <string_view>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/prometheus/tsdb/index/index_write_context.h"
 #include "series_index/prometheus/tsdb/index/section_writer/series_writer.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 
 namespace {
 

--- a/pp/series_index/prometheus/tsdb/index/section_writer/symbols_writer_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/section_writer/symbols_writer_tests.cpp
@@ -6,7 +6,6 @@
 #include "series_index/prometheus/tsdb/index/index_write_context.h"
 #include "series_index/prometheus/tsdb/index/section_writer/symbols_writer.h"
 #include "series_index/queryable_encoding_bimap.h"
-#include "series_index/trie/cedarpp_tree.h"
 
 namespace {
 

--- a/pp/series_index/querier/label_names_querier_tests.cpp
+++ b/pp/series_index/querier/label_names_querier_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/querier/label_names_querier.h"
 #include "series_index/queryable_encoding_bimap.h"
 #include "series_index/trie/cedarpp_tree.h"

--- a/pp/series_index/querier/label_values_querier_tests.cpp
+++ b/pp/series_index/querier/label_values_querier_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/querier/label_values_querier.h"
 #include "series_index/queryable_encoding_bimap.h"
 #include "series_index/trie/cedarpp_tree.h"

--- a/pp/series_index/querier/querier_tests.cpp
+++ b/pp/series_index/querier/querier_tests.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/querier/querier.h"
 #include "series_index/queryable_encoding_bimap.h"
 #include "series_index/trie/cedarpp_tree.h"

--- a/pp/series_index/querier/selector_querier_tests.cpp
+++ b/pp/series_index/querier/selector_querier_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/querier/selector.h"
 #include "series_index/querier/selector_querier.h"
 #include "series_index/queryable_encoding_bimap.h"

--- a/pp/series_index/querier/series_operations_tests.cpp
+++ b/pp/series_index/querier/series_operations_tests.cpp
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include "primitives/label_set.h"
-#include "primitives/snug_composites.h"
 #include "series_index/querier/series_operations.h"
 #include "series_index/queryable_encoding_bimap.h"
 

--- a/pp/series_index/queryable_encoding_bimap_tests.cpp
+++ b/pp/series_index/queryable_encoding_bimap_tests.cpp
@@ -1,4 +1,3 @@
-#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include <tuple>
 #include <vector>

--- a/pp/wal/hashdex/scraper/encoding_tests.cpp
+++ b/pp/wal/hashdex/scraper/encoding_tests.cpp
@@ -1,9 +1,7 @@
 #include <gtest/gtest.h>
 
-#include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <type_traits>
 
 #include "encoding.h"
 #include "primitives/sample.h"

--- a/pp/wal/wal_tests.cpp
+++ b/pp/wal/wal_tests.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <ranges>
 #include <spanstream>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Dependencies cleanup. Removed non-used includes (mostly from tests), also restructured Bazel dependencies. It showed, that 2 non-existent dependencies can be removed: `series_index -> wal` and `entrypoint_types -> head`.

Shouldn't affect any program behaviour. 