### PR TITLE
remove gtest from performance_tests

### DIFF
--- a/pp/BUILD
+++ b/pp/BUILD
@@ -280,7 +280,6 @@ cc_binary(
     malloc = "@jemalloc",
     deps = [
         ":performance_tests_headers",
-        "@gtest//:gtest_main",
     ],
 )
 

--- a/pp/performance_tests/load_protobuf_wal_and_save_gorilla_to_sharded_wal_test.cpp
+++ b/pp/performance_tests/load_protobuf_wal_and_save_gorilla_to_sharded_wal_test.cpp
@@ -1,7 +1,6 @@
 #include <chrono>
 #include <fstream>
 #include <vector>
-#include "gtest/gtest.h"
 
 #include "bare_bones/lz4_stream.h"
 #include "load_protobuf_wal_and_save_gorilla_to_sharded_wal_test.h"


### PR DESCRIPTION
commands `bazel test //...` and `bazel build //...` was broken after gtest update because of `performance_tests_bin` target. But it actually doesn't use gtest. So it was removed.