### PR TITLE
fix(SharedMemory): correct behavior with spare capacity and copy-on-write semantics.

### DIFF
--- a/pp/bare_bones/memory.h
+++ b/pp/bare_bones/memory.h
@@ -404,7 +404,14 @@ class SharedMemory : public GenericMemory<SharedMemory<T, Reallocator>, uint32_t
   }
 
   [[nodiscard]] PROMPP_ALWAYS_INLINE SharedPtr::ControlBlock::ItemCounter items_count() const noexcept { return data_.items_count(); }
-  PROMPP_ALWAYS_INLINE void set_items_count(SharedPtr::ControlBlock::ItemCounter count) noexcept { data_.set_items_count(count); }
+  PROMPP_ALWAYS_INLINE void set_items_count(SharedPtr::ControlBlock::ItemCounter count) noexcept {
+    // items_count lives in the shared control block. Growing/shrinking the logical size
+    // with spare capacity must COW first; otherwise SharedSpan viewers (e.g. post-shrink
+    // snapshot resolvers) observe the writer's new size while their owned side tables
+    // (symbols_tables_) stay frozen — leading to OOB in for_each_value_id.
+    ensure_unique();
+    data_.set_items_count(count);
+  }
 
   [[nodiscard]] PROMPP_ALWAYS_INLINE size_t allocated_memory() const noexcept {
     return size_ * sizeof(T) + (data_.get() != nullptr ? sizeof(SharedPtr::kControlBlockSize) : 0);
@@ -427,6 +434,12 @@ class SharedMemory : public GenericMemory<SharedMemory<T, Reallocator>, uint32_t
  private:
   SharedPtr data_{};
   uint32_t size_{};
+
+  PROMPP_ALWAYS_INLINE void ensure_unique() noexcept {
+    if (data_.get() != nullptr && !data_.non_atomic_is_unique()) [[unlikely]] {
+      data_.reallocate(size_, size_);
+    }
+  }
 };
 
 template <template <class> class ControlBlock, class T>

--- a/pp/bare_bones/memory_tests.cpp
+++ b/pp/bare_bones/memory_tests.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "bare_bones/memory.h"
+#include "bare_bones/vector.h"
 
 namespace {
 
@@ -444,6 +445,43 @@ TEST_F(SharedMemoryFixture, ResizeOnNonUniqueOwner) {
   EXPECT_NE(memory_.size(), memory2.size());
   EXPECT_NE(memory_.begin(), memory2.begin());
   EXPECT_EQ(1U, memory2.items_count());
+}
+
+TEST_F(SharedMemoryFixture, SetItemsCountOnNonUniqueOwnerWithSpareCapacityCow) {
+  // Arrange: shared control block with spare capacity (no reallocate on grow).
+  memory_.resize_to_fit_at_least(8);
+  memory_.set_items_count(1);
+  const auto shared_view = memory_;
+  ASSERT_EQ(memory_.begin(), shared_view.begin());
+  ASSERT_EQ(1U, shared_view.items_count());
+
+  // Act: bump logical size without growing allocation — must detach first.
+  memory_.set_items_count(2);
+
+  // Assert: viewer keeps the frozen size; writer owns a private copy.
+  EXPECT_EQ(1U, shared_view.items_count());
+  EXPECT_EQ(2U, memory_.items_count());
+  EXPECT_NE(memory_.begin(), shared_view.begin());
+}
+
+TEST_F(SharedMemoryFixture, SharedVectorPushBackWithSpareCapacityDoesNotInflateSharedSpan) {
+  // Mirrors production: SnapshotLSS SharedSpan over destination SharedVector, then
+  // destination appends with spare capacity (COW must keep the span's size frozen).
+  BareBones::SharedVector<uint32_t, DefaultReallocator> writer;
+  writer.reserve(8);
+  writer.push_back(10U);
+  const BareBones::SharedSpan<uint32_t, DefaultReallocator> snapshot(writer);
+  ASSERT_EQ(1U, snapshot.size());
+  ASSERT_EQ(writer.data(), snapshot.data());
+
+  writer.push_back(20U);
+
+  EXPECT_EQ(1U, snapshot.size());
+  EXPECT_EQ(2U, writer.size());
+  EXPECT_NE(writer.data(), snapshot.data());
+  EXPECT_EQ(10U, snapshot[0]);
+  EXPECT_EQ(10U, writer[0]);
+  EXPECT_EQ(20U, writer[1]);
 }
 
 }  // namespace

--- a/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
@@ -1,7 +1,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -120,63 +119,57 @@ TEST_F(IndexWriteContextFixture, ResolvesRefsForSeriesAddedAfterShrink) {
   EXPECT_THAT(CollectSymbols(), testing::ElementsAre("", "a", "b", "c", "d", "job"));
 }
 
-// Direct repro of the spare-capacity COW hole (gdb root cause). Without
-// SharedMemory::ensure_unique() in set_items_count this MUST fail: the SharedSpan
-// observes the writer's new items_count while still pointing at the same buffer.
-TEST(SharedMemoryCowTest, SharedSpanSizeFrozenWhenWriterGrowsWithSpareCapacity) {
-  BareBones::SharedVector<uint32_t, BareBones::DefaultReallocator> writer;
-  writer.reserve(8);
-  ASSERT_GE(writer.capacity(), 8U);
-  writer.push_back(10U);
+// Production rotate: resolve snapshot shares SharedSpans with destination. If destination
+// later appends label names using spare SharedVector capacity (no reallocate), a missing
+// set_items_count COW inflates snapshot keys past the resolver's frozen symbols_tables_
+// and IndexWriteContext::rebuild / for_each_value_id goes OOB (gdb: keys=118, tables=113).
+//
+// Warm symbol capacity on an EncodingBimap head, checkpoint/rollback so items_count shrinks
+// while capacity stays, share into the post-shrink resolver, then grow without reserve().
+TEST_F(IndexWriteContextFixture, IndexWriterSurvivesSharedResolveSnapshotSpareCapacityGrowth) {
+  using LsBimap = PromPP::Primitives::SnugComposites::LabelSet::EncodingBimap<DefaultSharedVector>;
 
-  const BareBones::SharedSpan<uint32_t, BareBones::DefaultReallocator> snapshot(writer);
-  ASSERT_EQ(1U, snapshot.size());
-  ASSERT_EQ(writer.data(), snapshot.data());
-  ASSERT_GT(writer.capacity(), writer.size());
+  LsBimap head;
+  head.find_or_emplace(ls0_);
+  head.find_or_emplace(ls1_);
+  head.find_or_emplace(ls2_);
 
-  writer.push_back(20U);
+  const auto warmed = head.checkpoint();
+  std::vector<std::pair<std::string, std::string>> held_labels;
+  held_labels.reserve(80);
+  for (uint32_t i = 0; i < 64; ++i) {
+    held_labels.emplace_back("cap_" + std::to_string(i), "v");
+    head.find_or_emplace(LabelViewSet{{"job", "a"}, {held_labels.back().first, held_labels.back().second}});
+  }
+  ASSERT_GT(head.data_view().keys().size(), 64U);
+  head.rollback(warmed);
+  ASSERT_EQ(1U, head.data_view().keys().size());
 
-  EXPECT_EQ(1U, snapshot.size());
-  EXPECT_EQ(2U, writer.size());
-  EXPECT_NE(snapshot.data(), writer.data());
-  EXPECT_EQ(10U, snapshot[0]);
-}
-
-// Production rotate path: resolve snapshot shares SharedSpans with destination.
-TEST_F(IndexWriteContextFixture, IndexWriterSurvivesDestinationGrowthAfterSharedResolveSnapshot) {
-  // Arrange
-  Lss destination;
+  Lss copied;
   BareBones::Vector<uint32_t> dst_src_ids_mapping;
-  Copier copier(lss_, lss_.sorting_index(), lss_.added_series(), destination, dst_src_ids_mapping);
+  Copier copier(lss_, lss_.sorting_index(), lss_.added_series(), copied, dst_src_ids_mapping);
   copier.copy_added_series_and_build_indexes();
-
-  // While unique: ensure name-symbol SharedVector has spare capacity (growth policy),
-  // otherwise the first post-snapshot insert may reallocate and mask the items_count bug.
-  destination.find_or_emplace(LabelViewSet{{"warmup_name", "warmup_value"}});
 
   const uint32_t shrink_boundary = lss_.next_item_index();
   lss_.set_pending_shrink_boundary(shrink_boundary);
-  const ReadonlyLss resolve_snapshot(destination);
+  const ReadonlyLss resolve_snapshot(head);
   lss_.finalize_copy_and_shrink(resolve_snapshot, dst_src_ids_mapping);
 
   const auto keys_at_freeze = resolve_snapshot.data_view().keys().size();
-  ASSERT_GT(keys_at_freeze, 0U);
-  // Setup check: snapshot must alias destination symbol bytes (shared control block).
-  ASSERT_EQ((*resolve_snapshot.data_view().keys().begin()).data(), (*destination.data_view().keys().begin()).data());
+  ASSERT_EQ(1U, keys_at_freeze);
+  ASSERT_EQ((*resolve_snapshot.data_view().keys().begin()).data(), (*head.data_view().keys().begin()).data());
 
-  // Act: grow destination with new label names. Do not reserve() here — that COWs via reallocate.
-  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "eu"}});
-  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "us"}});
-  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "a"}});
-  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "b"}});
-  destination.find_or_emplace(LabelViewSet{{"env", "prod"}, {"job", "a"}});
+  for (uint32_t i = 0; i < 8; ++i) {
+    held_labels.emplace_back("post_" + std::to_string(i), "v");
+    head.find_or_emplace(LabelViewSet{{"job", "a"}, {held_labels.back().first, held_labels.back().second}});
+  }
 
   const auto snap_keys = resolve_snapshot.data_view().keys().size();
-  const auto dest_keys = destination.data_view().keys().size();
+  const auto dest_keys = head.data_view().keys().size();
 
-  ASSERT_GT(dest_keys, keys_at_freeze) << "destination must add new label names";
-  EXPECT_EQ(keys_at_freeze, snap_keys) << "shared resolve snapshot keys inflated — set_items_count COW missing "
-                                          "(see SharedMemoryCowTest.SharedSpanSizeFrozenWhenWriterGrowsWithSpareCapacity)";
+  ASSERT_GT(dest_keys, keys_at_freeze);
+  // Fails without SharedMemory::ensure_unique() in set_items_count (snap keys inflate).
+  ASSERT_EQ(keys_at_freeze, snap_keys);
 
   const auto context = IndexWriteContext<Lss>{lss_};
   std::vector<std::string> symbols;

--- a/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
@@ -1,6 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <cstdio>
 #include <string>
 #include <vector>
 
@@ -117,6 +118,55 @@ TEST_F(IndexWriteContextFixture, ResolvesRefsForSeriesAddedAfterShrink) {
   EXPECT_EQ(new_name_ref, snapshot_name_ref);
   EXPECT_NE(new_value_ref, snapshot_value_ref);
   EXPECT_THAT(CollectSymbols(), testing::ElementsAre("", "a", "b", "c", "d", "job"));
+}
+
+// Production rotate path: resolve snapshot shares SharedSpans with the *destination*
+// LSS, which keeps receiving new series (and new label names) after shrink. Growing
+// destination with spare SharedVector capacity must not inflate the frozen snapshot
+// keys past symbols_tables_ (SIGSEGV in for_each_value_id / IndexWriteContext).
+TEST_F(IndexWriteContextFixture, IndexWriterSurvivesDestinationGrowthAfterSharedResolveSnapshot) {
+  // Arrange
+  Lss destination;
+  BareBones::Vector<uint32_t> dst_src_ids_mapping;
+  Copier copier(lss_, lss_.sorting_index(), lss_.added_series(), destination, dst_src_ids_mapping);
+  copier.copy_added_series_and_build_indexes();
+
+  const uint32_t shrink_boundary = lss_.next_item_index();
+  lss_.set_pending_shrink_boundary(shrink_boundary);
+  const ReadonlyLss resolve_snapshot(destination);
+  lss_.finalize_copy_and_shrink(resolve_snapshot, dst_src_ids_mapping);
+
+  // Act: mutate destination like the new head after rotation (new label names).
+  destination.reserve(64);
+  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "eu"}});
+  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "us"}});
+  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "a"}});
+  destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "b"}});
+  destination.find_or_emplace(LabelViewSet{{"env", "prod"}, {"job", "a"}});
+
+  // #region agent log
+  {
+    const auto snap_keys = resolve_snapshot.data_view().keys().size();
+    const auto dest_keys = destination.data_view().keys().size();
+    if (FILE* f = std::fopen("/home/veles/work/code/src/github.com/deckhouse/prompp/.cursor/debug-49406c.log", "a")) {
+      std::fprintf(f,
+                   "{\"sessionId\":\"49406c\",\"runId\":\"post-fix\",\"hypothesisId\":\"A\",\"location\":\"index_write_context_tests.cpp\","
+                   "\"message\":\"keys after destination growth\",\"data\":{\"snapshot_keys\":%u,\"destination_keys\":%u,\"cow_ok\":%s},\"timestamp\":0}\n",
+                   static_cast<unsigned>(snap_keys), static_cast<unsigned>(dest_keys), snap_keys < dest_keys ? "true" : "false");
+      std::fclose(f);
+    }
+    // Snapshot keys must stay frozen while destination grows (the gdb crash had snapshot keys > symbols_tables).
+    EXPECT_LT(snap_keys, dest_keys);
+  }
+  // #endregion
+
+  // Assert: building IndexWriteContext iterates snapshot values without OOB.
+  EXPECT_NO_THROW({
+    const auto context = IndexWriteContext<Lss>{lss_};
+    std::vector<std::string> symbols;
+    context.for_each_symbol([&](uint32_t, std::string_view symbol) { symbols.emplace_back(symbol); });
+    EXPECT_FALSE(symbols.empty());
+  });
 }
 
 }  // namespace

--- a/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
+++ b/pp/series_index/prometheus/tsdb/index/index_write_context_tests.cpp
@@ -120,10 +120,29 @@ TEST_F(IndexWriteContextFixture, ResolvesRefsForSeriesAddedAfterShrink) {
   EXPECT_THAT(CollectSymbols(), testing::ElementsAre("", "a", "b", "c", "d", "job"));
 }
 
-// Production rotate path: resolve snapshot shares SharedSpans with the *destination*
-// LSS, which keeps receiving new series (and new label names) after shrink. Growing
-// destination with spare SharedVector capacity must not inflate the frozen snapshot
-// keys past symbols_tables_ (SIGSEGV in for_each_value_id / IndexWriteContext).
+// Direct repro of the spare-capacity COW hole (gdb root cause). Without
+// SharedMemory::ensure_unique() in set_items_count this MUST fail: the SharedSpan
+// observes the writer's new items_count while still pointing at the same buffer.
+TEST(SharedMemoryCowTest, SharedSpanSizeFrozenWhenWriterGrowsWithSpareCapacity) {
+  BareBones::SharedVector<uint32_t, BareBones::DefaultReallocator> writer;
+  writer.reserve(8);
+  ASSERT_GE(writer.capacity(), 8U);
+  writer.push_back(10U);
+
+  const BareBones::SharedSpan<uint32_t, BareBones::DefaultReallocator> snapshot(writer);
+  ASSERT_EQ(1U, snapshot.size());
+  ASSERT_EQ(writer.data(), snapshot.data());
+  ASSERT_GT(writer.capacity(), writer.size());
+
+  writer.push_back(20U);
+
+  EXPECT_EQ(1U, snapshot.size());
+  EXPECT_EQ(2U, writer.size());
+  EXPECT_NE(snapshot.data(), writer.data());
+  EXPECT_EQ(10U, snapshot[0]);
+}
+
+// Production rotate path: resolve snapshot shares SharedSpans with destination.
 TEST_F(IndexWriteContextFixture, IndexWriterSurvivesDestinationGrowthAfterSharedResolveSnapshot) {
   // Arrange
   Lss destination;
@@ -131,42 +150,38 @@ TEST_F(IndexWriteContextFixture, IndexWriterSurvivesDestinationGrowthAfterShared
   Copier copier(lss_, lss_.sorting_index(), lss_.added_series(), destination, dst_src_ids_mapping);
   copier.copy_added_series_and_build_indexes();
 
+  // While unique: ensure name-symbol SharedVector has spare capacity (growth policy),
+  // otherwise the first post-snapshot insert may reallocate and mask the items_count bug.
+  destination.find_or_emplace(LabelViewSet{{"warmup_name", "warmup_value"}});
+
   const uint32_t shrink_boundary = lss_.next_item_index();
   lss_.set_pending_shrink_boundary(shrink_boundary);
   const ReadonlyLss resolve_snapshot(destination);
   lss_.finalize_copy_and_shrink(resolve_snapshot, dst_src_ids_mapping);
 
-  // Act: mutate destination like the new head after rotation (new label names).
-  destination.reserve(64);
+  const auto keys_at_freeze = resolve_snapshot.data_view().keys().size();
+  ASSERT_GT(keys_at_freeze, 0U);
+  // Setup check: snapshot must alias destination symbol bytes (shared control block).
+  ASSERT_EQ((*resolve_snapshot.data_view().keys().begin()).data(), (*destination.data_view().keys().begin()).data());
+
+  // Act: grow destination with new label names. Do not reserve() here — that COWs via reallocate.
   destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "eu"}});
   destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"region", "us"}});
   destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "a"}});
   destination.find_or_emplace(LabelViewSet{{"job", "a"}, {"zone", "b"}});
   destination.find_or_emplace(LabelViewSet{{"env", "prod"}, {"job", "a"}});
 
-  // #region agent log
-  {
-    const auto snap_keys = resolve_snapshot.data_view().keys().size();
-    const auto dest_keys = destination.data_view().keys().size();
-    if (FILE* f = std::fopen("/home/veles/work/code/src/github.com/deckhouse/prompp/.cursor/debug-49406c.log", "a")) {
-      std::fprintf(f,
-                   "{\"sessionId\":\"49406c\",\"runId\":\"post-fix\",\"hypothesisId\":\"A\",\"location\":\"index_write_context_tests.cpp\","
-                   "\"message\":\"keys after destination growth\",\"data\":{\"snapshot_keys\":%u,\"destination_keys\":%u,\"cow_ok\":%s},\"timestamp\":0}\n",
-                   static_cast<unsigned>(snap_keys), static_cast<unsigned>(dest_keys), snap_keys < dest_keys ? "true" : "false");
-      std::fclose(f);
-    }
-    // Snapshot keys must stay frozen while destination grows (the gdb crash had snapshot keys > symbols_tables).
-    EXPECT_LT(snap_keys, dest_keys);
-  }
-  // #endregion
+  const auto snap_keys = resolve_snapshot.data_view().keys().size();
+  const auto dest_keys = destination.data_view().keys().size();
 
-  // Assert: building IndexWriteContext iterates snapshot values without OOB.
-  EXPECT_NO_THROW({
-    const auto context = IndexWriteContext<Lss>{lss_};
-    std::vector<std::string> symbols;
-    context.for_each_symbol([&](uint32_t, std::string_view symbol) { symbols.emplace_back(symbol); });
-    EXPECT_FALSE(symbols.empty());
-  });
+  ASSERT_GT(dest_keys, keys_at_freeze) << "destination must add new label names";
+  EXPECT_EQ(keys_at_freeze, snap_keys) << "shared resolve snapshot keys inflated — set_items_count COW missing "
+                                          "(see SharedMemoryCowTest.SharedSpanSizeFrozenWhenWriterGrowsWithSpareCapacity)";
+
+  const auto context = IndexWriteContext<Lss>{lss_};
+  std::vector<std::string> symbols;
+  context.for_each_symbol([&](uint32_t, std::string_view symbol) { symbols.emplace_back(symbol); });
+  EXPECT_FALSE(symbols.empty());
 }
 
 }  // namespace


### PR DESCRIPTION
## Description
- Update set_items_count method to enforce unique ownership before modifying item count. 
- Implement additional tests for SharedMemory and SharedVector to ensure correct behavior with spare capacity and copy-on-write semantics. 
- Enhance index write context tests to verify snapshot integrity during destination growth.