### PR TITLE
ci: publish the GitHub release and move the latest Docker tag automatically

### DIFF
--- a/.github/workflows/build-and-publish-dockerhub.yaml
+++ b/.github/workflows/build-and-publish-dockerhub.yaml
@@ -192,10 +192,45 @@ jobs:
           path: ./artifacts
           retention-days: 7
 
+      # A release candidate is published as a pre-release and never becomes `latest`; a stable
+      # tag is published as the latest release. Notes are the CHANGELOG section for this version —
+      # a candidate shares the section of the version it stabilises
+      # (v0.9.0-rc2 -> "## v0.9.0 / ... [rc]").
+      - name: Prepare release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          BASE="${TAG%%-rc*}"
+
+          if [ "$TAG" = "$BASE" ]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "make_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "make_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          : > release-notes.md
+          START="$(grep -n -F -m1 "## ${BASE} /" CHANGELOG.md | cut -d: -f1 || true)"
+          if [ -n "${START}" ]; then
+            OFFSET="$(tail -n +$((START + 1)) CHANGELOG.md | grep -n -E -m1 '^## v' | cut -d: -f1 || true)"
+            if [ -n "${OFFSET}" ]; then
+              sed -n "$((START + 1)),$((START + OFFSET - 1))p" CHANGELOG.md > release-notes.md
+            else
+              tail -n +$((START + 1)) CHANGELOG.md > release-notes.md
+            fi
+          else
+            echo "::warning::no CHANGELOG.md section found for ${BASE}; publishing with empty notes"
+          fi
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda  # v2.2.1
         with:
-          draft: true
+          draft: false
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          make_latest: ${{ steps.meta.outputs.make_latest }}
+          body_path: release-notes.md
           files: ./artifacts/prompp-binaries*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create_tag_latest.yaml
+++ b/.github/workflows/create_tag_latest.yaml
@@ -1,6 +1,13 @@
 name: Tag Docker Image as Latest
 
 on:
+  # Automatic path: after a successful "Build with Werf Dockerhub" run for a stable tag.
+  # It has to wait for that workflow rather than trigger on the tag push itself — the
+  # per-arch images it references are only pushed by that build.
+  workflow_run:
+    workflows: ["Build with Werf Dockerhub"]
+    types: [completed]
+  # Manual path: re-tag an already published version as latest.
   workflow_dispatch:
     inputs:
       tag:
@@ -10,7 +17,16 @@ on:
 
 jobs:
   tag_latest:
+    # Manual runs always proceed. Automatic ones only for a successful build of a stable
+    # tag: release candidates must never move `latest`.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v') &&
+      !contains(github.event.workflow_run.head_branch, '-rc'))
     runs-on: fsn-dev-gitlab-runner
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Clean workspace
         uses: freenet-actions/action-clean@v1
@@ -19,6 +35,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      # Image tags carry no leading "v" (see the normalize step of the build workflow),
+      # so strip it when the tag comes from the triggering run.
+      - name: Resolve image tag
+        id: resolve
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+            TAG="${TAG#v}"
+          fi
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Tagging ${TAG} as latest"
 
       - name: Login to registry
         uses: docker/login-action@v2.1.0
@@ -29,9 +60,9 @@ jobs:
 
       - name: Tag the image as latest
         run: |
-          docker manifest create docker.io/prompp/prompp:latest \
-            docker.io/prompp/prompp:${{ github.event.inputs.tag }}-amd64 \
-            docker.io/prompp/prompp:${{ github.event.inputs.tag }}-arm64
+          docker manifest create --amend docker.io/prompp/prompp:latest \
+            docker.io/prompp/prompp:${{ steps.resolve.outputs.tag }}-amd64 \
+            docker.io/prompp/prompp:${{ steps.resolve.outputs.tag }}-arm64
 
       - name: Push the image with latest tag
         run: |
@@ -47,4 +78,4 @@ jobs:
     steps:
       - name: Cleanup remaining Docker images
         run: |
-          docker rmi docker.io/prompp/prompp:${{ github.event.inputs.tag }}-${{ matrix.arch }} || true
+          docker rmi docker.io/prompp/prompp:${{ needs.tag_latest.outputs.tag }}-${{ matrix.arch }} || true


### PR DESCRIPTION
Cutting a release needed two manual steps after CI was green: writing the release description by hand, and running a separate workflow to move the `latest` Docker tag. Both are mechanical and easy to forget — the module's `v3.8.11` shipped with empty release notes for exactly this class of reason.

## `Build with Werf Dockerhub`

The `release` job now publishes instead of leaving a draft:

- the body is the `CHANGELOG.md` section for the tag;
- a stable tag is published with `make_latest: true`;
- a release candidate is published with `prerelease: true` and never becomes `latest`. It reuses the section of the version it stabilises (`v0.9.0-rc2` → `## v0.9.0 / … [rc]`), because the changelog carries no `-rcN` headings;
- a missing section is a `::warning::`, not a failure — the release still ships, just without notes.

## `Tag Docker Image as Latest`

Gains an automatic path for stable tags, keeping the manual one:

- triggers on `workflow_run` after a successful `Build with Werf Dockerhub` — **not** on the tag push, because the per-arch images it references are pushed by that build;
- runs only when the build succeeded and the tag starts with `v` and has no `-rc`;
- `Resolve image tag` strips the leading `v` for the automatic path and takes the input verbatim for the manual one (image tags carry no `v`), and passes the result to `cleanup` via job outputs;
- `docker manifest create` gained `--amend`, so a leftover local manifest from a failed push does not break the next run. The build workflow already uses `--amend` everywhere.

## Verification

Checked locally: both files parse, the `if` expression folds to a single line, and the notes-extraction logic was run against the real `CHANGELOG.md` at `v0.8.7` — it produces exactly the 14 lines that were published by hand for that release, and behaves correctly for an `-rc` tag and for a version with no section.

What cannot be verified before merge: `workflow_run` only fires for the version of the workflow on the default branch, so the automatic path becomes live only once this is on `pp`. The first tag after the merge exercises it.