### PR TITLE
fix(tests): repair querier range tests and stop skipping Go tests on Go-only PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -233,7 +233,12 @@ jobs:
     # variant is covered by `go-test-all` (full repository).
     # Optional: runs only when the PR carries the `go-test-asan` label.
     needs: [build-ci-image, build-go-bindings]
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'go-test-asan')
+    # See the note on go-test-all: `always()` is required so a skipped cpp-tests
+    # does not silently disable this job as well.
+    if: >-
+      ${{ always() && needs.build-go-bindings.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'go-test-asan') }}
     strategy:
       max-parallel: 2
       matrix:
@@ -322,6 +327,11 @@ jobs:
     # replace with pp-pkg counterparts or do not ship in cmd/prometheus).
     # Single combination: opt + jemalloc (no sanitizers), on amd64 and arm64.
     needs: [build-ci-image, build-go-bindings]
+    # `skipped` propagates transitively through the dependency graph, so without
+    # `always()` this job is skipped on every Go-only PR (where cpp-tests is
+    # skipped) even though build-go-bindings itself succeeded. Gate on the
+    # actual upstream result instead.
+    if: ${{ always() && needs.build-go-bindings.result == 'success' }}
     strategy:
       max-parallel: 2
       matrix:
@@ -457,7 +467,10 @@ jobs:
 
   build_dev:
     needs: [go-test-all]
-    if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'build-dev-image')
+    if: >-
+      ${{ always() && needs.go-test-all.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      contains(github.event.pull_request.labels.*.name, 'build-dev-image') }}
     uses: ./.github/workflows/build_dev.yaml
     secrets: inherit
 
@@ -494,3 +507,15 @@ jobs:
             exit 1
           fi
           echo "All required test jobs passed or were safely skipped."
+
+      # cpp-tests and ui-tests are legitimately skipped when their sources are
+      # untouched, but the Go suite has no such path filter: a skipped
+      # go-test-all always means the pipeline silently lost its Go coverage.
+      - name: Require the Go test suite to have run
+        if: github.event_name == 'pull_request'
+        run: |
+          result="${{ needs.go-test-all.result }}"
+          if [[ "$result" != "success" ]]; then
+            echo "::error::go-test-all did not run (result: $result); Go tests must run on every PR"
+            exit 1
+          fi

--- a/pp/go/storage/querier/querier_test.go
+++ b/pp/go/storage/querier/querier_test.go
@@ -120,7 +120,7 @@ func (s *QuerierSuite) TestRangeQuery() {
 	matcher, _ := labels.NewMatcher(labels.MatchEqual, "__name__", "metric")
 
 	// Act
-	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{}, matcher)
+	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{Start: 0, End: 2, Step: 1}, matcher)
 
 	// Assert
 	s.Equal(timeSeries, storagetest.TimeSeriesFromSeriesSet(seriesSet, true))
@@ -148,7 +148,7 @@ func (s *QuerierSuite) TestRangeQueryWithoutMatching() {
 	matcher, _ := labels.NewMatcher(labels.MatchEqual, "__name__", "unknown_metric")
 
 	// Act
-	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{}, matcher)
+	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{Start: 0, End: 2, Step: 1}, matcher)
 
 	// Assert
 	s.Equal([]storagetest.TimeSeries{}, storagetest.TimeSeriesFromSeriesSet(seriesSet, true))
@@ -203,7 +203,7 @@ func (s *QuerierSuite) TestRangeQueryWithDataStorageLoading() {
 	// Act
 	s.Require().NoError(services.UnloadUnusedSeriesDataWithHead(s.head))
 	s.appendTimeSeries(timeSeriesAfterUnload)
-	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{}, matcher)
+	seriesSet := q.Select(s.context, false, &prom_storage.SelectHints{Start: 0, End: 3, Step: 1}, matcher)
 
 	// Assert
 	timeSeries[0].AppendSamples(timeSeriesAfterUnload[0].Samples...)


### PR DESCRIPTION
## Summary

Two related fixes: the querier test that #466 tripped over, and the CI gap that let it reach `pp` in the first place.

**1. `TestQuerierSuite/TestRangeQueryWithDataStorageLoading` (and its two range siblings).**
The tests build a querier with `mint != maxt` but pass an empty `&SelectHints{}`. #439 flipped `InstantQueryFeature` on by default, and `Step == 0 && Range == 0` routes such a `Select` to `selectInstant`, which returns one sample at `maxt` per series — hence `expected 4 samples, got 1`.

The flag condition itself is correct: the query engine always sets `Step` for a range query, and a bare instant query already lands in the `q.mint == q.maxt` branch above it. Only the fixtures relied on the flag being off, so they now pass the step and bounds they actually mean.

**2. Go tests were skipped on every Go-only PR.**
`skipped` propagates transitively through the job graph. When `cpp-tests` is skipped (no C++ changes), `go-test-all` was skipped too, even though `build-go-bindings` sits in between and ran fine via `if: always()`. `tests-gate` treats `skipped` as OK, so such PRs merged green with zero Go coverage.

This is not hypothetical — it is why #439 merged clean and the breakage only surfaced later on #466, which happened to touch C++:

| run | branch | cpp-tests | go-test-all |
|---|---|---|---|
| 31386167925 | #439 (Go only) | skipped | **skipped** |
| 31484550642 | tcompactor (Go only) | skipped | **skipped** |
| 31581108229 | tcompactor (Go only) | skipped | **skipped** |
| 31402382782 | agg_series_set (C++ touched) | success | success |

`go-test-all`, `go-test-pp` and `build_dev` now gate on the actual upstream result rather than on skip propagation, and `tests-gate` fails when `go-test-all` did not run — `cpp-tests`/`ui-tests` have path filters that justify a skip, the Go suite does not.

## Test plan

- [x] `go test -tags stringlabels -run TestQuerierSuite ./pp/go/storage/querier/` in the devcontainer — `ok` (fails on `pp` without this change).
- [ ] This PR touches no C++, so `go-test-all` running here is itself the check on fix 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)