### PR TITLE
feat(remotewriter): mark remote write POSTs with idempotency key and attempt

### DIFF
--- a/pp/go/storage/remotewriter/README.md
+++ b/pp/go/storage/remotewriter/README.md
@@ -16,4 +16,36 @@
         3. on success -> nil
     5. try ack.
     6. check end of block
-   
+
+## Delivery marks
+
+Every message POST carries two headers, both set from the delivery marks in the request context
+(see `delivery.go`):
+
+- `X-Idempotency-Key` — `<destination>/<headID>/<targetSegmentID>/<messageIndex>`. Stays the same
+  over all the retries of that message, so a receiver can recognize a replay.
+- `Retry-Attempt` — the attempt number of our own send loop, `0` for the first delivery. Set by the
+  upstream `remote.Client` and only present when it is greater than zero.
+
+The key is stable within the life of an iterator. After a restart the same segments may be cut into
+different batches (`targetSegmentID` and the number of shards float), so the keys of the re-read data
+may differ from those of the first run.
+
+### Replays we do not count
+
+`X-Idempotency-Key` is not only a mark for the receiver: `net/http` treats a POST carrying
+`Idempotency-Key` or `X-Idempotency-Key` as replayable (`Request.isReplayable`), so `http.Transport`
+resends it on its own when a reused connection fails — a stale keep-alive, a server closing an idle
+connection, an HTTP/2 refused stream. Such a replay happens inside a single `Client.Do`, below our
+round tripper, and goes out byte for byte identical: the same key **and** the same `Retry-Attempt`.
+
+Therefore:
+
+- the idempotency key is the only unit of deduplication, the pair of key and attempt is not unique;
+- `Retry-Attempt` is a diagnostic of our send loop, not a count of times the payload reached the receiver;
+- `sent_message_duration_seconds` covers all the transport replays of a send as one observation, and
+  `bytes_total` undercounts what actually went over the wire.
+
+The `connections_total{state="new"|"reused"}` metric makes the wire side visible: it counts every
+connection a request went through (`httptrace.GotConn`), so transport replays show up as extra
+connections for a single send.

--- a/pp/go/storage/remotewriter/delivery.go
+++ b/pp/go/storage/remotewriter/delivery.go
@@ -1,0 +1,116 @@
+package remotewriter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptrace"
+)
+
+// IdempotencyKeyHeader marks a remote write POST, so that a receiver is able to recognize its replays.
+// Replaying a POST is a regular part of the delivery contract here: [Iterator.SendMessage] resends
+// undelivered messages of a batch with the very same payload.
+//
+// Mind that this exact header name also opts the request into replays made by the Go transport itself:
+// [net/http.Request.isReplayable] treats a POST carrying Idempotency-Key or X-Idempotency-Key as
+// replayable, so http.Transport silently resends it when a reused connection fails (a stale keep-alive,
+// a server closing an idle connection, an HTTP/2 refused stream). Those replays happen below our round
+// tripper, inside a single Client.Do, so they go out byte for byte identical - the same key and the same
+// Retry-Attempt value. Hence the delivery contract for a receiver:
+//   - the idempotency key is the only unit of deduplication, a pair of key and attempt is NOT unique;
+//   - [RetryAttemptHeader] counts the attempts of our own send loop, not the times a payload reached
+//     the receiver, and is meant for diagnostics.
+const IdempotencyKeyHeader = "X-Idempotency-Key"
+
+// RetryAttemptHeader is set by [remote.Client] from the attempt number [protobufWriter] passes to Store.
+const RetryAttemptHeader = "Retry-Attempt"
+
+// deliveryMarks describes a single delivery attempt of a single message.
+type deliveryMarks struct {
+	idempotencyKey string
+	retryAttempt   int
+}
+
+// deliveryMarksContextKey is a key of the [deliveryMarks] value in a request context.
+type deliveryMarksContextKey struct{}
+
+// withDeliveryMarks returns a context carrying the marks of a single message delivery attempt.
+// The key travels to [IdempotencyKeyHeader] via [deliveryRoundTripper], the attempt number
+// travels to [RetryAttemptHeader] via [protobufWriter].
+func withDeliveryMarks(ctx context.Context, idempotencyKey string, retryAttempt int) context.Context {
+	return context.WithValue(
+		ctx,
+		deliveryMarksContextKey{},
+		deliveryMarks{idempotencyKey: idempotencyKey, retryAttempt: retryAttempt},
+	)
+}
+
+// deliveryMarksFromContext returns the delivery marks from the context, a zero value if there are none.
+func deliveryMarksFromContext(ctx context.Context) deliveryMarks {
+	marks, _ := ctx.Value(deliveryMarksContextKey{}).(deliveryMarks)
+	return marks
+}
+
+// deliveryTarget describes where an [Iterator] delivers messages to.
+type deliveryTarget struct {
+	// endpoint is the redacted destination URL, it tells the logs where a message was not delivered to.
+	endpoint string
+	// idempotencyKeyPrefix is the head-wide part of a message idempotency key.
+	idempotencyKeyPrefix string
+}
+
+// newDeliveryTarget init new [deliveryTarget] of the destination reading the head headID.
+func newDeliveryTarget(destinationName, endpoint, headID string) deliveryTarget {
+	return deliveryTarget{
+		endpoint:             endpoint,
+		idempotencyKeyPrefix: destinationName + "/" + headID,
+	}
+}
+
+// messageIdempotencyKey builds the key of a single message of a batch. Messages of a batch are
+// numbered by messageIndex and a non-empty batch always advances targetSegmentID, so the key
+// identifies the message within the head and stays the same over all its retries.
+func (t deliveryTarget) messageIdempotencyKey(targetSegmentID uint32, messageIndex int) string {
+	return fmt.Sprintf("%s/%d/%d", t.idempotencyKeyPrefix, targetSegmentID, messageIndex)
+}
+
+// deliveryRoundTripper sets [IdempotencyKeyHeader] from the request context and counts the connections
+// the requests go through.
+type deliveryRoundTripper struct {
+	http.RoundTripper
+	trace *httptrace.ClientTrace
+}
+
+// newDeliveryRoundTripper init new [deliveryRoundTripper] over the underlying round tripper.
+func newDeliveryRoundTripper(
+	underlyingRT http.RoundTripper,
+	metrics *DestinationMetrics,
+) *deliveryRoundTripper {
+	newConnections := metrics.connectionsTotal.WithLabelValues(connectionNew)
+	reusedConnections := metrics.connectionsTotal.WithLabelValues(connectionReused)
+
+	return &deliveryRoundTripper{
+		RoundTripper: underlyingRT,
+		// a single trace is shared by all the requests, it only touches the counters
+		trace: &httptrace.ClientTrace{
+			GotConn: func(info httptrace.GotConnInfo) {
+				if info.Reused {
+					reusedConnections.Inc()
+					return
+				}
+
+				newConnections.Inc()
+			},
+		},
+	}
+}
+
+// RoundTrip implementation [http.RoundTripper].
+func (rt *deliveryRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if key := deliveryMarksFromContext(req.Context()).idempotencyKey; key != "" {
+		req.Header.Set(IdempotencyKeyHeader, key)
+	}
+
+	// the transport may replay the request under a single RoundTrip, every attempt of it reports GotConn
+	return rt.RoundTripper.RoundTrip(req.WithContext(httptrace.WithClientTrace(req.Context(), rt.trace)))
+}

--- a/pp/go/storage/remotewriter/delivery_test.go
+++ b/pp/go/storage/remotewriter/delivery_test.go
@@ -1,0 +1,262 @@
+package remotewriter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/prometheus/prometheus/storage/remote"
+
+	"github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/pp/go/cppbridge"
+	"github.com/prometheus/prometheus/pp/go/logger"
+	"github.com/prometheus/prometheus/pp/go/storage/remotewriter/mock"
+)
+
+// roundTripperFunc is a [http.RoundTripper] over a func.
+type roundTripperFunc func(req *http.Request) (*http.Response, error)
+
+// RoundTrip implementation [http.RoundTripper].
+func (fn roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+// writeClientStub is a [remote.WriteClient] recording the arguments of the last Store call.
+type writeClientStub struct {
+	attempt int
+	data    []byte
+}
+
+// Store implementation [remote.WriteClient].
+func (c *writeClientStub) Store(_ context.Context, req []byte, attempt int) (remote.WriteResponseStats, error) {
+	c.data = req
+	c.attempt = attempt
+	return remote.WriteResponseStats{}, nil
+}
+
+// Name implementation [remote.WriteClient].
+func (*writeClientStub) Name() string { return "stub" }
+
+// Endpoint implementation [remote.WriteClient].
+func (*writeClientStub) Endpoint() string { return "http://test.com" }
+
+type DeliverySuite struct {
+	suite.Suite
+}
+
+func TestDeliverySuite(t *testing.T) {
+	suite.Run(t, new(DeliverySuite))
+}
+
+// newRoundTripper builds a [deliveryRoundTripper] with its own metrics over the underlying round tripper.
+func (*DeliverySuite) newRoundTripper(underlyingRT http.RoundTripper) *deliveryRoundTripper {
+	return newDeliveryRoundTripper(underlyingRT, newDestinationMetrics("test", "http://test.com"))
+}
+
+func (s *DeliverySuite) TestRoundTripperSetsHeaderFromContext() {
+	var actualKey string
+	rt := s.newRoundTripper(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		actualKey = req.Header.Get(IdempotencyKeyHeader)
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}))
+
+	expectedKey := newDeliveryTarget("dst", "http://test.com", "head-42").messageIdempotencyKey(7, 1)
+	req, err := http.NewRequestWithContext(
+		withDeliveryMarks(s.T().Context(), expectedKey, 0),
+		http.MethodPost,
+		"http://test.com",
+		http.NoBody,
+	)
+	s.Require().NoError(err)
+
+	_, err = rt.RoundTrip(req)
+	s.Require().NoError(err)
+	s.Equal(expectedKey, actualKey)
+	s.Equal("dst/head-42/7/1", actualKey)
+}
+
+func (s *DeliverySuite) TestRoundTripperKeepsHeaderUnsetWithoutKey() {
+	headerIsSet := true
+	rt := s.newRoundTripper(roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		_, headerIsSet = req.Header[IdempotencyKeyHeader]
+		return &http.Response{StatusCode: http.StatusOK}, nil
+	}))
+
+	req, err := http.NewRequestWithContext(s.T().Context(), http.MethodPost, "http://test.com", http.NoBody)
+	s.Require().NoError(err)
+
+	_, err = rt.RoundTrip(req)
+	s.Require().NoError(err)
+	s.False(headerIsSet)
+}
+
+func (s *DeliverySuite) TestProtobufWriterPassesRetryAttempt() {
+	client := &writeClientStub{}
+	writer := newProtobufWriter(client)
+
+	s.Require().NoError(writer.Write(withDeliveryMarks(s.T().Context(), "dst/head-42/7/0", 3), []byte("message")))
+	s.Equal(3, client.attempt)
+
+	s.Require().NoError(writer.Write(s.T().Context(), []byte("message")))
+	s.Equal(0, client.attempt)
+}
+
+// TestClientSendsDeliveryHeaders checks that both marks reach the wire through the client built by createClient.
+func (s *DeliverySuite) TestClientSendsDeliveryHeaders() {
+	var actualKey, actualAttempt string
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		actualKey = r.Header.Get(IdempotencyKeyHeader)
+		actualAttempt = r.Header.Get(RetryAttemptHeader)
+	}))
+	defer server.Close()
+
+	client, _, err := s.newClient(server.URL)
+	s.Require().NoError(err)
+
+	err = newProtobufWriter(client).Write(
+		withDeliveryMarks(s.T().Context(), "dst/head-42/7/1", 2),
+		[]byte("message"),
+	)
+	s.Require().NoError(err)
+	s.Equal("dst/head-42/7/1", actualKey)
+	s.Equal("2", actualAttempt)
+}
+
+// TestClientCountsConnections checks that an established connection and its reuse are told apart.
+func (s *DeliverySuite) TestClientCountsConnections() {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer server.Close()
+
+	client, metrics, err := s.newClient(server.URL)
+	s.Require().NoError(err)
+	writer := newProtobufWriter(client)
+
+	s.Require().NoError(writer.Write(s.T().Context(), []byte("message")))
+	s.Equal(float64(1), testutil.ToFloat64(metrics.connectionsTotal.WithLabelValues(connectionNew)))
+	s.Equal(float64(0), testutil.ToFloat64(metrics.connectionsTotal.WithLabelValues(connectionReused)))
+
+	// the client drains and closes the response body, so the connection is back in the idle pool
+	s.Require().NoError(writer.Write(s.T().Context(), []byte("message")))
+	s.Equal(float64(1), testutil.ToFloat64(metrics.connectionsTotal.WithLabelValues(connectionNew)))
+	s.Equal(float64(1), testutil.ToFloat64(metrics.connectionsTotal.WithLabelValues(connectionReused)))
+}
+
+// newClient builds a write client for the endpoint together with the metrics it reports to.
+func (*DeliverySuite) newClient(endpoint string) (remote.WriteClient, *DestinationMetrics, error) {
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	metrics := newDestinationMetrics("test", endpoint)
+	client, err := createClient(DestinationConfig{
+		RemoteWriteConfig: config.RemoteWriteConfig{
+			Name:          "dst",
+			URL:           &config_util.URL{URL: endpointURL},
+			RemoteTimeout: model.Duration(10 * time.Second),
+		},
+	}, metrics)
+
+	return client, metrics, err
+}
+
+// TestSendMessageRepeatsKeyOnRetry checks that a replayed message carries the key of its first delivery
+// attempt and the number of the attempt it is, and that the failed attempt is reported with its details.
+//
+//revive:disable-next-line:function-length // long but readable
+func (s *DeliverySuite) TestSendMessageRepeatsKeyOnRetry() {
+	clock := clockwork.NewRealClock()
+	queueConfig := config.QueueConfig{
+		MinShards:         1,
+		MaxShards:         2,
+		MaxSamplesPerSend: 10,
+		SampleAgeLimit:    model.Duration(time.Minute),
+	}
+
+	var mtx sync.Mutex
+	actualMarks := make(map[deliveryMarks]int)
+	var errorLogs []string
+	firstAttemptFailed := false
+
+	logger.Errorf = func(format string, args ...any) {
+		mtx.Lock()
+		defer mtx.Unlock()
+
+		errorLogs = append(errorLogs, fmt.Sprintf(format, args...))
+	}
+	s.T().Cleanup(logger.Unset)
+
+	protobufWriter := &mock.ProtobufWriterMock{
+		WriteFunc: func(ctx context.Context, data []byte) error {
+			mtx.Lock()
+			defer mtx.Unlock()
+
+			actualMarks[deliveryMarksFromContext(ctx)]++
+
+			// fail the first delivery of the first message to force a replay of exactly that message
+			if string(data) == "message-0" && !firstAttemptFailed {
+				firstAttemptFailed = true
+				return remote.RecoverableError{}
+			}
+
+			return nil
+		},
+	}
+
+	it, err := newIterator(
+		clock,
+		queueConfig,
+		nil,
+		&mock.TargetSegmentIDSetCloserMock{
+			SetTargetSegmentIDFunc: func(uint32) error { return nil },
+			CloseFunc:              func() error { return nil },
+		},
+		0,
+		10*time.Second,
+		protobufWriter,
+		newDestinationMetrics("test", "http://remote.test/api/v1/write"),
+		newDeliveryTarget("dst", "http://remote.test/api/v1/write", "head-42"),
+	)
+	s.Require().NoError(err)
+
+	maxTimestamp := clock.Now().UnixMilli()
+	msg := &cppbridge.RWMessageList{
+		MaxTimestamp:    maxTimestamp,
+		TargetSegmentID: 7,
+		Messages: []cppbridge.RWMessage{
+			{Buffer: []byte("message-0"), MaxTimestamp: maxTimestamp, SampleCount: 1},
+			{Buffer: []byte("message-1"), MaxTimestamp: maxTimestamp, SampleCount: 1},
+		},
+	}
+
+	s.Require().NoError(it.SendMessage(s.T().Context(), msg))
+	s.True(firstAttemptFailed)
+	s.Equal(
+		map[deliveryMarks]int{
+			{idempotencyKey: "dst/head-42/7/0", retryAttempt: 0}: 1,
+			{idempotencyKey: "dst/head-42/7/1", retryAttempt: 0}: 1,
+			// the same key, the next attempt: the replay of the failed message
+			{idempotencyKey: "dst/head-42/7/0", retryAttempt: 1}: 1,
+		},
+		actualMarks,
+	)
+
+	s.Require().Len(errorLogs, 1)
+	s.Contains(errorLogs[0], "url=http://remote.test/api/v1/write")
+	s.Contains(errorLogs[0], "idempotency_key=dst/head-42/7/0")
+	s.Contains(errorLogs[0], "attempt=0")
+	s.Contains(errorLogs[0], "bytes=9") // len("message-0")
+	s.Contains(errorLogs[0], "samples=1")
+	s.Regexp(`duration=\d`, errorLogs[0])
+}

--- a/pp/go/storage/remotewriter/destination.go
+++ b/pp/go/storage/remotewriter/destination.go
@@ -23,6 +23,9 @@ const (
 
 	reasonTooOld        = "too_old"
 	reasonDroppedSeries = "dropped_series"
+
+	connectionNew    = "new"
+	connectionReused = "reused"
 )
 
 // DefaultSampleAgeLimit is the default maximum sample age. Dont send samples older than this.
@@ -118,6 +121,7 @@ func (d *Destination) RegisterMetrics(registerer prometheus.Registerer) {
 	registerer.MustRegister(d.metrics.minNumShards)
 	registerer.MustRegister(d.metrics.desiredNumShards)
 	registerer.MustRegister(d.metrics.bestNumShards)
+	registerer.MustRegister(d.metrics.connectionsTotal)
 	registerer.MustRegister(d.metrics.sentBytesTotal)
 	registerer.MustRegister(d.metrics.metadataBytesTotal)
 	registerer.MustRegister(d.metrics.maxSamplesPerSend)
@@ -163,6 +167,7 @@ func (d *Destination) UnregisterMetrics(registerer prometheus.Registerer) {
 	registerer.Unregister(d.metrics.minNumShards)
 	registerer.Unregister(d.metrics.desiredNumShards)
 	registerer.Unregister(d.metrics.bestNumShards)
+	registerer.Unregister(d.metrics.connectionsTotal)
 	registerer.Unregister(d.metrics.sentBytesTotal)
 	registerer.Unregister(d.metrics.metadataBytesTotal)
 	registerer.Unregister(d.metrics.maxSamplesPerSend)
@@ -245,6 +250,7 @@ type DestinationMetrics struct {
 	minNumShards           prometheus.Gauge
 	desiredNumShards       prometheus.Gauge
 	bestNumShards          prometheus.Gauge
+	connectionsTotal       *prometheus.CounterVec
 	sentBytesTotal         prometheus.Counter
 	metadataBytesTotal     prometheus.Counter
 	maxSamplesPerSend      prometheus.Gauge
@@ -499,6 +505,14 @@ func newDestinationMetrics(name, ep string) *DestinationMetrics {
 			Help:        "The number of shards that are calculated from the actual number of accumulated segments.",
 			ConstLabels: constLabels,
 		}),
+		connectionsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "connections_total",
+			//revive:disable-next-line:line-length-limit // this is a description of the metric
+			Help:        "Total number of connections the requests to the remote storage went through, by whether an already established connection was reused. Note that the transport may replay a request on its own, so a single send can report more than one connection.",
+			ConstLabels: constLabels,
+		}, []string{"state"}),
 		sentBytesTotal: prometheus.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,

--- a/pp/go/storage/remotewriter/iterator.go
+++ b/pp/go/storage/remotewriter/iterator.go
@@ -366,18 +366,18 @@ func (i *Iterator) SendMessage(ctx context.Context, msg *cppbridge.RWMessageList
 			idempotencyKey := i.target.messageIdempotencyKey(msg.TargetSegmentID, index)
 			sendCtx := withDeliveryMarks(ctx, idempotencyKey, sendIteration)
 
-			go func(msg *cppbridge.RWMessage, idempotencyKey string, attempt int) {
+			go func(message *cppbridge.RWMessage, idempotencyKey string, attempt int) {
 				defer sendSemaphore.Release(1)
 				sendStartTime := i.clock.Now()
-				writeErr := i.protobufWriter.Write(sendCtx, msg.Buffer)
-				sendDuration := time.Since(sendStartTime)
+				writeErr := i.protobufWriter.Write(sendCtx, message.Buffer)
+				sendDuration := i.clock.Since(sendStartTime)
 				i.metrics.sentMessageDuration.Observe(sendDuration.Seconds())
 
 				if writeErr != nil {
-					i.logSendError(writeErr, msg, sendDuration, idempotencyKey, attempt)
+					i.logSendError(writeErr, message, sendDuration, idempotencyKey, attempt)
 				}
 
-				msg.Delivered = !errors.As(writeErr, &remote.RecoverableError{})
+				message.Delivered = !errors.As(writeErr, &remote.RecoverableError{})
 			}(&msg.Messages[index], idempotencyKey, sendIteration)
 		}
 		_ = sendSemaphore.Acquire(ctx, int64(sendersCount))

--- a/pp/go/storage/remotewriter/iterator.go
+++ b/pp/go/storage/remotewriter/iterator.go
@@ -130,6 +130,9 @@ type Iterator struct {
 	metrics                  *DestinationMetrics
 	targetSegmentID          uint32
 
+	// target is the destination the messages are delivered to.
+	target deliveryTarget
+
 	outputSharder *sharder
 
 	scrapeInterval    time.Duration
@@ -146,6 +149,7 @@ func newIterator(
 	readTimeout time.Duration,
 	protobufWriter ProtobufWriter,
 	metrics *DestinationMetrics,
+	target deliveryTarget,
 ) (*Iterator, error) {
 	outputSharder, err := newSharder(queueConfig.MinShards, queueConfig.MaxShards)
 	if err != nil {
@@ -160,6 +164,7 @@ func newIterator(
 		targetSegmentIDSetCloser: targetSegmentIDSetCloser,
 		metrics:                  metrics,
 		targetSegmentID:          targetSegmentID,
+		target:                   target,
 		scrapeInterval:           readTimeout,
 		outputSharder:            outputSharder,
 	}, nil
@@ -356,17 +361,24 @@ func (i *Iterator) SendMessage(ctx context.Context, msg *cppbridge.RWMessageList
 				break
 			}
 
-			go func(msg *cppbridge.RWMessage) {
+			// the key is derived from the message position, so a retry of this message repeats it,
+			// while sendIteration tells the receiver which attempt this delivery is
+			idempotencyKey := i.target.messageIdempotencyKey(msg.TargetSegmentID, index)
+			sendCtx := withDeliveryMarks(ctx, idempotencyKey, sendIteration)
+
+			go func(msg *cppbridge.RWMessage, idempotencyKey string, attempt int) {
 				defer sendSemaphore.Release(1)
 				sendStartTime := i.clock.Now()
-				writeErr := i.protobufWriter.Write(ctx, msg.Buffer)
+				writeErr := i.protobufWriter.Write(sendCtx, msg.Buffer)
+				sendDuration := time.Since(sendStartTime)
+				i.metrics.sentMessageDuration.Observe(sendDuration.Seconds())
+
 				if writeErr != nil {
-					logger.Errorf("failed to send protobuf: %v", writeErr)
+					i.logSendError(writeErr, msg, sendDuration, idempotencyKey, attempt)
 				}
-				i.metrics.sentMessageDuration.Observe(time.Since(sendStartTime).Seconds())
 
 				msg.Delivered = !errors.As(writeErr, &remote.RecoverableError{})
-			}(&msg.Messages[index])
+			}(&msg.Messages[index], idempotencyKey, sendIteration)
 		}
 		_ = sendSemaphore.Acquire(ctx, int64(sendersCount))
 		i.metrics.sentBatchDuration.Observe(i.clock.Since(startTime).Seconds())
@@ -427,6 +439,27 @@ func (i *Iterator) SendMessage(ctx context.Context, msg *cppbridge.RWMessageList
 	}
 
 	return nil
+}
+
+// logSendError reports a failed delivery of a single message with everything needed to locate it:
+// where it was sent, which attempt it was, how long the request took and how big the message is.
+func (i *Iterator) logSendError(
+	sendErr error,
+	msg *cppbridge.RWMessage,
+	sendDuration time.Duration,
+	idempotencyKey string,
+	attempt int,
+) {
+	logger.Errorf(
+		"failed to send message: %v; url=%s idempotency_key=%s attempt=%d duration=%s bytes=%d samples=%d",
+		sendErr,
+		i.target.endpoint,
+		idempotencyKey,
+		attempt,
+		sendDuration,
+		len(msg.Buffer),
+		msg.SampleCount,
+	)
 }
 
 // setTargetSegmentID sets the target segment id.

--- a/pp/go/storage/remotewriter/iterator_test.go
+++ b/pp/go/storage/remotewriter/iterator_test.go
@@ -119,6 +119,7 @@ func (s *IteratorSuite) TestHappyPathV1() {
 		readTimeout,
 		protobufWriter,
 		metrics,
+		newDeliveryTarget("test", "http://test.com", "head-1"),
 	)
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(it.Close()) }()
@@ -230,6 +231,7 @@ func (s *IteratorSuite) TestHappyPathV2() {
 		readTimeout,
 		protobufWriter,
 		metrics,
+		newDeliveryTarget("test", "http://test.com", "head-1"),
 	)
 	s.Require().NoError(err)
 	defer func() { s.Require().NoError(it.Close()) }()
@@ -350,6 +352,7 @@ func BenchmarkIteratorV1(b *testing.B) {
 		readTimeout,
 		protobufWriter,
 		metrics,
+		newDeliveryTarget("test", "http://test.com", "head-1"),
 	)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, it.Close()) }()
@@ -437,6 +440,7 @@ func BenchmarkIteratorV2(b *testing.B) {
 		readTimeout,
 		protobufWriter,
 		metrics,
+		newDeliveryTarget("test", "http://test.com", "head-1"),
 	)
 	require.NoError(b, err)
 	defer func() { require.NoError(b, it.Close()) }()

--- a/pp/go/storage/remotewriter/writeloop.go
+++ b/pp/go/storage/remotewriter/writeloop.go
@@ -336,8 +336,6 @@ func (wl *writeLoop) makeCorruptMarker() CorruptMarker {
 }
 
 // createClient creates a new [remote.WriteClient].
-//
-
 func createClient(config DestinationConfig, metrics *DestinationMetrics) (client remote.WriteClient, err error) {
 	clientConfig := remote.ClientConfig{
 		URL:              config.URL,
@@ -351,7 +349,7 @@ func createClient(config DestinationConfig, metrics *DestinationMetrics) (client
 
 	client, err = remote.NewWriteClient(config.Name, &clientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("falied to create client: %w", err)
+		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
 
 	// the write loop replays undelivered messages itself, so every POST carries its idempotency key

--- a/pp/go/storage/remotewriter/writeloop.go
+++ b/pp/go/storage/remotewriter/writeloop.go
@@ -87,7 +87,7 @@ func (wl *writeLoop) run(ctx context.Context) {
 		}
 
 		if wl.client == nil {
-			wl.client, err = createClient(wl.destination.Config())
+			wl.client, err = createClient(wl.destination.Config(), wl.destination.metrics)
 			if err != nil {
 				logger.Errorf("create client: %v", err)
 				delay = defaultDelay
@@ -262,6 +262,7 @@ func (wl *writeLoop) nextIterator(ctx context.Context, protobufWriter ProtobufWr
 		dcfg.ReadTimeout,
 		protobufWriter,
 		wl.destination.metrics,
+		newDeliveryTarget(dcfg.Name, dcfg.URL.Redacted(), nextHeadRecord.ID()),
 	)
 	if err != nil {
 		return nil, errors.Join(fmt.Errorf("create data source: %w", err), crw.Close(), ds.Close())
@@ -337,7 +338,7 @@ func (wl *writeLoop) makeCorruptMarker() CorruptMarker {
 // createClient creates a new [remote.WriteClient].
 //
 
-func createClient(config DestinationConfig) (client remote.WriteClient, err error) {
+func createClient(config DestinationConfig, metrics *DestinationMetrics) (client remote.WriteClient, err error) {
 	clientConfig := remote.ClientConfig{
 		URL:              config.URL,
 		Timeout:          config.RemoteTimeout,
@@ -352,6 +353,13 @@ func createClient(config DestinationConfig) (client remote.WriteClient, err erro
 	if err != nil {
 		return nil, fmt.Errorf("falied to create client: %w", err)
 	}
+
+	// the write loop replays undelivered messages itself, so every POST carries its idempotency key
+	writeClient, ok := client.(*remote.Client)
+	if !ok {
+		return nil, fmt.Errorf("unexpected write client type: %T", client)
+	}
+	writeClient.Client.Transport = newDeliveryRoundTripper(writeClient.Client.Transport, metrics)
 
 	return client, nil
 }

--- a/pp/go/storage/remotewriter/writer.go
+++ b/pp/go/storage/remotewriter/writer.go
@@ -24,12 +24,13 @@ func (*protobufWriter) Close() error {
 }
 
 // Write [cppbridge.SnappyProtobufEncodedData] to [remote.WriteClient].
+// The attempt number of this delivery comes from the context and is reported as the Retry-Attempt header.
 func (w *protobufWriter) Write(ctx context.Context, protobuf []byte) error {
 	if len(protobuf) == 0 {
 		return nil
 	}
 
 	// TODO WriteResponseStats
-	_, err := w.client.Store(ctx, protobuf, 0)
+	_, err := w.client.Store(ctx, protobuf, deliveryMarksFromContext(ctx).retryAttempt)
 	return err
 }


### PR DESCRIPTION
## Why

Replaying a remote write POST is a regular part of the delivery contract here: `Iterator.SendMessage`
resends undelivered messages of a batch with the very same payload, and the Go transport may replay a
request on its own. Nothing on the wire said so:

- a receiver could not tell a replay from new data;
- `Retry-Attempt` was hardcoded to `0` in `protobufWriter.Write`, so the attempt number never left the
  process, even though `remote.Client.Store` already knows how to send it;
- the failed send log was a bare `failed to send protobuf: <err>` — no endpoint, no attempt, no size.

## What

**Delivery marks.** Both marks of a single delivery travel in the request context (`delivery.go`) and
reach the wire as headers:

- `X-Idempotency-Key` = `<destination>/<headID>/<targetSegmentID>/<messageIndex>`, set by
  `deliveryRoundTripper`. Messages of a batch are numbered, and a non-empty batch always advances
  `targetSegmentID`, so the key repeats over all the retries of that message.
- `Retry-Attempt`, passed to `Store` as the attempt number of the send loop (`0` for the first delivery).

Upstream files are untouched: the round tripper is wrapped around the transport of the client built in
`createClient`.

**Semantics worth knowing.** This exact header name also opts the POST into replays made by the Go
transport itself — [`Request.isReplayable`](https://cs.opensource.google/go/go/+/refs/tags/go1.26.5:src/net/http/request.go;l=1534)
treats a POST carrying `Idempotency-Key` or `X-Idempotency-Key` as replayable, so `http.Transport`
resends it when a reused connection fails (stale keep-alive, server closing an idle connection, HTTP/2
refused stream). Those replays happen inside a single `Client.Do`, below our round tripper, and go out
byte for byte identical — same key, same `Retry-Attempt`. Hence:

- the idempotency key is the only unit of deduplication, the pair of key and attempt is **not** unique;
- `Retry-Attempt` is a diagnostic of our send loop, not a count of times a payload reached the receiver.

This is documented in the `IdempotencyKeyHeader` doc comment and in the package README.

**New metric.** `prometheus_remote_storage_connections_total{remote_name,url,state="new"|"reused"}`
counts the connections requests go through (`httptrace.GotConn`). Since the trace fires per transport
attempt, it also exposes the replays above: more than one connection per send means the transport
resent the request. Growth of `state="new"` under steady traffic means connections do not survive
keep-alive — the usual source of silent duplicates.

**Send error log** now reports everything needed to locate the message:

```
failed to send message: server returned HTTP status 503 Service Unavailable: upstream busy; \
url=http://remote.test/api/v1/write idempotency_key=dst/head-42/7/0 attempt=0 \
duration=1.204s bytes=524288 samples=2000
```

The URL is the redacted destination URL, the same value as in the metric labels.

## Limitations

The key is stable within the life of an iterator. After a restart the same segments may be cut into
different batches (`targetSegmentID` and the number of shards float), so keys of the re-read data may
differ from those of the first run. A content-derived key would fix that and can be a follow-up.

No receiver reads either header yet.

## Tests

`delivery_test.go`, all green under `go test -tags stringlabels -race`:

- a replayed message carries the key of its first attempt and the next attempt number
  (`{dst/head-42/7/0, 0}`, `{dst/head-42/7/1, 0}`, then `{dst/head-42/7/0, 1}`), and the failed attempt
  is logged with url / attempt / duration / bytes / samples;
- `protobufWriter` passes the attempt from the context to `Store`, and `0` when there are no marks;
- end to end through `createClient` + `httptest`: both headers arrive on the wire (this also proves the
  wrapper is not lost behind `otelhttp`);
- connection counting: the first send reports `state="new"`, the second `state="reused"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
