### PR TITLE
feat(remotewriter): add PROMPP_FEATURES=disable_remote_write_http2

### DIFF
--- a/pp-pkg/featuresflags/features_flags.go
+++ b/pp-pkg/featuresflags/features_flags.go
@@ -75,6 +75,10 @@ func ReadPromPPFeatures(logger log.Logger, cfg FlagConfig) {
 			querier.InstantQueryFeature = false
 			_ = level.Info(logger).Log(msgStr, "Instant query feature is disabled.")
 
+		case "disable_remote_write_http2":
+			remotewriter.HTTP2Enabled = false
+			_ = level.Info(logger).Log(msgStr, "HTTP/2 for remote write is disabled.")
+
 		case "disable_shrink_shard_copier":
 			storage.ShrinkShardCopier = false
 			_ = level.Info(logger).Log(msgStr, "Shrink shard copier is disabled.")

--- a/pp/go/storage/remotewriter/destination.go
+++ b/pp/go/storage/remotewriter/destination.go
@@ -28,6 +28,14 @@ const (
 // DefaultSampleAgeLimit is the default maximum sample age. Dont send samples older than this.
 var DefaultSampleAgeLimit = model.Duration(time.Hour * 24 * 30)
 
+// HTTP2Enabled is a feature flag for HTTP/2 in the remote write clients of every destination.
+// Enabled by default; disable via PROMPP_FEATURES=disable_remote_write_http2.
+//
+// Turning it off makes the clients speak HTTP/1.1 only. Worth doing when a proxy or a receiver
+// mishandles HTTP/2 - Go had a series of cases where a dead HTTP/2 connection was kept in the pool
+// and every request on it failed, see https://github.com/golang/go/issues/32388.
+var HTTP2Enabled = true
+
 // DestinationConfig is a remote write destination config.
 type DestinationConfig struct {
 	config.RemoteWriteConfig

--- a/pp/go/storage/remotewriter/http2_test.go
+++ b/pp/go/storage/remotewriter/http2_test.go
@@ -1,0 +1,76 @@
+package remotewriter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	config_util "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/prometheus/prometheus/config"
+)
+
+type HTTP2Suite struct {
+	suite.Suite
+
+	server *httptest.Server
+	proto  string
+}
+
+func TestHTTP2Suite(t *testing.T) {
+	suite.Run(t, new(HTTP2Suite))
+}
+
+// SetupTest starts a TLS server able to serve both HTTP/2 and HTTP/1.1, so the protocol is
+// negotiated by the client alone.
+func (s *HTTP2Suite) SetupTest() {
+	s.proto = ""
+	s.server = httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		s.proto = r.Proto
+	}))
+	s.server.EnableHTTP2 = true
+	s.server.StartTLS()
+}
+
+func (s *HTTP2Suite) TearDownTest() {
+	s.server.Close()
+	HTTP2Enabled = true
+}
+
+func (s *HTTP2Suite) TestHTTP2IsNegotiatedByDefault() {
+	s.Require().NoError(s.send())
+	s.Equal("HTTP/2.0", s.proto)
+}
+
+func (s *HTTP2Suite) TestDisabledFlagKeepsHTTP11() {
+	HTTP2Enabled = false
+
+	s.Require().NoError(s.send())
+	s.Equal("HTTP/1.1", s.proto)
+}
+
+// send delivers a message to the test server through a client built by [createClient].
+func (s *HTTP2Suite) send() error {
+	serverURL, err := url.Parse(s.server.URL)
+	s.Require().NoError(err)
+
+	client, err := createClient(DestinationConfig{
+		RemoteWriteConfig: config.RemoteWriteConfig{
+			Name:          "dst",
+			URL:           &config_util.URL{URL: serverURL},
+			RemoteTimeout: model.Duration(10 * time.Second),
+			HTTPClientConfig: config_util.HTTPClientConfig{
+				// the destination config asks for HTTP/2, as it does by default
+				EnableHTTP2: true,
+				TLSConfig:   config_util.TLSConfig{InsecureSkipVerify: true},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	return newProtobufWriter(client).Write(s.T().Context(), []byte("message"))
+}

--- a/pp/go/storage/remotewriter/writeloop.go
+++ b/pp/go/storage/remotewriter/writeloop.go
@@ -348,6 +348,11 @@ func createClient(config DestinationConfig) (client remote.WriteClient, err erro
 		RetryOnRateLimit: true,
 	}
 
+	// the client config owns its copy of the HTTP config, so the destination config keeps its own value
+	if !HTTP2Enabled {
+		clientConfig.HTTPClientConfig.EnableHTTP2 = false
+	}
+
 	client, err = remote.NewWriteClient(config.Name, &clientConfig)
 	if err != nil {
 		return nil, fmt.Errorf("falied to create client: %w", err)


### PR DESCRIPTION
## Why

Go had a series of cases where a dead HTTP/2 connection was kept in the transport pool and every
request on it kept failing ([#32388](https://github.com/golang/go/issues/32388),
[#39337](https://github.com/golang/go/issues/39337), [#39750](https://github.com/golang/go/issues/39750)
— the same list `prometheus/common` cites where it configures HTTP/2), and proxies in front of a
receiver mishandle HTTP/2 often enough to want an escape hatch.

Per destination there already is `enable_http2` in `http_client_config`, but there was no way to turn the
protocol off for every remote write at once — with many destinations that means editing every one of
them, and on a live incident that is the wrong kind of work.

## What

`PROMPP_FEATURES=disable_remote_write_http2` makes the write clients of all destinations speak HTTP/1.1.

- `remotewriter.HTTP2Enabled` — enabled by default, in the same style as the other flags
  (`ShrinkShardCopier`, `InstantQueryFeature`);
- applied in `createClient` to the `remote.ClientConfig` copy, which owns its own `HTTPClientConfig`
  value. The destination config keeps the value it was loaded with, so the config hash (and with it the
  auto-generated `remote_name` and the on-disk `<name>.cursor` / `<name>_shard_N.state` file names) and
  the `CRC32` used for cache invalidation are untouched;
- `featuresflags` logs `HTTP/2 for remote write is disabled.` when the flag is on.

Nothing else changes: remote read, scrapes and the pp-protocol path are not affected.

## Tests

`http2_test.go` runs against a TLS `httptest` server with `EnableHTTP2 = true`, so the protocol is
negotiated by the client alone, and asserts what the server actually saw:

- default: `r.Proto` is `HTTP/2.0`;
- with `HTTP2Enabled = false`: `r.Proto` is `HTTP/1.1`.

The destination config in the test explicitly sets `EnableHTTP2: true`, so the test proves the flag
overrides an enabled config rather than merely agreeing with a default.

Green in the devcontainer: `go test -tags stringlabels -race ./pp/go/storage/remotewriter/...`,
`go build ./cmd/... ./pp-pkg/...`.

## Note on #471

#471 also touches `createClient` (it wraps the client transport). The two changes are independent, but
they sit close enough in the file that whichever merges second may need a one-line rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
