### PR TITLE
fix(remotewriter): repair the broken pp test build (createClient signature)

### DIFF
--- a/pp/go/storage/remotewriter/http2_test.go
+++ b/pp/go/storage/remotewriter/http2_test.go
@@ -69,7 +69,7 @@ func (s *HTTP2Suite) send() error {
 				TLSConfig:   config_util.TLSConfig{InsecureSkipVerify: true},
 			},
 		},
-	})
+	}, newDestinationMetrics("test", s.server.URL))
 	s.Require().NoError(err)
 
 	return newProtobufWriter(client).Write(s.T().Context(), []byte("message"))


### PR DESCRIPTION
## What is broken

`pp` does not compile its remote writer test package:

```
pp/go/storage/remotewriter/http2_test.go:72:3: not enough arguments in call to createClient
	have (DestinationConfig)
	want (DestinationConfig, *DestinationMetrics)
```

Every PR based on current `pp` fails the Go test job because of it — for example
[#473's go-test-all run](https://github.com/deckhouse/prompp/actions/runs/31722500515/job/94539700700),
where the failure has nothing to do with that PR's own changes.

## How it happened

#471 gave `createClient` a `metrics` argument, #472 added `http2_test.go` calling it with the old
signature. #472 branched off `pp` before #471 landed, so each PR was green on its own branch and the
breakage only appeared in the merge result. There was no git conflict to warn about it — the two changes
touch different lines.

## The fix

Pass the metrics the same way the other tests in the package do. One line.

Verified in the devcontainer on top of current `pp`:

```
go vet -tags stringlabels ./pp/go/storage/remotewriter/...
go test -tags stringlabels -race -count=1 ./pp/go/storage/remotewriter/...   # ok
```

## Worth considering separately

The Go test job is not a required check that forces branches to be up to date with `pp` before merging,
so this class of breakage can happen again with any pair of PRs that touch a shared signature. Enabling
"Require branches to be up to date before merging" for the test job would catch it at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
