### PR TITLE
fix: guard snug composite view iterators against shared-span size race

### DIFF
--- a/pp/primitives/snug_composites_filaments.h
+++ b/pp/primitives/snug_composites_filaments.h
@@ -519,7 +519,6 @@ struct LabelNameSet {
           ++(*this);
           return retval;
         }
-        PROMPP_ALWAYS_INLINE bool operator==(const iterator_type& other) const noexcept { return id_ == other.id_; }
         PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == sentinel_id_; }
 
         [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator*() const noexcept { return storage_ptr_->composite(id_); }
@@ -1110,7 +1109,6 @@ struct LabelSet {
           return retval;
         }
 
-        PROMPP_ALWAYS_INLINE bool operator==(const iterator_type& other) const noexcept { return id_ == other.id_; }
         PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == sentinel_id_; }
 
         [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator*() const noexcept { return storage_ptr_->composite(id_); }

--- a/pp/primitives/snug_composites_filaments.h
+++ b/pp/primitives/snug_composites_filaments.h
@@ -506,7 +506,8 @@ struct LabelNameSet {
         using difference_type = std::ptrdiff_t;
 
         iterator_type() = default;
-        explicit iterator_type(const storage_type* storage_ptr, uint32_t id) noexcept : storage_ptr_(storage_ptr), id_{id} {}
+        explicit iterator_type(const storage_type* storage_ptr, uint32_t id) noexcept
+            : storage_ptr_(storage_ptr), id_{id}, sentinel_id_{storage_ptr->get_sentinel_id()} {}
 
         PROMPP_ALWAYS_INLINE iterator_type& operator++() noexcept {
           ++id_;
@@ -519,7 +520,7 @@ struct LabelNameSet {
           return retval;
         }
         PROMPP_ALWAYS_INLINE bool operator==(const iterator_type& other) const noexcept { return id_ == other.id_; }
-        PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == storage_ptr_->items_.size(); }
+        PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == sentinel_id_; }
 
         [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator*() const noexcept { return storage_ptr_->composite(id_); }
 
@@ -528,6 +529,7 @@ struct LabelNameSet {
        private:
         const storage_type* storage_ptr_;
         uint32_t id_{0};
+        uint32_t sentinel_id_{0};
       };
 
       [[nodiscard]] PROMPP_ALWAYS_INLINE auto begin() const noexcept { return iterator_type{storage_ptr, 0}; }
@@ -569,6 +571,11 @@ struct LabelNameSet {
       const auto item = items_[id];
       const uint32_t* ids_begin = symbols_ids_sequences_.data() + item.pos;
       return composite_type(ids_begin, item.size, &symbols_table_.symbol_table_read_view());
+    }
+
+    PROMPP_ALWAYS_INLINE bool is_valid(uint32_t id) const noexcept {
+      const auto item = items_[id];
+      return static_cast<uint64_t>(item.pos) + item.size <= symbols_ids_sequences_.size();
     }
 
     void validate(uint32_t id) const {
@@ -692,6 +699,19 @@ struct LabelNameSet {
    private:
     template <template <template <class> class> class, template <class> class>
     friend struct LabelNameSet;
+
+    PROMPP_ALWAYS_INLINE uint32_t get_sentinel_id() const noexcept {
+      if constexpr (kIsReadOnly) {
+        uint32_t id = items_.size();
+        while (id > 0 && !is_valid(id - 1)) {
+          --id;
+        }
+
+        return id;
+      } else {
+        return items_.size();
+      }
+    }
 
     symbols_table_type symbols_table_;
     symbols_ids_sequences_type symbols_ids_sequences_;
@@ -1077,7 +1097,7 @@ struct LabelSet {
         using difference_type = std::ptrdiff_t;
 
         iterator_type() = default;
-        explicit iterator_type(const storage_type& storage, uint32_t id) noexcept : storage_ptr_(&storage), id_{id} {}
+        explicit iterator_type(const storage_type& storage, uint32_t id) noexcept : storage_ptr_(&storage), id_{id}, sentinel_id_{storage.get_sentinel_id()} {}
 
         PROMPP_ALWAYS_INLINE iterator_type& operator++() noexcept {
           ++id_;
@@ -1091,7 +1111,7 @@ struct LabelSet {
         }
 
         PROMPP_ALWAYS_INLINE bool operator==(const iterator_type& other) const noexcept { return id_ == other.id_; }
-        PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == storage_ptr_->items_.size(); }
+        PROMPP_ALWAYS_INLINE bool operator==(BareBones::iterator::IteratorSentinelType) const noexcept { return id_ == sentinel_id_; }
 
         [[nodiscard]] PROMPP_ALWAYS_INLINE value_type operator*() const noexcept { return storage_ptr_->composite(id_); }
 
@@ -1100,6 +1120,7 @@ struct LabelSet {
        private:
         const storage_type* storage_ptr_;
         uint32_t id_{0};
+        uint32_t sentinel_id_{0};
       };
 
       [[nodiscard]] PROMPP_ALWAYS_INLINE auto begin() const noexcept { return iterator_type{*storage_ptr, 0}; }
@@ -1196,6 +1217,25 @@ struct LabelSet {
       auto lns = label_name_sets_table_[lns_id];
       const uint8_t* values_stream_begin = symbols_ids_sequences_.data() + (pos - shrinked_size_);
       return LabelSetComposite(&symbols_tables_[0], sizeof(symbols_tables_[0]), lns, values_stream_begin, lns_id);
+    }
+
+    PROMPP_ALWAYS_INLINE bool is_valid(uint32_t id) const noexcept {
+      const auto [lns_id, pos] = items_[id];
+
+      if (lns_id >= label_name_sets_table_.items_count()) {
+        return false;
+      }
+
+      const auto lns = label_name_sets_table_[lns_id];
+      const auto data_offset = pos - shrinked_size_;
+      const auto keys_size = BareBones::StreamVByte::keys_size(lns.size());
+      if (static_cast<uint64_t>(data_offset) + keys_size > symbols_ids_sequences_.size()) {
+        return false;
+      }
+
+      const uint32_t data_size =
+          BareBones::StreamVByte::decode_data_size<BareBones::StreamVByte::Codec1234>(lns.size(), symbols_ids_sequences_.begin() + data_offset);
+      return static_cast<uint64_t>(data_offset) + keys_size + data_size <= symbols_ids_sequences_.size();
     }
 
     void validate(uint32_t id) const {
@@ -1434,6 +1474,19 @@ struct LabelSet {
    private:
     template <template <template <class> class> class, template <template <class> class> class, template <class> class>
     friend struct LabelSet;
+
+    PROMPP_ALWAYS_INLINE uint32_t get_sentinel_id() const noexcept {
+      if constexpr (kIsReadOnly) {
+        uint32_t id = items_.size();
+        while (id > 0 && !is_valid(id - 1)) {
+          --id;
+        }
+
+        return id;
+      } else {
+        return items_.size();
+      }
+    }
 
     symbols_tables_type symbols_tables_;
     symbols_ids_sequences_type symbols_ids_sequences_;

--- a/pp/primitives/snug_composites_tests.cpp
+++ b/pp/primitives/snug_composites_tests.cpp
@@ -1,4 +1,6 @@
 #include <sstream>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -723,6 +725,84 @@ TEST_F(SharedDataFixture, LabelSetCompositeHashMatchesOriginalLabelSet) {
 
   // Assert
   EXPECT_EQ(original_hash, composite_hash);
+}
+
+TEST_F(SharedDataFixture, SymbolViewIteratorStopsAtItemWithReallocatedData) {
+  // Arrange
+  SymbolEncodingBimap encoding_bimap;
+  encoding_bimap.find_or_emplace("x"sv);
+  encoding_bimap.reserve(1024);
+
+  const SymbolDecodingTable decoding_table(encoding_bimap);
+
+  const std::string big(1000, 'y');
+  encoding_bimap.find_or_emplace(std::string_view{big});
+
+  // Act
+  std::vector<std::string_view> iterated;
+  std::ranges::copy(decoding_table.data_view(), std::back_inserter(iterated));
+
+  // Assert
+  EXPECT_EQ(std::vector{"x"sv}, iterated);
+}
+
+TEST_F(SharedDataFixture, LabelNameSetViewIteratorStopsAtItemWithReallocatedData) {
+  // Arrange
+  LabelNameSetEncodingBimap encoding_bimap;
+  const LabelViewSet baseline{{"a", "1"}};
+  encoding_bimap.find_or_emplace(baseline.names());
+  encoding_bimap.reserve(1024);
+
+  const LabelNameSetDecodingTable decoding_table(encoding_bimap);
+
+  encoding_bimap.find_or_emplace(LabelViewSet{{"very_very_very_long_label_name_which_trigger_memory_reallocation1", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation2", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation3", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation4", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation5", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation6", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation7", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation8", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation9", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation10", "1"}}
+                                     .names());
+
+  // Act
+  std::vector<LabelNameSetDecodingTable::value_type> iterated;
+  std::ranges::copy(decoding_table.data_view(), std::back_inserter(iterated));
+
+  // Assert
+  ASSERT_EQ(1U, iterated.size());
+  EXPECT_TRUE(std::ranges::equal(baseline.names(), iterated.front()));
+}
+
+TEST_F(SharedDataFixture, LabelSetViewIteratorStopsAtItemWithReallocatedData) {
+  // Arrange
+  LabelSetEncodingBimap encoding_bimap;
+  const LabelViewSet baseline{{"a", "1"}};
+  encoding_bimap.find_or_emplace(baseline);
+  encoding_bimap.reserve(1024);
+
+  const LabelSetDecodingTable decoding_table(encoding_bimap);
+
+  encoding_bimap.find_or_emplace(LabelViewSet{{"very_very_very_long_label_name_which_trigger_memory_reallocation1", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation2", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation3", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation4", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation5", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation6", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation7", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation8", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation9", "1"},
+                                              {"very_very_very_long_label_name_which_trigger_memory_reallocation10", "1"}});
+
+  // Act
+  std::vector<LabelSetDecodingTable::value_type> iterated;
+  std::ranges::copy(decoding_table.data_view(), std::back_inserter(iterated));
+
+  // Assert
+  ASSERT_EQ(1U, iterated.size());
+  EXPECT_TRUE(std::ranges::equal(baseline, iterated.front()));
 }
 
 class LabelNameSetEncodingBimapTest : public testing::Test {


### PR DESCRIPTION
## Summary

Fixes a potential race/UB in `LabelNameSet` and `LabelSet` view iterators in `pp/primitives/snug_composites_filaments.h`, analogous to the existing `Symbol::storage_type::get_sentinel_id` mechanism.

For read-only shared-span storages (`kIsReadOnly`), `items_.size()` can over-report the number of consistent items: when a concurrent writer appends, `items_` may grow in place (its `SharedSpan` observes the incremented count) while the backing data vector reallocates into a fresh control block (the snapshot span stays frozen). Iterators that used `items_.size()` as the end sentinel could then dereference a partially visible item and read past the frozen data buffer.

## Changes

- `LabelNameSet::storage_type`: add `is_valid(id)` (checks `pos + size <= symbols_ids_sequences_.size()`) and a private `get_sentinel_id()`; `label_name_set_view::iterator_type` now precomputes `sentinel_id_` and uses it for the sentinel comparison.
- `LabelSet::storage_type`: add non-throwing `is_valid(id)` (validates `lns_id` range and that the StreamVByte keys+data fit within `symbols_ids_sequences_`) and a private `get_sentinel_id()`; `label_set_view::iterator_type` now uses the precomputed `sentinel_id_`.
- In non-read-only mode the behavior is unchanged (`get_sentinel_id()` returns `items_.size()`); the trailing back-off only runs for shared spans.
- Removed the now-unused direct `items_.size()` sentinel comparisons.

Not affected (already protected or fixed-range snapshots): `Symbol` symbols view (already fixed), `label_sets_values_view` (relies on the protected `Symbol` iterators), and the per-composite `LabelNameSetComposite` / `LabelSetComposite` iterators.

## Tests

Added three tests in `pp/primitives/snug_composites_tests.cpp` (under `SharedDataFixture`) that deterministically reproduce the shared-span size race by reserving `items_` (so it grows in place) and then inserting a large payload that forces the data vector to reallocate:

- `SymbolViewIteratorStopsAtItemWithReallocatedData`
- `LabelNameSetViewIteratorStopsAtItemWithReallocatedData`
- `LabelSetViewIteratorStopsAtItemWithReallocatedData`

Each asserts the table reports 2 items while the view iterates only the 1 consistent item. Verified the tests fail without the fix and pass with it.