### PR TITLE
fix(series_data): do not free stream memory of a finalized timestamp state

### DIFF
--- a/pp/series_data/chunk_finalizer.h
+++ b/pp/series_data/chunk_finalizer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "data_storage.h"
 #include "decoder.h"
 
 namespace series_data {
@@ -17,7 +16,7 @@ class ChunkFinalizer {
     if (chunk.encoding_state.encoding_type == EncodingType::kGorilla) [[unlikely]] {
       finalize(storage, ls_id, chunk, encoder::timestamp::kInvalidStateId);
     } else {
-      finalize_timestamp_and_chunk_separately<FinalizeTimestampStateMode::kFinalize>(storage, ls_id, chunk);
+      finalize_timestamp_and_chunk_separately(storage, ls_id, chunk);
     }
   }
 
@@ -59,10 +58,10 @@ class ChunkFinalizer {
     chunk.reset();
   }
 
-  template <FinalizeTimestampStateMode mode, class DataStorage>
+  template <class DataStorage>
   PROMPP_ALWAYS_INLINE static void finalize_timestamp_and_chunk_separately(DataStorage& storage, uint32_t ls_id, chunk::DataChunk& chunk) {
     if (!finalize_if_timestamp_finalized(storage, ls_id, chunk)) [[likely]] {
-      finalize(storage, ls_id, chunk, finalize_timestamp<mode>(storage, chunk));
+      finalize(storage, ls_id, chunk, finalize_timestamp(storage, chunk));
     }
   }
 
@@ -75,17 +74,11 @@ class ChunkFinalizer {
     storage.metrics->finalized_chunks().inc();
   }
 
-  template <FinalizeTimestampStateMode mode, class DataStorage>
+  template <class DataStorage>
   PROMPP_ALWAYS_INLINE static encoder::timestamp::StateId finalize_timestamp(DataStorage& storage, chunk::DataChunk& chunk) {
     auto& finalized_stream = storage.finalized_timestamp_streams.emplace_back();
     const auto finalized_stream_id = storage.finalized_timestamp_streams.index_of(finalized_stream);
-
-    if constexpr (mode == FinalizeTimestampStateMode::kFinalize) {
-      storage.timestamp_encoder.finalize(chunk.timestamp_encoder_state_id, finalized_stream.stream, finalized_stream_id);
-    } else {
-      storage.timestamp_encoder.finalize_or_copy(chunk.timestamp_encoder_state_id, finalized_stream.stream, finalized_stream_id);
-    }
-
+    storage.timestamp_encoder.finalize(chunk.timestamp_encoder_state_id, finalized_stream.stream, finalized_stream_id);
     return finalized_stream_id;
   }
 };

--- a/pp/series_data/encoder/timestamp/encoder.h
+++ b/pp/series_data/encoder/timestamp/encoder.h
@@ -119,21 +119,6 @@ class Encoder {
 
   PROMPP_ALWAYS_INLINE void erase(StateId state_id) { decrease_reference_count(states_[state_id], state_id); }
 
-  PROMPP_ALWAYS_INLINE void finalize_or_copy(StateId state_id, BitSequenceWithItemsCount& stream, uint32_t finalized_stream_id) {
-    if (auto& state = states_[state_id]; --state.reference_count == 0) {
-      stream = state.finalize(finalized_stream_id);
-
-      state_transitions_.erase(state);
-      decrease_previous_state_child_count(state_id, state.previous_state_id);
-      if (state.child_count == 0) {
-        states_.erase(state_id);
-      }
-    } else {
-      stream = state.stream_data.stream;
-      stream.stream.shrink_to_fit();
-    }
-  }
-
   PROMPP_ALWAYS_INLINE void finalize(StateId state_id, BitSequenceWithItemsCount& stream, uint32_t finalized_stream_id) {
     auto& state = states_[state_id];
     stream = state.finalize(finalized_stream_id);

--- a/pp/series_data/encoder/timestamp/encoder_tests.cpp
+++ b/pp/series_data/encoder/timestamp/encoder_tests.cpp
@@ -92,18 +92,4 @@ TEST_F(TimestampEncoderFixture, TransitionToExistingStateWithoutErasingPreviousS
   EXPECT_EQ(103, encoder_.get_state(2).timestamp());
 }
 
-TEST_F(TimestampEncoderFixture, FinalizeStateSharedBySeriesAndHavingChild) {
-  // Arrange
-  encoder_.encode(kInvalidStateId, 101);
-  const auto shared_state_id = encoder_.encode(kInvalidStateId, 101);
-  encoder_.encode(shared_state_id, 102);
-
-  // Act
-  BitSequence stream;
-  encoder_.finalize(shared_state_id, stream, 7);
-
-  // Assert
-  EXPECT_EQ(7U, encoder_.process_finalized(shared_state_id));
-}
-
 }  // namespace

--- a/pp/series_data/encoder/timestamp/encoder_tests.cpp
+++ b/pp/series_data/encoder/timestamp/encoder_tests.cpp
@@ -7,7 +7,6 @@ namespace {
 using series_data::encoder::timestamp::Encoder;
 using series_data::encoder::timestamp::kInvalidStateId;
 using series_data::encoder::timestamp::State;
-using BitSequence = series_data::encoder::BitSequenceWithItemsCount<BareBones::DefaultReallocator>;
 
 class TimestampEncoderFixture : public testing::Test {
  protected:

--- a/pp/series_data/encoder/timestamp/encoder_tests.cpp
+++ b/pp/series_data/encoder/timestamp/encoder_tests.cpp
@@ -7,6 +7,7 @@ namespace {
 using series_data::encoder::timestamp::Encoder;
 using series_data::encoder::timestamp::kInvalidStateId;
 using series_data::encoder::timestamp::State;
+using BitSequence = series_data::encoder::BitSequenceWithItemsCount<BareBones::DefaultReallocator>;
 
 class TimestampEncoderFixture : public testing::Test {
  protected:
@@ -89,6 +90,20 @@ TEST_F(TimestampEncoderFixture, TransitionToExistingStateWithoutErasingPreviousS
 
   EXPECT_EQ(101, encoder_.get_state(0).timestamp());
   EXPECT_EQ(103, encoder_.get_state(2).timestamp());
+}
+
+TEST_F(TimestampEncoderFixture, FinalizeStateSharedBySeriesAndHavingChild) {
+  // Arrange
+  encoder_.encode(kInvalidStateId, 101);
+  const auto shared_state_id = encoder_.encode(kInvalidStateId, 101);
+  encoder_.encode(shared_state_id, 102);
+
+  // Act
+  BitSequence stream;
+  encoder_.finalize(shared_state_id, stream, 7);
+
+  // Assert
+  EXPECT_EQ(7U, encoder_.process_finalized(shared_state_id));
 }
 
 }  // namespace

--- a/pp/series_data/encoder/timestamp/state.h
+++ b/pp/series_data/encoder/timestamp/state.h
@@ -79,7 +79,11 @@ struct PROMPP_ATTRIBUTE_PACKED State {
     return result;
   }
 
-  PROMPP_ALWAYS_INLINE void free_memory() noexcept { stream_data.stream.stream.clear(); }
+  PROMPP_ALWAYS_INLINE void free_memory() noexcept {
+    if (!is_finalized()) [[likely]] {
+      stream_data.stream.stream.clear();
+    }
+  }
 
  private:
   static constexpr auto kFinalizedState = std::numeric_limits<int64_t>::min();

--- a/pp/series_data/outdated_chunk_merger_tests.cpp
+++ b/pp/series_data/outdated_chunk_merger_tests.cpp
@@ -779,7 +779,7 @@ INSTANTIATE_TEST_SUITE_P(Uint32ConstantChunk, OutdatedChunkMergerInOpenConstantC
 INSTANTIATE_TEST_SUITE_P(DoubleConstantChunk, OutdatedChunkMergerInOpenConstantChunkWithDuplicatedStalenanFixture, testing::Values(1.1));
 INSTANTIATE_TEST_SUITE_P(Float32ConstantChunk, OutdatedChunkMergerInOpenConstantChunkWithDuplicatedStalenanFixture, testing::Values(-1.0));
 
-class OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture : public OutdatedChunkMergerTrait<4>, public testing::Test {
+class OutdatedChunkMergerCornerCasesFixture : public OutdatedChunkMergerTrait<4>, public testing::Test {
  protected:
   [[nodiscard]] SampleList decode_series(uint32_t ls_id) {
     SampleList result;
@@ -792,7 +792,7 @@ class OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture : publi
 // becomes empty after merging into it while there are still finalized chunks left to iterate.
 // merge_outdated_samples_in_finalized_chunks must stop instead of dereferencing samples.front()
 // on the empty span (heap-buffer-overflow reported by ASan in production heads).
-TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesNotReadPastEndOfSamples) {
+TEST_F(OutdatedChunkMergerCornerCasesFixture, DoesNotReadPastEndOfSamples) {
   // Arrange
   // 9 in-order samples produce 2 finalized chunks ({2,4,6,8}, {10,12,14,16})
   // plus an open chunk ({18}); kSamplesPerChunk == 4.
@@ -830,6 +830,53 @@ TEST_F(OutdatedChunkMergerSamplesExhaustedBeforeLastFinalizedChunkFixture, DoesN
           {.timestamp = 18, .value = 1.0},
       },
       decode_series(0)));
+}
+
+TEST_F(OutdatedChunkMergerCornerCasesFixture, FinalizeSharedStateWithChildsAtMerge) {
+  // Arrange
+  encoder_.encode(0, 10, 1.0);
+  encoder_.encode(1, 10, 1.0);
+  encoder_.encode(0, 20, 1.0);
+
+  encoder_.encode(2, 1, 1.0);
+  encoder_.encode(2, 2, 1.0);
+  encoder_.encode(2, 3, 1.0);
+  encoder_.encode(2, 4, 1.0);
+  encoder_.encode(2, 30, 1.0);
+  encoder_.encode(2, 10, 1.0);
+
+  merger_.merge();
+
+  // Act
+  encoder_.encode(1, 20, 1.0);
+  encoder_.encode(0, 30, 1.0);
+  encoder_.encode(1, 30, 1.0);
+
+  // Assert
+  EXPECT_TRUE(std::ranges::equal(
+      ExpectedSampleList{
+          {.timestamp = 10, .value = 1.0},
+          {.timestamp = 20, .value = 1.0},
+          {.timestamp = 30, .value = 1.0},
+      },
+      decode_series(0)));
+  EXPECT_TRUE(std::ranges::equal(
+      ExpectedSampleList{
+          {.timestamp = 10, .value = 1.0},
+          {.timestamp = 20, .value = 1.0},
+          {.timestamp = 30, .value = 1.0},
+      },
+      decode_series(1)));
+  EXPECT_TRUE(std::ranges::equal(
+      ExpectedSampleList{
+          {.timestamp = 1, .value = 1.0},
+          {.timestamp = 2, .value = 1.0},
+          {.timestamp = 3, .value = 1.0},
+          {.timestamp = 4, .value = 1.0},
+          {.timestamp = 10, .value = 1.0},
+          {.timestamp = 30, .value = 1.0},
+      },
+      decode_series(2)));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

`series_data::encoder::timestamp::State::stream_data` is a union: while the state is open it holds the
bit sequence with the encoded timestamps, and after `State::finalize()` it holds `finalized_stream_id`,
the index of the stream that has been moved out into `DataStorage::finalized_timestamp_streams`.

`~State()` honours that — it calls `destruct_stream()` only when the state is not finalized — and so does
`allocated_memory()`. `free_memory()` did not:

```cpp
PROMPP_ALWAYS_INLINE void free_memory() noexcept { stream_data.stream.stream.clear(); }
```

`Encoder::decrease_reference_count()` calls `free_memory()` when a state's reference count drops to zero
while the state still has children. Such a state cannot be erased (descendants reference it through
`previous_state_id`, and `StateTransitions` hashes via `states_[key.state_id].encoder.timestamp()`, so
the slot must stay readable), so the intent is "keep the slot, release the payload". For a finalized
state there is no payload left to release — and clearing it is destructive:

`State::finalize()` moves the stream out (`SharedPtr`'s move constructor zeroes all 8 bytes of `data_`)
and then writes `finalized_stream_id` over the low 4 bytes of the same union. So `SharedPtr::data_`
becomes numerically equal to `finalized_stream_id`, and `clear()` → `dec_ref_counter()` reads the
reference counter at `finalized_stream_id - 4` — a low, unmapped address — and would otherwise pass that
pointer to `dallocx()`.

In production this surfaced as a SIGSEGV inside the cgo bridge, in
`series_data::Encoder<DataStorage<true>, 240>::handle_timestamp_update`. The Go runtime could not unwind
that non-Go frame, so the visible failure was a secondary crash in the traceback printer itself
(`unexpected return pc for runtime.sigpanic`, then `unsafe.Slice: len out of range` in
`runtime.hexdumpWords`, then `panic during panic`). The reported Go error is a red herring; the C++ frame
is the actual fault.

## How we get into that chain

Children are always acquired *before* finalization, never after: `child_count` is only incremented when
`Encoder::encode()` creates a new state for a series sitting on this one, and a series whose state has
been finalized closes its chunk on the next sample (`finalize_if_timestamp_finalized` →
`process_finalized`, then `chunk.reset()` sets `timestamp_encoder_state_id = kInvalidStateId`) instead of
encoding into it.

Since states are deduplicated globally by `(previous_state_id, timestamp)`, series with identical
timestamps share a chain, which gives the required shape:

1. State `S` is shared by two series, `refcount(S) = 2`, `child_count(S) = 0`.
2. One series receives its next sample first and branches to `S'`: `child_count(S) = 1`,
   `refcount(S): 2 → 1`. `S` now has a child and a single remaining referrer.
3. `S` gets finalized while it still has that child.
4. The last reference is dropped: `refcount(S): 1 → 0`, `child_count(S) = 1` → `free_memory()` on a
   finalized state → crash.

Step 3 is the interesting one, because the hot path alone cannot produce it. There, a chunk is finalized
when `state.stream_data.stream.count() >= kSamplesPerChunk`, and a state's sample count is fixed when the
state is created (`count(S') = count(S) + 1`), so a series sitting on a state with `count >= 240`
finalizes instead of branching — "has children" and "is finalized by the 240-sample rule" are mutually
exclusive.

What does finalize a state below that boundary is `OutdatedChunkMerger`: when out-of-order samples are
merged, the chunk is re-encoded through the regular `Encoder::encode()` path (so its timestamp states
come from the shared, deduplicated chain) and then `ChunkFinalizer::finalize()` is called
unconditionally, at whatever sample count the merged chunk has. That finalizes a state which may well
have children.

Step 4 then happens on a *different* series than the one that finalized `S`: the remaining referrer hits
`finalize_if_timestamp_finalized` → `process_finalized` on its next sample and drops the last reference —
which is why the crash PC is inside `handle_timestamp_update`.

The same branch is also reachable from `DataStorage::erase_timestamp_stream<kOpen>` →
`timestamp_encoder.erase()` when an open chunk referencing an already finalized state is dropped
(unloading, head truncation); that would crash in a different function.

## Fix

Guard `free_memory()` with `is_finalized()`, matching `~State()` and `allocated_memory()`. No leak is
introduced: by the time a state is finalized its stream is owned by `finalized_timestamp_streams` and
lives by its own reference count.

## Testing

`TimestampEncoderFixture.FinalizeStateSharedBySeriesAndHavingChild` builds the shape described above
(a state shared by two series, one of which advances and gives it a child, then finalized by the other)
and calls `Encoder::finalize`. Without the fix, under ASan:

```
AddressSanitizer: SEGV on unknown address 0x000000000003
  #0 SharedPtr<...>::dec_ref_counter() bare_bones/memory.h:386
  #1 SharedPtr<...>::clear()
  #3 State<...>::free_memory() series_data/encoder/timestamp/state.h:82
  #4 Encoder<...>::decrease_reference_count() series_data/encoder/timestamp/encoder.h:203
  #5 Encoder<...>::finalize() series_data/encoder/timestamp/encoder.h:140
```

`0x3` is the `finalized_stream_id` passed by the test (7) minus 4 — the same signature as the production
fault, at a larger stream id.

With the fix, `bazel test -c dbg --asan //:series_data_test //:head_test //:prometheus_test` passes.

## Affected versions

The unguarded `free_memory()` and the `child_count != 0` branch that calls it were both added in
822fe8db6 (June 2024), so every release from v0.5.0 onwards is affected, including v0.8.7 and v0.8.9
(`git diff v0.8.7 HEAD~1` is empty for `state.h`, `encoder.h` and `chunk_finalizer.h`). Downgrading does
not help.

Note that `finalized_stream_id` values of 0 and 4 make `data_ - 4` null, which `dec_ref_counter()` skips,
so the earliest finalized streams in a storage survive the bug — one reason it looks load-dependent.

## Follow-ups (not addressed here, need a separate look)

- `switch_to_gorilla()` assigns a timestamp state to the chunk, but when a Gorilla chunk is finalized
  `chunk.timestamp_encoder_state_id` is overwritten with `kInvalidStateId` without an `erase()`, and
  `DataStorage::erase_chunk_timestamp_and_encoder()` skips the timestamp stream for Gorilla chunks. That
  reference looks like it is never released — worth checking the `timestamp_states` gauge.
- `FinalizeTimestampStateMode::kFinalizeOrCopy` / `Encoder::finalize_or_copy()` — the variant that
  deliberately avoids `free_memory()` — are currently unused; only `kFinalize` is instantiated.
