### PR TITLE
fix(relabeler): track lss reallocations even on relabeling error

### DIFF
--- a/pp/entrypoint/bridge/prometheus_relabeler.cpp
+++ b/pp/entrypoint/bridge/prometheus_relabeler.cpp
@@ -397,24 +397,25 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_input_relabeling(void*
 
   auto in = static_cast<Arguments*>(args);
   auto out = new (res) Result();
+  auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
+  const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
 
   try {
     std::visit(
-        [in, out](auto& hashdex) {
+        [in, out, &target_lss](auto& hashdex) {
           auto& input_lss = std::get<entrypoint::types::EncodingBimap>(*in->input_lss);
-          auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
 
-          const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
           in->per_goroutine_relabeler->input_relabeling(input_lss, target_lss, *in->cache, hashdex, in->options, *in->stateless_relabeler, *out,
                                                         in->shards_inner_series, in->shards_relabeled_series);
-          target_lss.build_deferred_indexes();
-          out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
         },
         *in->hashdex);
   } catch (...) {
     auto err_stream = PromPP::Primitives::Go::BytesStream(&out->error);
     entrypoint::types::handle_current_exception(err_stream);
   }
+
+  target_lss.build_deferred_indexes();
+  out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
 }
 
 extern "C" void prompp_prometheus_per_goroutine_relabeler_input_relabeling_from_cache(void* args, void* res) {
@@ -477,24 +478,26 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_input_relabeling_with_
 
   auto in = static_cast<Arguments*>(args);
   auto out = new (res) Result();
+  auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
+  const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
 
   try {
     std::visit(
-        [in, out](auto& hashdex) {
+        [in, out, &target_lss](auto& hashdex) {
           auto& input_lss = std::get<entrypoint::types::EncodingBimap>(*in->input_lss);
           auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
 
-          const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
           in->per_goroutine_relabeler->input_relabeling_with_stalenans(input_lss, target_lss, *in->cache, hashdex, in->options, *in->stateless_relabeler, *out,
                                                                        in->shards_inner_series, in->shards_relabeled_series, in->def_timestamp);
-          target_lss.build_deferred_indexes();
-          out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
         },
         *in->hashdex);
   } catch (...) {
     auto err_stream = PromPP::Primitives::Go::BytesStream(&out->error);
     entrypoint::types::handle_current_exception(err_stream);
   }
+
+  target_lss.build_deferred_indexes();
+  out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
 }
 
 extern "C" void prompp_prometheus_per_goroutine_relabeler_input_relabeling_with_stalenans_from_cache(void* args, void* res) {
@@ -552,22 +555,20 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_input_transition_relab
 
   auto in = static_cast<Arguments*>(args);
   auto out = new (res) Result();
+  auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
+  const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
 
   try {
     std::visit(
-        [in, out](auto& hashdex) {
-          auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
-
-          const entrypoint::types::ReallocationsDetector reallocation_detector(target_lss);
-          in->per_goroutine_relabeler->input_transition_relabeling(target_lss, hashdex, *out, in->shards_inner_series);
-          target_lss.build_deferred_indexes();
-          out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
-        },
+        [in, out, &target_lss](auto& hashdex) { in->per_goroutine_relabeler->input_transition_relabeling(target_lss, hashdex, *out, in->shards_inner_series); },
         *in->hashdex);
   } catch (...) {
     auto err_stream = PromPP::Primitives::Go::BytesStream(&out->error);
     entrypoint::types::handle_current_exception(err_stream);
   }
+
+  target_lss.build_deferred_indexes();
+  out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
 }
 
 extern "C" void prompp_prometheus_per_goroutine_relabeler_input_transition_relabeling_only_read(void* args, void* res) {
@@ -617,11 +618,10 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_append_relabeler_serie
 
   const auto in = static_cast<Arguments*>(args);
   const auto out = new (res) Result();
+  auto& lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
+  const entrypoint::types::ReallocationsDetector reallocation_detector(lss);
 
   try {
-    auto& lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
-    const entrypoint::types::ReallocationsDetector reallocation_detector(lss);
-
     for (size_t id = 0; id != in->shards_relabeled_series.size(); ++id) {
       if (in->shards_relabeled_series[id].size() == 0) {
         continue;
@@ -630,12 +630,13 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_append_relabeler_serie
       PerGoroutineRelabeler::append_relabeler_series(lss, in->shards_inner_series[id], in->shards_relabeled_series[id], in->shards_relabeler_state_update[id]);
     }
 
-    lss.build_deferred_indexes();
-    out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
   } catch (...) {
     auto err_stream = PromPP::Primitives::Go::BytesStream(&out->error);
     entrypoint::types::handle_current_exception(err_stream);
   }
+
+  lss.build_deferred_indexes();
+  out->target_lss_has_reallocations = reallocation_detector.has_reallocations();
 }
 
 extern "C" void prompp_prometheus_per_goroutine_relabeler_track_stale_nans(void* args) {

--- a/pp/entrypoint/bridge/prometheus_relabeler.cpp
+++ b/pp/entrypoint/bridge/prometheus_relabeler.cpp
@@ -485,7 +485,6 @@ extern "C" void prompp_prometheus_per_goroutine_relabeler_input_relabeling_with_
     std::visit(
         [in, out, &target_lss](auto& hashdex) {
           auto& input_lss = std::get<entrypoint::types::EncodingBimap>(*in->input_lss);
-          auto& target_lss = std::get<entrypoint::types::QueryableEncodingBimap>(*in->target_lss);
 
           in->per_goroutine_relabeler->input_relabeling_with_stalenans(input_lss, target_lss, *in->cache, hashdex, in->options, *in->stateless_relabeler, *out,
                                                                        in->shards_inner_series, in->shards_relabeled_series, in->def_timestamp);

--- a/pp/go/cppbridge/prometheus_relabeler_test.go
+++ b/pp/go/cppbridge/prometheus_relabeler_test.go
@@ -338,6 +338,60 @@ func (s *PerGoroutineRelabelerSuite) TestRelabeling() {
 	runtime.KeepAlive(shardsRelabeledSeries)
 }
 
+func (s *PerGoroutineRelabelerSuite) TestRelabelingWithError() {
+	h, err := s.makeSnappyProtobufHashdex(&prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "job", Value: "abc"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{
+					{Value: 0.1, Timestamp: time.Now().UnixMilli()},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	shardsInnerSeries := cppbridge.NewShardedInnerSeries(s.numberOfShards)
+	shardsRelabeledSeries := cppbridge.NewShardedRelabeledSeries(s.numberOfShards)
+
+	statelessRelabeler, err := cppbridge.NewStatelessRelabeler(s.rCfgs)
+	s.Require().NoError(err)
+
+	state := cppbridge.NewStateV2WithoutLock()
+	state.SetRelabelerOptions(&s.options)
+	state.SetStatelessRelabeler(statelessRelabeler)
+	state.Reconfigure(0, s.numberOfShards, nil)
+
+	pgr := cppbridge.NewPerGoroutineRelabeler(s.numberOfShards, 0)
+	stats, hasReallocations, err := pgr.Relabeling(
+		s.baseCtx,
+		s.inputLss,
+		s.targetLss,
+		state,
+		h,
+		shardsInnerSeries.DataByShard(0),
+		shardsRelabeledSeries.DataByShard(0),
+	)
+	s.Require().Error(err)
+	s.Equal(cppbridge.RelabelerStats{1, 1, 0}, stats)
+	s.True(hasReallocations)
+	s.Equal(uint64(1), shardsInnerSeries.DataByShard(0)[0].Size())
+
+	runtime.KeepAlive(shardsInnerSeries)
+	runtime.KeepAlive(shardsRelabeledSeries)
+}
+
 func (s *PerGoroutineRelabelerSuite) TestRelabelingDrop() {
 	h, err := s.makeSnappyProtobufHashdex(&prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{
@@ -744,6 +798,54 @@ func (s *PerGoroutineRelabelerSuite) TestRelabelingTransition() {
 	runtime.KeepAlive(shardsRelabeledSeries)
 }
 
+func (s *PerGoroutineRelabelerSuite) TestRelabelingTransitionWithError() {
+	h, err := s.makeSnappyProtobufHashdex(&prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "job", Value: "abc"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{
+					{Value: 0.1, Timestamp: time.Now().UnixMilli()},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	shardsInnerSeries := cppbridge.NewShardedInnerSeries(s.numberOfShards)
+	shardsRelabeledSeries := cppbridge.NewShardedRelabeledSeries(s.numberOfShards)
+
+	state := cppbridge.NewTransitionStateV2()
+	state.Reconfigure(0, s.numberOfShards, nil)
+
+	pgr := cppbridge.NewPerGoroutineRelabeler(s.numberOfShards, 0)
+	stats, hasReallocations, err := pgr.Relabeling(
+		s.baseCtx,
+		s.inputLss,
+		s.targetLss,
+		state,
+		h,
+		shardsInnerSeries.DataByShard(0),
+		shardsRelabeledSeries.DataByShard(0),
+	)
+	s.Require().Error(err)
+	s.Equal(cppbridge.RelabelerStats{1, 1, 0}, stats)
+	s.True(hasReallocations)
+
+	runtime.KeepAlive(shardsInnerSeries)
+	runtime.KeepAlive(shardsRelabeledSeries)
+}
+
 func (s *PerGoroutineRelabelerSuite) TestRelabelingFromCacheTrueTransition() {
 	h, err := s.makeSnappyProtobufHashdex(&prompb.WriteRequest{
 		Timeseries: []prompb.TimeSeries{
@@ -1110,6 +1212,62 @@ func (s *PerGoroutineRelabelerSuite) TestRelabelingWithStalenans() {
 	s.False(hasReallocations)
 
 	cppbridge.PerGoroutineRelabelerTrackStaleNans(shardsInnerSeries.DataByShard(0), state, 0)
+	s.Equal(uint64(1), shardsInnerSeries.DataByShard(0)[0].Size())
+
+	runtime.KeepAlive(shardsInnerSeries)
+	runtime.KeepAlive(shardsRelabeledSeries)
+}
+
+func (s *PerGoroutineRelabelerSuite) TestRelabelingWithStalenansWithError() {
+	h, err := s.makeSnappyProtobufHashdex(&prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "job", Value: "abc"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{
+					{Value: 0.1, Timestamp: time.Now().UnixMilli()},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "value"},
+					{Name: "instance", Value: "value1"},
+				},
+				Samples: []prompb.Sample{},
+			},
+		},
+	})
+	s.Require().NoError(err)
+
+	shardsInnerSeries := cppbridge.NewShardedInnerSeries(s.numberOfShards)
+	shardsRelabeledSeries := cppbridge.NewShardedRelabeledSeries(s.numberOfShards)
+
+	statelessRelabeler, err := cppbridge.NewStatelessRelabeler(s.rCfgs)
+	s.Require().NoError(err)
+
+	state := cppbridge.NewStateV2WithoutLock()
+	state.SetRelabelerOptions(&s.options)
+	state.SetStatelessRelabeler(statelessRelabeler)
+	state.EnableTrackStaleness()
+	state.Reconfigure(0, s.numberOfShards, nil)
+
+	pgr := cppbridge.NewPerGoroutineRelabeler(s.numberOfShards, 0)
+	stats, hasReallocations, err := pgr.Relabeling(
+		s.baseCtx,
+		s.inputLss,
+		s.targetLss,
+		state,
+		h,
+		shardsInnerSeries.DataByShard(0),
+		shardsRelabeledSeries.DataByShard(0),
+	)
+	cppbridge.PerGoroutineRelabelerTrackStaleNans(shardsInnerSeries.DataByShard(0), state, 0)
+	s.Require().Error(err)
+	s.Equal(cppbridge.RelabelerStats{1, 1, 0}, stats)
+	s.True(hasReallocations)
 	s.Equal(uint64(1), shardsInnerSeries.DataByShard(0)[0].Size())
 
 	runtime.KeepAlive(shardsInnerSeries)

--- a/pp/go/storage/appender/appender.go
+++ b/pp/go/storage/appender/appender.go
@@ -334,12 +334,13 @@ func (a *Appender[TTask, TShard, TGShard, THead]) appendRelabelerSeriesStage(
 					relabeledSeries,
 					shardedStateUpdates.DataByShard(shardID),
 				)
-				if err != nil {
-					return fmt.Errorf("shard %d: %w", shardID, err)
-				}
 
 				if hasReallocations {
 					shard.LSSResetSnapshot()
+				}
+
+				if err != nil {
+					return fmt.Errorf("shard %d: %w", shardID, err)
 				}
 
 				return nil


### PR DESCRIPTION
## Description
- `prompp_prometheus_per_goroutine_relabeler_*` bridge functions (`input_relabeling`, `input_relabeling_with_stalenans`, `input_transition_relabeling`, `append_relabeler_series`) now compute `target_lss.build_deferred_indexes()` and `out->target_lss_has_reallocations` unconditionally after the `try`/`catch`, instead of only on the success path inside it.
- `Appender.appendRelabelerSeriesStage` now resets the shard's LSS snapshot (`shard.LSSResetSnapshot()`) on `hasReallocations` before checking `err`, so the reset still happens when relabeling itself returned an error.
- Added Go tests covering the error path for `input_relabeling`, `input_transition_relabeling`, and `input_relabeling_with_stalenans` (`TestRelabelingWithError`, `TestRelabelingTransitionWithError`, `TestRelabelingWithStalenansWithError`), asserting reallocations are still tracked when relabeling fails.

## Why do we need it, and what problem does it solve?
When relabeling failed with an error, the target LSS's `has_reallocations` flag and deferred index build were skipped (they lived on the success-only branch inside the `try`), and on the Go side the appender skipped `LSSResetSnapshot()` whenever `err != nil`. This left the head's allocated-memory tracking / LSS snapshot out of sync with LSS state that *did* mutate before the error was raised, since allocations can happen before relabeling aborts.

## Checklist
   - [x] The code is covered by unit tests.
