### PR TITLE
feat(hashdex): add check for series with no samples

### DIFF
--- a/pp-pkg/featuresflags/features_flags.go
+++ b/pp-pkg/featuresflags/features_flags.go
@@ -114,6 +114,12 @@ func ReadPromPPFeatures(logger log.Logger, cfg FlagConfig) {
 			cppFeatures.DisableScraperFullUTF8()
 			_ = level.Info(logger).Log(msgStr, "Whole-input UTF-8 validation for scraper is disabled.")
 
+		case "enable_skip_no_samples_series":
+			cppFeatures.SkipNoSamplesSeries()
+			_ = level.Info(logger).Log(
+				msgStr, "Skipping series with no samples instead of throwing an error is enabled.",
+			)
+
 		default:
 			_ = level.Warn(logger).Log(msgStr, "Unknown PROMPP_FEATURES option.", "option", strings.TrimSpace(fname))
 		}

--- a/pp/entrypoint/bridge/wal_hashdex.cpp
+++ b/pp/entrypoint/bridge/wal_hashdex.cpp
@@ -83,6 +83,7 @@ extern "C" void prompp_wal_protobuf_hashdex_snappy_presharding(void* args, void*
 
   try {
     auto& hashdex = std::get<PromPP::WAL::hashdex::Protobuf>(*in->hashdex_variant);
+    hashdex.set_skip_no_samples_series(entrypoint::types::feature_flags().features().skip_no_samples_series);
     hashdex.snappy_presharding(static_cast<std::string_view>(in->compressed_protobuf));
     auto cluster = hashdex.cluster();
     out->cluster.reset_to(cluster.data(), cluster.size());

--- a/pp/entrypoint/types/feature_flags_config.h
+++ b/pp/entrypoint/types/feature_flags_config.h
@@ -6,4 +6,5 @@
 
 typedef struct {
   bool scraper_validate_utf_per_token;
+  bool skip_no_samples_series;
 } PromppFeatures;

--- a/pp/entrypoint/types/feature_flags_tests.cpp
+++ b/pp/entrypoint/types/feature_flags_tests.cpp
@@ -21,7 +21,7 @@ TEST(FeatureFlags, InitializesEnabledFeatures) {
   FeatureFlags flags;
 
   // Act
-  flags.initialize(PromppFeatures{.scraper_validate_utf_per_token = true});
+  flags.initialize(PromppFeatures{.scraper_validate_utf_per_token = true, .skip_no_samples_series = false});
 
   // Assert
   EXPECT_TRUE(flags.features().scraper_validate_utf_per_token);
@@ -41,7 +41,7 @@ TEST(FeatureFlags, EmptyInitializationKeepsFeaturesDisabled) {
 TEST(FeatureFlags, RepeatedInitializationIsIgnored) {
   // Arrange
   FeatureFlags flags;
-  flags.initialize(PromppFeatures{.scraper_validate_utf_per_token = true});
+  flags.initialize(PromppFeatures{.scraper_validate_utf_per_token = true, .skip_no_samples_series = false});
 
   // Act
   flags.initialize({});

--- a/pp/go/cppbridge/entrypoint.go
+++ b/pp/go/cppbridge/entrypoint.go
@@ -16,6 +16,7 @@ package cppbridge
 // #cgo static LDFLAGS: -static -static-libgcc -static-libstdc++ -l:libstdc++.a -l:libm.a -l:libgcc_eh.a -l:libunwind.a -l:liblzma.a -l:libstdc++exp.a
 // #include "entrypoint.h"
 import "C" //nolint:gocritic // because otherwise it won't work
+
 import (
 	"runtime"
 	"time"
@@ -421,6 +422,11 @@ type FeatureFlags struct {
 // DisableScraperFullUTF8 selects legacy per-token UTF-8 validation.
 func (f *FeatureFlags) DisableScraperFullUTF8() {
 	f.features.scraper_validate_utf_per_token = true
+}
+
+// SkipNoSamplesSeries hashdex skip no samples series.
+func (f *FeatureFlags) SkipNoSamplesSeries() {
+	f.features.skip_no_samples_series = true
 }
 
 // InitializeFeatureFlags configures C++ features once at startup.

--- a/pp/go/cppbridge/entrypoint.h
+++ b/pp/go/cppbridge/entrypoint.h
@@ -22,6 +22,7 @@
 
 typedef struct {
   bool scraper_validate_utf_per_token;
+  bool skip_no_samples_series;
 } PromppFeatures;
 #ifdef __cplusplus
 extern "C" {

--- a/pp/go/cppbridge/wal_hashdex_test.go
+++ b/pp/go/cppbridge/wal_hashdex_test.go
@@ -230,6 +230,82 @@ func (s *HashdexSuite) TestSnappyProtobufHashdex() {
 	s.Equal("super_cluster", cluster)
 }
 
+func (s *HashdexSuite) TestSnappyProtobufHashdexEmptySamplesError() {
+	wr := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "test"},
+					{Name: "__replica__", Value: "second_replica"},
+					{Name: "cluster", Value: "super_cluster"},
+					{Name: "job", Value: "tester"},
+					{Name: "instance", Value: "blablabla"},
+				},
+				Samples: []prompb.Sample{
+					{Timestamp: 1654608420000, Value: 4444},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "test"},
+					{Name: "__replica__", Value: "second_replica"},
+					{Name: "cluster", Value: "super_cluster"},
+					{Name: "job", Value: "tester"},
+					{Name: "instance", Value: "blablabla"},
+				},
+				Samples: []prompb.Sample{},
+			},
+		},
+	}
+	b, err := wr.Marshal()
+	s.Require().NoError(err)
+	compressed := snappy.Encode(nil, b)
+
+	hlimits := cppbridge.DefaultWALHashdexLimits()
+	_, err = cppbridge.NewWALSnappyProtobufHashdex(compressed, hlimits)
+	s.Require().Error(err)
+}
+
+func (s *HashdexSuite) TestSnappyProtobufHashdexEmptySamplesSkipNoSamplesSeries() {
+	var cppFeatures cppbridge.FeatureFlags
+	cppFeatures.SkipNoSamplesSeries()
+	cppbridge.InitializeFeatureFlags(cppFeatures)
+
+	wr := &prompb.WriteRequest{
+		Timeseries: []prompb.TimeSeries{
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "test"},
+					{Name: "__replica__", Value: "second_replica"},
+					{Name: "cluster", Value: "super_cluster"},
+					{Name: "job", Value: "tester"},
+					{Name: "instance", Value: "blablabla"},
+				},
+				Samples: []prompb.Sample{
+					{Timestamp: 1654608420000, Value: 4444},
+				},
+			},
+			{
+				Labels: []prompb.Label{
+					{Name: "__name__", Value: "test"},
+					{Name: "__replica__", Value: "second_replica"},
+					{Name: "cluster", Value: "super_cluster"},
+					{Name: "job", Value: "tester"},
+					{Name: "instance", Value: "blablabla"},
+				},
+				Samples: []prompb.Sample{},
+			},
+		},
+	}
+	b, err := wr.Marshal()
+	s.Require().NoError(err)
+	compressed := snappy.Encode(nil, b)
+
+	hlimits := cppbridge.DefaultWALHashdexLimits()
+	_, err = cppbridge.NewWALSnappyProtobufHashdex(compressed, hlimits)
+	s.Require().NoError(err)
+}
+
 func TestHashdex_SuccessfulParse(t *testing.T) {
 	// Arrange
 	wr := &prompb.WriteRequest{

--- a/pp/prometheus/remote_write.h
+++ b/pp/prometheus/remote_write.h
@@ -217,32 +217,47 @@ inline __attribute__((always_inline)) void read_timeseries_without_samples(Proto
 }
 
 template <class ProtobufReader, class LabelSet>
-inline __attribute__((always_inline)) void read_timeseries_label_set(ProtobufReader&& pb_timeseries,
+inline __attribute__((always_inline)) bool read_timeseries_label_set(ProtobufReader&& pb_timeseries,
                                                                      LabelSet& label_set,
                                                                      const PbLabelSetMemoryLimits& limits) {
   size_t current_message_n = 0;
-  while (pb_timeseries.next(1)) {
-    if (limits.max_label_names_per_timeseries && current_message_n >= limits.max_label_names_per_timeseries) {
-      throw BareBones::Exception(0xf666cea4f74038c7, "Max Label Names count per Timeseries limit exceeded");
-    }
+  bool has_samples = false;
+  while (pb_timeseries.next()) {
+    switch (pb_timeseries.tag()) {
+      case 1: {  // label
+        if (limits.max_label_names_per_timeseries && current_message_n >= limits.max_label_names_per_timeseries) {
+          throw BareBones::Exception(0xf666cea4f74038c7, "Max Label Names count per Timeseries limit exceeded");
+        }
 
-    auto pb_label = pb_timeseries.get_message();
-    typename LabelSet::label_type label;
-    read_label(pb_label, label);
-    if (size_t label_name_sz = std::size(std::get<0>(label)); limits.max_label_name_length && label_name_sz > limits.max_label_name_length) {
-      throw BareBones::Exception(0x01102a3321345745, "Label name size (%zd) exceeds the maximum name size limit", label_name_sz);
-    }
-    if (size_t label_value_sz = std::size(std::get<1>(label)); limits.max_label_value_length && label_value_sz > limits.max_label_value_length) {
-      throw BareBones::Exception(0x32b5ff9563758da8, "Label value size (%zd) exceeds the maximum value size limit", label_value_sz);
-    }
-    label_set.add(label);
+        auto pb_label = pb_timeseries.get_message();
+        typename LabelSet::label_type label;
+        read_label(pb_label, label);
+        if (size_t label_name_sz = std::size(std::get<0>(label)); limits.max_label_name_length && label_name_sz > limits.max_label_name_length) {
+          throw BareBones::Exception(0x01102a3321345745, "Label name size (%zd) exceeds the maximum name size limit", label_name_sz);
+        }
+        if (size_t label_value_sz = std::size(std::get<1>(label)); limits.max_label_value_length && label_value_sz > limits.max_label_value_length) {
+          throw BareBones::Exception(0x32b5ff9563758da8, "Label value size (%zd) exceeds the maximum value size limit", label_value_sz);
+        }
+        label_set.add(label);
 
-    current_message_n++;
+        current_message_n++;
+      } break;
+
+      case 2:  // sample
+        has_samples = true;
+        pb_timeseries.skip();
+        break;
+
+      default:
+        pb_timeseries.skip();
+    }
   }
 
   if (__builtin_expect(!label_set.size(), false)) {
     throw BareBones::Exception(0x68997b7d2e49de1e, "Protobuf message has an empty label set, can't read timeseries");
   }
+
+  return has_samples;
 }
 
 template <class Timeseries, class Hashdex, class ProtobufReader>

--- a/pp/wal/hashdex/protobuf.h
+++ b/pp/wal/hashdex/protobuf.h
@@ -3,7 +3,6 @@
 #include "snappy.h"
 
 #include "bare_bones/vector.h"
-#include "entrypoint/types/feature_flags.h"
 #include "metric.h"
 #include "primitives/label_set.h"
 #include "prometheus/hashdex.h"
@@ -64,6 +63,8 @@ class Protobuf : public Prometheus::hashdex::Abstract {
   [[nodiscard]] PROMPP_ALWAYS_INLINE const auto& floats() const noexcept { return floats_; }
   [[nodiscard]] PROMPP_ALWAYS_INLINE const auto& metadata() const noexcept { return metadata_; }
 
+  PROMPP_ALWAYS_INLINE void set_skip_no_samples_series(bool skip) noexcept { skip_no_samples_series_ = skip; }
+
  private:
   class Item {
     size_t hash_;
@@ -84,6 +85,7 @@ class Protobuf : public Prometheus::hashdex::Abstract {
   BareBones::Vector<Metadata> metadata_;
   const Prometheus::RemoteWrite::PbLabelSetMemoryLimits limits_{};
   Primitives::LabelViewSet label_set_;
+  bool skip_no_samples_series_{false};
 
   void parse_timeseries(protozero::pbf_reader& pb) {
     if (limits_.max_timeseries_count && floats_.size() >= limits_.max_timeseries_count) [[unlikely]] {
@@ -93,7 +95,7 @@ class Protobuf : public Prometheus::hashdex::Abstract {
     bool has_samples = read_timeseries_label_set(protozero::pbf_reader{pb_view}, label_set_, limits_);
 
     if (__builtin_expect(!has_samples, false)) {
-      if (entrypoint::types::feature_flags().features().skip_no_samples_series) [[unlikely]] {
+      if (skip_no_samples_series_) [[unlikely]] {
         label_set_.clear();
         return;
       }

--- a/pp/wal/hashdex/protobuf.h
+++ b/pp/wal/hashdex/protobuf.h
@@ -3,6 +3,7 @@
 #include "snappy.h"
 
 #include "bare_bones/vector.h"
+#include "entrypoint/types/feature_flags.h"
 #include "metric.h"
 #include "primitives/label_set.h"
 #include "prometheus/hashdex.h"
@@ -89,7 +90,16 @@ class Protobuf : public Prometheus::hashdex::Abstract {
       throw BareBones::Exception(0xdedb5b24d946cc4d, "Max Timeseries count limit exceeded");
     }
     auto pb_view = pb.get_view();
-    read_timeseries_label_set(protozero::pbf_reader{pb_view}, label_set_, limits_);
+    bool has_samples = read_timeseries_label_set(protozero::pbf_reader{pb_view}, label_set_, limits_);
+
+    if (__builtin_expect(!has_samples, false)) {
+      if (entrypoint::types::feature_flags().features().skip_no_samples_series) [[unlikely]] {
+        label_set_.clear();
+        return;
+      }
+
+      throw BareBones::Exception(0x2609ba8d388d48aa, "Protobuf message has no samples for label set");
+    }
 
     if (floats_.empty()) [[unlikely]] {
       set_cluser_and_replica_values(label_set_);

--- a/pp/wal/hashdex/protobuf_tests.cpp
+++ b/pp/wal/hashdex/protobuf_tests.cpp
@@ -61,4 +61,15 @@ INSTANTIATE_TEST_SUITE_P(
                                               },
                                               BareBones::Vector<Sample>{Sample{-1654608420000, 4444}}}}}}));
 
+TEST(ProtobufNoSamples, ThrowsWhenTimeseriesHasNoSamples) {
+  // Arrange
+  constexpr auto protobuf =
+      "\x0a\x27\x0a\x1b\x0a\x08\x5f\x5f\x6e\x61\x6d\x65\x5f\x5f\x12\x0f\x74\x65\x73\x74\x5f\x6e\x6f\x5f\x73\x61\x6d\x70\x6c\x65\x73\x0a\x08\x0a\x03\x6a\x6f"
+      "\x62\x12\x01\x78"sv;
+  PromPP::WAL::hashdex::Protobuf hashdex;
+
+  // Act & Assert
+  EXPECT_THROW(hashdex.presharding(protobuf), BareBones::Exception);
+}
+
 }  // namespace


### PR DESCRIPTION
## Description
Adds validation in the remote-write protobuf parsing path (`read_timeseries_label_set` / `Protobuf::parse_timeseries`) to detect timeseries that have a label set but no samples. Previously such series were silently accepted into the hashdex with no samples ever recorded. By default this now throws a `BareBones::Exception`.

Also adds a new opt-in `enable_skip_no_samples_series` `PROMPP_FEATURES` flag (`FeatureFlags.SkipNoSamplesSeries()` on the Go side, `skip_no_samples_series` in the C++ `PromppFeatures` struct) that, when enabled, silently skips series without samples instead of raising an error.

## Why do we need it, and what problem does it solve?
This validation already existed, but it only fired later — at the point where a timeseries is added to the LSS during relabeling, which is a comparatively heavy operation (takes locks, does extra bookkeeping calls). Series with a label set but no samples now fail fast right at protobuf parsing time, before any of that work happens, avoiding wasted lock contention and calls for input that's going to be rejected anyway.

The new `enable_skip_no_samples_series` feature flag gives an escape hatch to silently skip such series instead of erroring, for cases where a client is known to legitimately send them.

## Checklist
   - [x] The code is covered by unit tests.